### PR TITLE
feat(kernel): add Rubin SM107a ports, exact runtime-arch registry metadata, SM103a/SM107a defaults

### DIFF
--- a/.agents/sketch/bmm_fp8_rubin.md
+++ b/.agents/sketch/bmm_fp8_rubin.md
@@ -1,0 +1,607 @@
+<!--
+This file is a design sketch for a TIRx port of FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ 012cfdb97f217e0d48bc9352c17a74068c9e495b),
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashInfer SM107 FP8 batched GEMM kernel sketch
+
+This non-executable, operation-level sketch freezes the intended transcription
+of `flashinfer/gemm/kernels/bmm_fp8_rubin.py` together with the inherited
+scheduler in `bmm_fp8_blackwell.py` and the scaled TMA epilogue in
+`epilogue_utils.py`. The pinned source commit is
+`012cfdb97f217e0d48bc9352c17a74068c9e495b`; the primary file SHA-256 is
+`f10b5ee03096af8394b57cfbe7abb6ee3103baf87c6a58a60f576ead3f4386f3`.
+
+The writer independently exported all 48 tactic/dtype specializations with
+CuTeDSL line information under
+`.porting/bmm_fp8_rubin/source_export/writer/`. Every artifact targets
+`sm_107a`, declares 192 threads, contains `.loc` records, and directly maps
+files 1/2/3 to `bmm_fp8_rubin.py`, `bmm_fp8_blackwell.py`, and
+`epilogue_utils.py`. The primary tactic-0 E4M3-to-BF16 artifact has SHA-256
+`3f90d9c1260b601e6de70e655963a435c256b06a79e59b5eabc6068c79712072`
+and 295 `.loc` records. “Primary PTX” below means that artifact.
+
+After the independent sketch reviewer returns PASS, this file is immutable.
+
+## Transcription boundary and invariants
+
+The executable module is one parameterized K-language port and must import the
+device language only as `import tirx_kernels.kern as K`. It may use raw
+`K.ptx[...]` instructions, scalar K control flow, opaque TensorMaps, rank-one
+shared allocations, local register arrays, and ordinary integer helpers. It
+must not use a tile primitive, a first-class mapping object, a direct TVM script
+namespace, `K.cuda.func_call`, or any inline-CUDA function-call exemption. It
+must not modify anything under `tirx_kernels/kern/`.
+
+All source mappings are lowered before tracing into scalar extents, strides,
+byte offsets, XOR swizzle arithmetic, TensorMap fields, and integer UMMA
+descriptor bits. Every shared object is a byte interval in one rank-one arena;
+every TMEM reference is a scalar row/column address.
+
+The supported semantic operation is
+
+```text
+C[b,m,n] = cast_c_dtype(
+    output_scale_f32 * sum_k(float32(A[b,m,k]) * float32(B[b,k,n]))
+)
+```
+
+where A and B have the same FP8 type, either E4M3FN or E5M2; accumulation and
+scaling are FP32; C is BF16, FP16, or FP32. A is contiguous in K, B and C are
+contiguous in N. M/N/K are positive multiples of 16. TensorMap out-of-bounds
+fill supplies zeros for the final M/N/K tiles, and the output TensorMap drops
+out-of-bounds stores. The source loads `output_scale[0]` inside the kernel and
+never performs an unscaled branch.
+
+The source's B-keep/B-reuse branch is out of scope because its executable
+predicate is `mma_tiler_m // mma_instruction_m == 2`, which is false for all
+eight live tactics (`256 // 256 == 1`). Every writer PTX therefore uses only
+`collector::a::discard`; no `fill`, `use`, or `lastuse` collector occurs.
+
+## Static specialization table
+
+Every row uses CTA-group 2, four epilogue warps (0..3), MMA warp 4, TMA warp 5,
+one source swizzle unit, TMA output stores, two FP32 accumulator stages, a
+128x32 epilogue subtile, and a per-CTA M extent of 128.
+
+| tactic | MMA tile | instruction | cluster | raster | AB stages BF16/FP16/FP32 | C stages BF16/FP16/FP32 | TMEM columns |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 0 | 256x256x128 | 256x256x64 | 2x1 | M | 9/9/9 | 4/4/2 | 512 |
+| 1 | 256x128x128 | 256x128x64 | 2x1 | M | 12/12/12 | 4/4/2 | 256 |
+| 2 | 256x256x64 | 256x256x32 | 2x1 | M | 19/19/18 | 2/2/2 | 512 |
+| 3 | 256x256x64 | 256x256x64 | 2x1 | M | 19/19/18 | 2/2/2 | 512 |
+| 4 | 256x256x128 | 256x256x64 | 2x2 | M | 9/9/9 | 4/4/2 | 512 |
+| 5 | 256x128x128 | 256x128x64 | 4x1 | M | 12/12/12 | 4/4/2 | 256 |
+| 6 | 256x256x128 | 256x256x64 | 2x1 | N | 9/9/9 | 4/4/2 | 512 |
+| 7 | 256x128x128 | 256x128x64 | 2x1 | N | 12/12/12 | 4/4/2 | 256 |
+
+The stage counts are evidenced by emitted mbarrier groups:
+`AB_STAGES, AB_STAGES, 2, 2, 1`. The output depth is evidenced by
+`cp.async.bulk.wait_group.read 3` for four stages and `...read 1` for two.
+Input dtype changes only descriptor format bits. Output dtype changes the
+conversion/store sequence and, for tactics 2/3 FP32, reduces AB depth by one.
+
+## Primitive vocabulary
+
+The pseudocode uses structural names that carry only scalars or opaque hardware
+descriptors:
+
+```python
+specialize_static(...)
+launch(grid, block_threads, cluster, dynamic_smem_bytes)
+tensor_map(base, rank, extents, byte_strides, box_extents,
+           element_strides, dtype, swizzle_code, oob_zero)
+smem_interval(base, byte_offset, byte_count)
+tmem_address(base_column, row, column)
+encode_smem_descriptor(base_bits, shared_address)
+static_scheduler_cursor(problem_ctas, cluster_shape, grid_clusters, raster)
+```
+
+Movement, compute, and synchronization are explicit:
+
+```python
+load_global_f32(pointer)
+prefetch_tensormap(map)
+tma_load_group2(map, coordinates, shared_address, full_barrier,
+                optional_multicast_mask, cache_hint)
+tma_store(map, coordinates, shared_address, cache_hint)
+tmem_load_32x32_f32(tmem_address, 32_register_words)
+register_store_shared(words, shared_address)
+umma_f8f6f4_group2(accumulator, a_descriptor, b_descriptor,
+                   instruction_descriptor, accumulate)
+init_mbarrier(address, arrivals)
+arrive_expect_tx(address, bytes)
+try_wait_mbarrier(address, phase, acquire)
+wait_mbarrier(address, phase)
+arrive_mbarrier(address)
+umma_commit(address, multicast_mask)
+fence_mbarrier_init_cluster()
+cluster_arrive_relaxed(); cluster_wait(); named_barrier(id, threads)
+fence_async_shared_cta(); tma_commit(); tma_wait(pending)
+alloc_tmem_group2(columns); relinquish_tmem_group2(); dealloc_tmem_group2(columns)
+```
+
+## Complete operation sketch
+
+```python
+# ==========================================================================
+# 1. Specialization, opaque TensorMaps, and persistent launch
+# Source Rubin 182-257 and 721-817; Blackwell 762-784; primary PTX 8-42.
+# ==========================================================================
+P = specialize_static(B, M, N, K, ab_dtype, c_dtype, tactic, target="sm_107a")
+assert ab_dtype in (E4M3FN, E5M2)
+assert c_dtype in (BF16, FP16, FP32)
+assert B > 0 and M % 16 == 0 and N % 16 == 0 and K % 16 == 0
+
+CTA_GROUP = 2
+CTA_M = 128
+CTA_N = P.mma_tile_n
+K_TILE = P.mma_tile_k
+INSTRUCTION_K = P.instruction_k
+K_PHASES = K_TILE // INSTRUCTION_K
+WARPS = 6
+EPI_WARPS = (0, 1, 2, 3)
+MMA_WARP = 4
+TMA_WARP = 5
+ACC_STAGES = 2
+AB_STAGES = P.ab_stages
+C_STAGES = P.c_stages
+EPI_M = 128
+EPI_N = 32
+TMEM_COLUMNS = P.tmem_columns
+
+# TensorMap logical dimensions are ordered by physical contiguity. All fields
+# below are scalar integers fixed by the specialization; maps themselves are
+# opaque 128-byte launch arguments.
+map_A = tensor_map(
+    A_ptr, rank=3, extents=(K, M, B), byte_strides=(1, K, M*K),
+    box_extents=(K_TILE, 256, 1), element_strides=(1, 1, 1),
+    dtype=ab_dtype, swizzle_code=SW128B, oob_zero=True,
+)
+map_B = tensor_map(
+    B_ptr, rank=3, extents=(N, K, B), byte_strides=(1, N, K*N),
+    box_extents=(CTA_N, K_TILE, 1), element_strides=(1, 1, 1),
+    dtype=ab_dtype, swizzle_code=SW128B, oob_zero=True,
+)
+C_BYTES = 2 if c_dtype in (BF16, FP16) else 4
+map_C = tensor_map(
+    C_ptr, rank=3, extents=(N, M, B),
+    byte_strides=(C_BYTES, N*C_BYTES, M*N*C_BYTES),
+    box_extents=(EPI_N, EPI_M, 1), element_strides=(1, 1, 1),
+    dtype=c_dtype, swizzle_code=source_output_swizzle(c_dtype), oob_zero=False,
+)
+
+problem_ctas = (ceil_div(M, CTA_M), ceil_div(N, CTA_N), B)
+problem_clusters = cluster_count(problem_ctas, P.cluster_m, P.cluster_n)
+grid_clusters = min(problem_clusters, source_max_active_clusters(P.cluster_size))
+launch(
+    grid=(P.cluster_m, P.cluster_n, grid_clusters), block_threads=192,
+    cluster=(P.cluster_m, P.cluster_n, 1), arch="sm_107a",
+    dynamic_smem_bytes=P.dynamic_smem_bytes, min_blocks_per_sm=1,
+)
+# instruction_selection: `.target sm_107a`, `.reqntid 192,1,1`, dynamic
+# shared declaration aligned to 1024, and cluster launch metadata. Extent: one
+# specialized launch. `ctaid.x/y` are the CTA coordinates inside one cluster;
+# `ctaid.z` is the initial persistent-cluster work index. The three role
+# cursors below use exactly the same scalar StaticPersistentTileScheduler
+# decode and advance by `grid_clusters`.
+
+# ==========================================================================
+# 2. Exact rank-one shared storage
+# Source Rubin 308-388, 609-616; primary PTX 110-229, 376-434, 1260-1280.
+# ==========================================================================
+AB_FULL = smem_interval(smem, 0, 8 * AB_STAGES)
+AB_EMPTY = smem_interval(smem, 8 * AB_STAGES, 8 * AB_STAGES)
+ACC_FULL = smem_interval(smem, 16 * AB_STAGES, 16)
+ACC_EMPTY = smem_interval(smem, 16 * AB_STAGES + 16, 16)
+TMEM_DEALLOC = smem_interval(smem, 16 * AB_STAGES + 32, 8)
+TMEM_POINTER = smem_interval(smem, 16 * AB_STAGES + 40, 4)
+
+if AB_STAGES <= 12:
+    A_OFFSET = 256
+else:
+    A_OFFSET = 384
+A_STAGE_BYTES = 16384 if K_TILE == 128 else 8192
+B_STAGE_BYTES = 16384 if CTA_N == 256 and K_TILE == 128 else 8192
+B_OFFSET = A_OFFSET + AB_STAGES * A_STAGE_BYTES
+C_OFFSET = B_OFFSET + AB_STAGES * B_STAGE_BYTES
+C_STAGE_BYTES = 8192 if c_dtype in (BF16, FP16) else 16384
+
+sA = smem_interval(smem, A_OFFSET, AB_STAGES * A_STAGE_BYTES)
+sB = smem_interval(smem, B_OFFSET, AB_STAGES * B_STAGE_BYTES)
+sC = smem_interval(smem, C_OFFSET, C_STAGES * C_STAGE_BYTES)
+
+# Concrete writer offsets:
+#   tactics 0/4/6: A=256, B=147712, C=295168, end=327936
+#   tactics 1/5/7: A=256, B=196864, C=295168, end=327936
+#   tactics 2/3 BF16/FP16: A=384, B=156032, C=311680, end=328064
+#   tactics 2/3 FP32: A=384, B=147840, C=295296, end=328064
+
+def a_stage_address(stage, row, kk):
+    return sA + stage*A_STAGE_BYTES + source_sw128_a_byte_offset(row, kk, K_TILE)
+
+def b_stage_address(stage, col, kk):
+    return sB + stage*B_STAGE_BYTES + source_sw128_b_byte_offset(col, kk, CTA_N, K_TILE)
+
+def c_stage_address(stage, row, col):
+    return sC + stage*C_STAGE_BYTES + source_output_byte_offset(row, col, c_dtype)
+
+# Each source_* offset function is scalar integer/XOR arithmetic matching the
+# corresponding TensorMap swizzle. It returns a byte count and constructs no
+# mapping value.
+
+# ==========================================================================
+# 3. Raw descriptor constants and scalar address insertion
+# Source Rubin 133-180, 441-447, 583-592; primary PTX 756-805.
+# ==========================================================================
+# Dense SM107 instruction descriptor bits are folded on the host. E4M3 uses A/B
+# format 0; E5M2 uses A/B format 1. D format is FP32, trans_A=0, trans_B=1,
+# negate/saturate/sparse are zero. SM107 K=64 sets bit 29 in addition to the
+# common SM100 fields. Writer PTX fixes these exact images:
+if CTA_N == 256 and INSTRUCTION_K == 64:
+    INSTR_DESC = 0x30410010 if ab_dtype == E4M3FN else 0x30410490
+elif CTA_N == 128 and INSTRUCTION_K == 64:
+    INSTR_DESC = 0x30210010 if ab_dtype == E4M3FN else 0x30210490
+else:  # CTA_N=256, INSTRUCTION_K=32
+    INSTR_DESC = 0x10410010 if ab_dtype == E4M3FN else 0x10410490
+
+# Matrix descriptor constant fields are likewise compile-time integers. Only
+# the 14-bit shared address is inserted per stage/K phase at run time.
+A_DESC_BASE = source_smem_descriptor_base(
+    leading_units=source_a_leading_16B_units(K_TILE),
+    stride_units=source_a_stride_16B_units(K_TILE), swizzle_code=SW128B,
+)
+B_DESC_BASE = source_smem_descriptor_base(
+    leading_units=source_b_leading_16B_units(CTA_N, K_TILE),
+    stride_units=source_b_stride_16B_units(CTA_N, K_TILE), swizzle_code=SW128B,
+)
+
+def descriptor_with_address(base_bits, shared_address):
+    return base_bits | ((shared_address >> 4) & 0x3FFF)
+
+def a_descriptor(stage, kphase):
+    return descriptor_with_address(
+        A_DESC_BASE,
+        a_stage_address(stage, source_a_descriptor_row(kphase),
+                        source_a_descriptor_k(kphase, INSTRUCTION_K)),
+    )
+
+def b_descriptor(stage, kphase):
+    return descriptor_with_address(
+        B_DESC_BASE,
+        b_stage_address(stage, source_b_descriptor_col(kphase),
+                        source_b_descriptor_k(kphase, INSTRUCTION_K)),
+    )
+
+def accumulator_address(tmem_base, acc_stage):
+    return tmem_address(tmem_base + acc_stage*CTA_N, row=0, column=0)
+
+# instruction_selection: ordinary integer shifts/ORs plus raw 64-bit UMMA
+# descriptors. No runtime encoder helper and no inline CUDA function call.
+
+# ==========================================================================
+# 4. Coordinates, barrier initialization, and cluster publication
+# Source Rubin 282-450; primary PTX 78-322.
+# ==========================================================================
+output_scale_f32 = load_global_f32(output_scale_ptr)
+# instruction_selection: one `ld.global.b32`; extent: one FP32 scalar load per
+# thread before role dispatch, exactly source Rubin 282 and primary PTX 83-84.
+tid = thread_id_x()
+warp = warp_uniform(tid >> 5)
+lane = tid & 31
+cluster_rank = block_idx_in_cluster()
+mma_tile_coord_v = block_idx_x() % CTA_GROUP
+leader_cta = mma_tile_coord_v == 0
+cluster_m_coord = cluster_rank % P.cluster_m
+cluster_n_coord = (cluster_rank // P.cluster_m) % P.cluster_n
+
+if warp == TMA_WARP:
+    prefetch_tensormap(map_A)
+    prefetch_tensormap(map_B)
+    prefetch_tensormap(map_C)
+# instruction_selection: three `prefetch.tensormap`; extent: one per opaque map.
+
+AB_EMPTY_ARRIVALS = (
+    source_num_mcast_ctas_a(P.cluster_m, P.cluster_n)
+    + source_num_mcast_ctas_b(P.cluster_m, P.cluster_n) - 1
+)
+# Concrete values are 1 for tactics 0/1/2/3/6/7 and 2 for tactics 4/5.
+
+if warp == 0 and elect_one():
+    for stage in static_range(AB_STAGES):
+        init_mbarrier(AB_FULL + 8*stage, arrivals=1)
+    for stage in static_range(AB_STAGES):
+        init_mbarrier(AB_EMPTY + 8*stage, arrivals=AB_EMPTY_ARRIVALS)
+    for stage in static_range(ACC_STAGES):
+        init_mbarrier(ACC_FULL + 8*stage, arrivals=1)
+    for stage in static_range(ACC_STAGES):
+        init_mbarrier(ACC_EMPTY + 8*stage, arrivals=8)
+
+# instruction_selection: `mbarrier.init.shared.b64`; extent: exactly
+# `2*AB_STAGES + 4` elected-lane initializations, with arrivals
+# `1, AB_EMPTY_ARRIVALS, 1, 8` for the four consecutive groups. Writer PTX
+# groups are 9/9/2/2, 12/12/2/2, 19/19/2/2, or 18/18/2/2.
+
+if warp == TMA_WARP and elect_one():
+    init_mbarrier(TMEM_DEALLOC, arrivals=32)
+# instruction_selection: one `mbarrier.init.shared.b64` with arrival count 32;
+# extent: the group-2 teardown barrier.
+
+# CuTeDSL's two deferred pipeline constructors emit two publication fences,
+# then pipeline_init_arrive performs the cluster arrive. The source waits only
+# after shared/TMEM fragments and scalar descriptor coordinates are prepared.
+fence_mbarrier_init_cluster()
+fence_mbarrier_init_cluster()
+if P.cluster_size > 1:
+    cluster_arrive_relaxed()
+
+A_MULTICAST_MASK = source_a_multicast_mask(P.cluster_m, P.cluster_n,
+                                           cluster_m_coord, cluster_n_coord)
+B_MULTICAST_MASK = source_b_multicast_mask(P.cluster_m, P.cluster_n,
+                                           cluster_m_coord, cluster_n_coord)
+prepare_scalar_scheduler_and_descriptor_terms()
+
+if P.cluster_size > 1:
+    cluster_wait()
+else:
+    cta_sync()
+# instruction_selection: `fence.mbarrier_init.release.cluster` twice,
+# `barrier.cluster.arrive.relaxed`, then delayed `barrier.cluster.wait`; extent:
+# one prologue. Tactic 4's A load uses explicit multicast across cluster N;
+# tactic 5's B load uses explicit multicast across the two CTA-group pairs in
+# cluster M. CTA-group 2 itself does not require the explicit multicast suffix.
+
+# ==========================================================================
+# 5. Role: persistent TMA producer warp 5
+# Source Rubin 452-502; primary PTX 323-704.
+# ==========================================================================
+with role(warp == TMA_WARP):
+    work = static_scheduler_cursor(problem_ctas, P.cluster, grid_clusters, P.raster)
+    tma_state = pipeline_state(AB_STAGES, initial_phase=1)
+    while work.valid:
+        tile_m_cta, tile_n_cta, batch = work.cta_coordinate
+        mma_m = tile_m_cta // CTA_GROUP
+        k_tiles = ceil_div(K, K_TILE)
+        tma_state.reset()
+        speculative_empty = try_wait_mbarrier(
+            AB_EMPTY + 8*tma_state.stage, tma_state.phase, acquire=True,
+        )
+        for k_tile in runtime_range(k_tiles, unroll_hint=1):
+            wait_if_needed(AB_EMPTY + 8*tma_state.stage,
+                           tma_state.phase, speculative_empty)
+            if elect_one():
+                arrive_expect_tx(AB_FULL + 8*tma_state.stage, P.tma_transaction_bytes)
+                # P.tma_transaction_bytes is 65536 for N256/K128,
+                # 49152 for N128/K128, and 32768 for N256/K64.
+                tma_load_group2(
+                    map_A,
+                    coordinates=(k_tile*K_TILE, mma_m*256, batch),
+                    shared_address=a_stage_address(tma_state.stage, 0, 0),
+                    full_barrier=AB_FULL + 8*tma_state.stage,
+                    optional_multicast_mask=(A_MULTICAST_MASK if tactic == 4 else None),
+                    cache_hint=source_l2_cache_hint,
+                )
+                tma_load_group2(
+                    map_B,
+                    coordinates=(tile_n_cta*CTA_N, k_tile*K_TILE, batch),
+                    shared_address=b_stage_address(tma_state.stage, 0, 0),
+                    full_barrier=AB_FULL + 8*tma_state.stage,
+                    optional_multicast_mask=(B_MULTICAST_MASK if tactic == 5 else None),
+                    cache_hint=source_l2_cache_hint,
+                )
+            advance(tma_state)
+            speculative_empty = True
+            if k_tile + 1 < k_tiles:
+                speculative_empty = try_wait_mbarrier(
+                    AB_EMPTY + 8*tma_state.stage, tma_state.phase, acquire=True,
+                )
+        work.advance()
+    for unused_stage in static_range(AB_STAGES):
+        wait_mbarrier(AB_EMPTY + 8*tma_state.stage, tma_state.phase)
+        advance(tma_state)
+# instruction_selection: elected `mbarrier.arrive.expect_tx.shared.b64`;
+# two rank-3 `cp.async.bulk.tensor...cta_group::2` loads per K tile; optional
+# `.multicast::cluster`; parity waits and a full producer tail.
+
+# ==========================================================================
+# 6. Role: persistent leader-CTA MMA warp 4
+# Source Rubin 504-607; primary PTX 705-1068.
+# ==========================================================================
+with role(warp == MMA_WARP):
+    named_barrier(2, 160)
+    # instruction_selection: `bar.sync 2,160`; extent: all 32 MMA-warp lanes.
+    tmem_base = load_shared_u32(TMEM_POINTER)
+    work = static_scheduler_cursor(problem_ctas, P.cluster, grid_clusters, P.raster)
+    ab_state = pipeline_state(AB_STAGES, initial_phase=0)
+    acc_state = pipeline_state(ACC_STAGES, initial_phase=1)
+    while work.valid:
+        k_tiles = ceil_div(K, K_TILE)
+        ab_state.reset()
+        speculative_full = True
+        if leader_cta:
+            speculative_full = try_wait_mbarrier(
+                AB_FULL + 8*ab_state.stage, ab_state.phase, acquire=True,
+            )
+            wait_mbarrier(ACC_EMPTY + 8*acc_state.stage, acc_state.phase)
+        accumulate = False
+        for k_tile in runtime_range(k_tiles):
+            if leader_cta:
+                wait_if_needed(AB_FULL + 8*ab_state.stage,
+                               ab_state.phase, speculative_full)
+                for kphase in static_range(K_PHASES):
+                    if elect_one():
+                        umma_f8f6f4_group2(
+                            accumulator_address(tmem_base, acc_state.stage),
+                            a_descriptor(ab_state.stage, kphase),
+                            b_descriptor(ab_state.stage, kphase),
+                            INSTR_DESC,
+                            accumulate=accumulate,
+                            collector="a::discard",
+                            disabled_scale_registers=(0,0,0,0,0,0,0,0),
+                        )
+                    accumulate = True
+                if elect_one():
+                    umma_commit(AB_EMPTY + 8*ab_state.stage,
+                                source_ab_empty_multicast_mask(P, cluster_rank))
+                advance(ab_state)
+                speculative_full = True
+                if k_tile + 1 < k_tiles:
+                    speculative_full = try_wait_mbarrier(
+                        AB_FULL + 8*ab_state.stage, ab_state.phase, acquire=True,
+                    )
+        if leader_cta and elect_one():
+            umma_commit(ACC_FULL + 8*acc_state.stage,
+                        source_acc_full_multicast_mask(P, cluster_rank))
+        advance(acc_state)
+        work.advance()
+    for unused_stage in static_range(ACC_STAGES):
+        wait_mbarrier(ACC_EMPTY + 8*acc_state.stage, acc_state.phase)
+        advance(acc_state)
+# instruction_selection: raw
+# `tcgen05.mma.cta_group::2.kind::f8f6f4.collector::a::discard`; two issues per
+# source K tile for tactics 0/1/2/4/5/6/7 and one for tactic 3; raw
+# `tcgen05.commit.cta_group::2.mbarrier::arrive::one...`; extent: every K tile
+# and accumulator publication. Only the leader CTA issues UMMA.
+
+# ==========================================================================
+# 7. Roles: four persistent scaled TMA epilogue warps
+# Source Rubin 609-666; epilogue_utils 100-255; primary PTX 1069-1412.
+# ==========================================================================
+with role(warp in EPI_WARPS):
+    if warp == 0:
+        alloc_tmem_group2(TMEM_COLUMNS, destination=TMEM_POINTER)
+        # instruction_selection:
+        # `tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32`; extent:
+        # the full warp 0 in both paired CTAs, 512 columns for N256 or 256 for
+        # N128. There is deliberately no elected-lane predicate.
+    named_barrier(2, 160)
+    # instruction_selection: `bar.sync 2,160`; extent: all 160 lanes in the
+    # MMA plus four epilogue warps after warp 0 publishes the TMEM pointer.
+    tmem_base = load_shared_u32(TMEM_POINTER)
+    work = static_scheduler_cursor(problem_ctas, P.cluster, grid_clusters, P.raster)
+    acc_state = pipeline_state(ACC_STAGES, initial_phase=0)
+    c_sequence = 0
+    while work.valid:
+        tile_m_cta, tile_n_cta, batch = work.cta_coordinate
+        wait_mbarrier(ACC_FULL + 8*acc_state.stage, acc_state.phase)
+        for subtile in static_range(CTA_N // EPI_N):
+            # Each epilogue warp owns 32 rows. Each lane receives the 32 FP32
+            # columns of its row as 32 b32 registers.
+            acc_words = register_words(32)
+            tmem_load_32x32_f32(
+                tmem_address(
+                    tmem_base + acc_state.stage*CTA_N + subtile*EPI_N,
+                    row=warp*32, column=0,
+                ),
+                acc_words,
+            )
+            # Source vectorizes two FP32 values in each 64-bit register pair.
+            for pair in static_range(16):
+                acc_words[2*pair:2*pair+2] = mul_f32x2(
+                    acc_words[2*pair:2*pair+2], output_scale_f32,
+                )
+
+            c_stage = c_sequence % C_STAGES
+            if c_dtype == BF16:
+                out_words = register_words(16)
+                for pair in static_range(16):
+                    out_words[pair] = cvt_rn_bf16x2_f32(
+                        acc_words[2*pair+1], acc_words[2*pair],
+                    )
+                register_store_shared(
+                    out_words,
+                    c_stage_address(c_stage, warp*32, lane),
+                    vector_bytes=16, vectors_per_lane_group=4,
+                )
+                # instruction_selection: four `st.shared.v4.b32` per lane;
+                # extent: one 128x32 BF16 subtile across the four warps.
+            elif c_dtype == FP16:
+                out_words = register_words(16)
+                for pair in static_range(16):
+                    out_words[pair] = cvt_rn_f16x2_f32(
+                        acc_words[2*pair+1], acc_words[2*pair],
+                    )
+                register_store_shared(
+                    out_words,
+                    c_stage_address(c_stage, warp*32, lane),
+                    vector_bytes=16, vectors_per_lane_group=4,
+                )
+                # instruction_selection: four `st.shared.v4.b32` per lane;
+                # extent: one 128x32 FP16 subtile across the four warps.
+            else:
+                register_store_shared(
+                    acc_words,
+                    c_stage_address(c_stage, warp*32, lane),
+                    vector_bytes=16, vectors_per_lane_group=8,
+                )
+                # instruction_selection: eight `st.shared.v4.b32` per lane;
+                # extent: one 128x32 FP32 subtile across the four warps.
+
+            fence_async_shared_cta()
+            named_barrier(1, 128)
+            if warp == 0:
+                tma_store(
+                    map_C,
+                    coordinates=(tile_n_cta*CTA_N + subtile*EPI_N,
+                                 tile_m_cta*CTA_M, batch),
+                    shared_address=c_stage_address(c_stage, 0, 0),
+                    cache_hint=source_l2_cache_hint,
+                )
+                tma_commit()
+                tma_wait(pending=C_STAGES - 1)
+            named_barrier(1, 128)
+            c_sequence += 1
+        named_barrier(1, 128)
+        if elect_one():
+            # One elected lane in each of four warps and each paired CTA gives
+            # the accumulator-empty barrier's eight arrivals.
+            remote_empty = map_shared_to_accumulator_owner(
+                ACC_EMPTY + 8*acc_state.stage, cluster_rank,
+            )
+            arrive_mbarrier(remote_empty)
+        advance(acc_state)
+        work.advance()
+    tma_wait(pending=0)
+
+    if warp == 0:
+        relinquish_tmem_group2()
+        # Both paired CTAs' warp 0 map to the XOR partner, signal that partner,
+        # wait on their own local barrier, and execute group-2 deallocation.
+        partner_rank = cluster_rank ^ 1
+        remote_dealloc = map_shared_to_cluster_rank(TMEM_DEALLOC, partner_rank)
+        arrive_mbarrier(remote_dealloc)
+        wait_mbarrier(TMEM_DEALLOC, phase=0)
+        dealloc_tmem_group2(tmem_base, TMEM_COLUMNS)
+# instruction_selection per subtile:
+#   one `tcgen05.ld.sync.aligned.32x32b.x32.b32` per epilogue warp;
+#   sixteen `mul.f32x2`; sixteen BF16x2/FP16x2 conversions or none for FP32;
+#   64 or 128 shared bytes per lane-group store sequence;
+#   `fence.proxy.async.shared::cta`, `bar.sync 1,128`;
+#   full warp-0 rank-3 TMA store, `cp.async.bulk.commit_group`, and
+#   wait-group read 3/1 for the complete warp-collective store sequence.
+# All four epilogue warps first execute `cp.async.bulk.wait_group.read 0`.
+# Teardown then uses only full warp 0 in both paired CTAs:
+# `tcgen05.relinquish_alloc_permit.cta_group::2`, XOR-partner
+# `mapa.shared::cluster` arrival, local parity wait, and
+# `tcgen05.dealloc.cta_group::2.sync.aligned.b32`. No elected-lane or
+# single-owner-CTA predicate appears.
+```
+
+## Required verification boundary
+
+Correctness must exercise every one of the 48 tactic/input/output
+specializations on guarded, non-tile-multiple M/N/K shapes, plus the source
+anchor `(B,M,N,K)=(1,256,10304,2688)`. Inputs use deterministic small exactly
+representable FP8 integers and an exactly representable non-unit combined
+scale. The comparison is against the pinned source kernel on the same tensors,
+with output canaries and low-level IR rejection of any inline CUDA function
+call. Bitwise equality is the first criterion; any dtype-specific fallback
+tolerance must be no looser than one output ULP and must be justified from an
+observed source/TIRx conversion-order difference.
+
+Performance is a later gate and is not evidence for this sketch. At that gate,
+only `bench_suite` reference rows count, and every frozen row must satisfy the
+strict ratio `source_time / tirx_time > 0.99`.

--- a/.agents/sketch/cudnn/sm100_bsa_backward_blk128.md
+++ b/.agents/sketch/cudnn/sm100_bsa_backward_blk128.md
@@ -1,0 +1,574 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This sketch documents a TIRx port of NVIDIA cuDNN Frontend commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5, file
+python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk128/bsa_bwd_sm100.py,
+plus its bsa_bwd_preprocess.py and bsa_bwd_postprocess.py launch helpers.
+-->
+
+# cudnn_sm100_bsa_backward_blk128: source-shaped backward sketch
+
+This is the non-executable design for
+`tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py`.
+The implementation imports `tirx_kernels.kern as K` and nothing else from a
+kernel language.  It has no tile primitive, first-class layout, rank-greater-
+than-one shared allocation, CUDA function call, inline CUDA source, or change
+under `tirx_kernels/kern`.
+
+The public operation preserves the source launch graph:
+
+1. one 256-thread preprocess writes FP32 `dPsum`, `LSE_log2`, and clears the
+   FP32 `dQaccum` plane;
+2. one 512-thread SM100a main program consumes bucketed inverse CSR and writes
+   `dQaccum`; it writes BF16 dK/dV directly for one Q group and FP32 dK/dV
+   accumulation planes for more than one group;
+3. one 128-thread postprocess converts/scales `dQaccum` to BF16 dQ;
+4. only when `q_groups>1`, two more instances of that postprocess convert dK
+   with softmax scale and dV with scale one.
+
+CSR construction, tensor normalization, output/workspace allocation, zeroing
+of multi-group dK/dV accumulators, compilation and validation are host work.
+Only these source-shaped launches are timed.
+
+## Fixed scope and public ABI
+
+All specializations are BF16, head dimension `D in {64,128}`, sparse block
+128, singleton cluster and SM100a.  Public Q/K/V/O/dO/dQ/dK/dV may be BHSD or
+BSHD and are normalized to the source BSHD views without a copy.  LSE and
+workspaces are FP32.  Offsets and indices are i32.  Every outer tensor and
+workspace address is computed in i64; c11/p10 explicitly guard the KV and
+large-Q i64 paths.
+
+```text
+preprocess(O:bf16*, dO:bf16*, dPsum:f32*, LSE:f32*,
+           LSE_log2:f32*, dQaccum:f32*)
+main(Q,K,V,dO:bf16*, LSE_log2,dPsum,dQaccum:f32*,
+     dK,dV:(bf16* if groups==1 else f32*),
+     offsets,indices:i32*, softmax_scale:f32)
+postprocess(accum:f32*, output:bf16*, scale:f32)
+```
+
+With `Q128=ceil_div(SQ,128)*128`, `KV128=ceil_div(SKV,128)*128`:
+
+```text
+dPsum    [B,H,Q128]
+LSE_log2 [B,H,Q128]
+dQaccum  [B,H,Q128,D]
+dKaccum  [B,H,KV128,D]  only groups>1, zero before timed closure
+dVaccum  [B,H,KV128,D]  only groups>1, zero before timed closure
+```
+
+Preprocess arithmetic is exactly source arithmetic:
+
+```text
+dPsum[q]    = sum_d(float(O[q,d]) * float(dO[q,d]))
+LSE_log2[q] = (LSE[q] == -inf ? 0 : LSE[q]*log2(e))
+dQaccum[:]  = 0
+```
+
+Main recomputes `S=K@Q^T`, then
+`P=exp2(S*softmax_scale*log2(e)-LSE_log2)` and
+`dS=(dP-dPsum)*P`.  Postprocess multiplies dQ and dK by softmax scale,
+does not multiply dV, and rounds once to BF16.
+
+## Independent retained source evidence
+
+Writer exports are retained under
+`.porting/cudnn_sm100_bsa_backward_blk128/source_exports/` for all four
+specializations `(D64,D128) x (group1,group2)`.  AOT and cache were disabled;
+PTX retention and line info were enabled.  Each export executed with real
+nonzero GPU inputs and asserted finite, nonzero dQ/dK/dV.  Referenced source
+and helper files are copied under `.porting/.../source_snapshot/`.
+
+| main specialization | `.loc` | MMA | T2R x32 | prefetch | static dQ reduce | static dKV epilogue | total raw reduce |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: |
+| D64, group1 | 1353 | 64 | 8 | 6 | 2 | 2 rank-4 S2G | 2 |
+| D64, group2 | 1252 | 64 | 8 | 4 | 2 | 2 raw reduce-add | 4 |
+| D128, group1 | 1465 | 80 | 12 | 6 | 4 | 2 rank-4 S2G | 4 |
+| D128, group2 | 1403 | 80 | 12 | 4 | 4 | 4 raw reduce-add | 8 |
+
+The dQ counts are one elected static instruction per 32-D chunk.  Each static
+dKV epilogue instruction is executed by both 128-thread compute workgroups;
+that runtime workgroup multiplicity is separate from the static PTX count.
+
+All main exports have `.reqntid 512,1,1`, 24 mbarrier initializations, six
+initialization fences and six `bar.sync 0`.  D128 loads twelve rank-4 G2S
+boxes in the statically visible first/steady bodies; D64 loads six.  The
+preprocess and postprocess exports also retain nonzero `.loc` coverage.  Every
+`.file` entry resolves to the pinned source/helper snapshot, never generated
+CUDA.
+
+Static MMA counts are explained, rather than merely matched:
+
+```text
+QK:  two source sites * (D/16) issues
+dP:  two source sites * (D/16) issues
+dV:  prologue and steady sites * 8 K phases
+dK:  steady and tail sites * 8 K phases
+dQ:  steady and tail sites * 8 K phases
+total D64  = 2*4 + 2*4 + 2*8 + 2*8 + 2*8 = 64
+total D128 = 2*8 + 2*8 + 2*8 + 2*8 + 2*8 = 80
+```
+
+The exported instruction descriptors are:
+
+```text
+QK and dP, M128 N128 K16, shared/shared: 0x08200490
+dV/dK, M128 N64  K16, tmem/shared:       0x08110490 (D64)
+dV/dK, M128 N128 K16, tmem/shared:       0x08210490 (D128)
+dQ,    M128 N64  K16, shared/shared:     0x08118490 (D64)
+dQ,    M128 N128 K16, shared/shared:     0x08218490 (D128)
+```
+
+## Launches and inverse-CSR task decode
+
+```python
+q_blocks = ceil_div(SQ,128)
+kv_blocks = ceil_div(SKV,128)
+bucket = explicit_bucket or (256 if q_blocks>=4096 and H<=1 else
+                             512 if q_blocks>=2048 else 384)
+groups = ceil_div(q_blocks,bucket)
+
+pre_grid  = (ceil_div(SQ,128), H, B)       # 256 threads
+main_grid = (kv_blocks*groups, H, B)        # 512 threads
+postQ     = (ceil_div(SQ,128), H, B)        # 128 threads
+postKV    = (ceil_div(SKV,128), H, B)       # 128 threads, groups>1
+
+sched_n = blockIdx.x
+q_group = sched_n // kv_blocks
+kv_block = sched_n - q_group*kv_blocks
+begin = offsets[B,H,q_group,kv_block]
+end   = offsets[B,H,q_group,kv_block+1]
+count = end-begin
+q_block(iter) = indices[B,H,begin+iter]
+```
+
+One loop iteration is exactly one 128-row Q block.  There is no pairing or
+dummy second edge.  `m_block_safe=min(q_block,q_blocks-1)` protects a malformed
+last index in the same way as the source, while valid inputs always supply an
+in-range Q block.
+
+All six pipeline-constructor epochs and the TMEM allocation rendezvous occur
+for every CTA, including `count==0`.  Role loops do no edge work when empty.
+For direct group1, the compute warps explicitly zero the empty task's physical
+dK/dV output tile.  For multi-group, host-zeroed FP32 accumulation remains
+unchanged for an empty task.
+
+## Main CTA roles and named barriers
+
+Dispatch is source order:
+
+| warps | registers | role |
+| --- | --- | --- |
+| 15 | 24 decrease | empty |
+| 14 | 24 decrease | idle |
+| 13 | 88 decrease | descriptor prefetch and Q/K/V/dO/stats producer |
+| 12 | 88 decrease | TMEM owner and every MMA issue |
+| 4-11 | 136 increase | P/dS compute and dK/dV epilogue |
+| 0-3 | 152 increase | dQ TMEM reduction to global FP32 |
+
+Named barriers preserve the source IDs and counts:
+
+```text
+bar 1/2: 128 compute threads per epilogue half; leader-warp arrive uses 160
+bar 3:   256 compute threads, TMEM read/write and shared handoff
+bar 4:   128 reduce threads, every sdQ/reduce-add handoff plus tail
+bar 5:   416 threads, MMA + compute + reduce TMEM allocation/retrieval/free
+```
+
+Barrier 0 is reserved for the six constructor-local CTA synchronization
+epochs below.  `instruction_selection` includes
+`setmaxnreg.{inc,dec}.sync.aligned.u32`, `bar.sync`,
+`fence.mbarrier_init.release.cluster`,
+`tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32`, and matching
+deallocation.
+
+## One rank-1 shared arena
+
+The implementation allocates one `u8 arena[SMEM_BYTES] align=1024`.  All
+subobjects are byte offsets and all address transforms are integer formulas.
+Barrier/header offsets are identical in all specializations:
+
+| object | offset | bytes |
+| --- | ---: | ---: |
+| Q full[2],empty[2] | 0 | 32 |
+| dO full,empty | 32 | 16 |
+| LSE full[2],empty[2] | 48 | 32 |
+| dPsum full,empty | 80 | 16 |
+| S/P full,empty | 96 | 16 |
+| dP full,empty | 112 | 16 |
+| dS full,empty | 128 | 16 |
+| dKV full[2],empty[2] | 144 | 32 |
+| dQ full,empty | 176 | 16 |
+| TMEM holding word | 192 | 4 |
+| alignment gap | 196 | 828 |
+
+Data regions are source struct offsets measured by compiling the actual four
+specializations and reading the static struct metadata:
+
+| specialization | sQ / bytes | sK | sV | sdO / bytes | sdS | sLSE | dPsum | sdQ | total |
+| --- | --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| D64 g1 | 1024 / 32768 | 33792 | 50176 | 66560 / 16384 | 82944 | 115712 | 116736 | 117760 | 150528 |
+| D64 gN | 1024 / 32768 | 33792 | 50176 | 66560 / 32768 | 99328 | 132096 | 133120 | 134144 | 166912 |
+| D128 g1/gN | 1024 / 65536 | 66560 | 99328 | 132096 / 32768 | 164864 | 197632 | 198656 | 199680 | 232448 |
+
+Region extents not explicit in the table are:
+
+```text
+sK,sV: D*128*2 bytes each
+sdS:   128*128*2 = 32768 bytes
+sLSE:  2 stages * 128 f32 = 1024 bytes
+dPsum: 1 stage  * 128 f32 = 512 bytes, then alignment padding
+sdQ:   2 stages * 128*32 f32 = 32768 bytes
+```
+
+`sQ` is reused by sdK; `sdO` is reused by sdV.  D64 group1 needs only a
+16384-byte sdV view, while D64 multi-group needs two FP32 128x32 views and
+therefore a 32768-byte sdO allocation.  D128 needs 32768 bytes either way.
+
+The 128-byte swizzle is expressed directly.  For any 128-row BF16 operand and
+64-column band:
+
+```python
+band_elem(row,dim64) = (row*64 + dim64) ^ ((row & 7)*8)
+bf16_addr(base,row,dim,D,stage=0) = (
+  base + stage*(128*D*2) + (dim//64)*(128*64*2)
+       + 2*band_elem(row,dim%64)
+)
+```
+
+This names sQ, sK, sV, sdO and sdS views, including their transposed descriptor
+interpretations.  Scalar stats and reduction storage are:
+
+```python
+stat_addr(base,row,stage,stride128=True) = base + 4*(stage*128 + row)
+sdq_addr(stage,row,col32) = SDQ + 4*(stage*128*32 + row*32 + col32)
+tmem_cell(col,row_group32) = col + (row_group32 << 16)
+```
+
+The implementation must preserve the exported vector-store ordering and any
+swizzled R2S addresses used by direct dKV.  It may spell those as integer XOR
+functions, never as a layout object.
+
+## TMEM allocation and MMA descriptors
+
+Every CTA allocates 512 TMEM columns.  Logical regions are:
+
+```text
+S/P  = base + 0
+dV   = base + 128
+dP/dQ/dS = base + 128 + D
+dK   = base + 256 + D
+```
+
+Thus D64 uses `(S=0,dV=128,dP/dQ=192,dK=320)` and D128 uses
+`(0,128,256,384)`.  P aliases S; dS and dQ alias dP by alternating pipeline
+lifetimes.
+
+Shared descriptors use swizzle mode 3, `sdo=64`, `ldo=512`, and address field
+`(shared_addr>>4)&0x3fff`.  The QK/dP shared/shared helpers advance the low
+descriptor by `0,2,4,6` and, for D128, `0x400,0x402,0x404,0x406`.  The
+TMEM-A dV/dK helpers advance TMEM-A by 8 and shared-B by 0x80 for eight K
+phases.  dQ emits eight elected raw `tcgen05.mma` issues because its source
+helper uses a shared/shared partition whose accumulator coordinate must be
+spelled explicitly in K.
+
+Every elected issue is
+`tcgen05.mma.cta_group::1.kind::f16`; publication is
+`tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`.
+
+## Pipeline construction and state
+
+```text
+S/P:   stage1 UMMA->compute producer arrivals1, consumer arrivals8
+dP:    stage1 UMMA->compute producer arrivals1, consumer arrivals8
+dKV:   stage2 UMMA->compute producer arrivals1, consumer arrivals8
+dQ:    stage1 UMMA->reduce  producer arrivals1, consumer arrivals4
+dS:    stage1 compute->UMMA producer arrivals8, consumer arrivals1
+LSE:   stage2 TMA->compute  producer arrivals1, consumer arrivals8, 512B/stage
+dPsum: stage1 TMA->compute  producer arrivals1, consumer arrivals8, 512B/stage
+Q:     stage2 TMA->UMMA     producer arrivals1, consumer arrivals1, D*256B/stage
+dO:    stage1 TMA->UMMA     producer arrivals1, consumer arrivals1, D*256B/stage
+```
+
+Initialization follows source construction order, not shared declaration
+order.  The first five families sync independently; deferred TMA families
+share the sixth epoch completed by non-deferred dO:
+
+```text
+epoch 1 S/P:  full96, empty104                         -> fence; bar.sync 0
+epoch 2 dP:   full112,empty120                         -> fence; bar.sync 0
+epoch 3 dKV:  full144,152; empty160,168                -> fence; bar.sync 0
+epoch 4 dQ:   full176,empty184                         -> fence; bar.sync 0
+epoch 5 dS:   full128,empty136                         -> fence; bar.sync 0
+epoch 6 LSE:  full48,56; empty64,72
+        dPsum full80,empty88
+        Q:    full0,8; empty16,24
+        dO:   full32,empty40                           -> fence; bar.sync 0
+```
+
+That is exactly 24 `mbarrier.init`, six release fences and six `bar.sync 0`.
+Producer states start `(stage=0,phase=1)`, consumer states `(0,0)`.  One-stage
+advance toggles phase.  Two-stage Q/LSE/dKV advances stage and toggles phase
+only on wrap.  The source clones one Q consumer handle: the original advances
+after QK, while release is delayed until dK has consumed that Q stage.
+
+Role-owned states are:
+
+```text
+load:    Q_LSE_prod(depth2), dO_dPsum_prod(depth1)
+mma:     Q_cons+delayed_handles, dO_cons, dS_cons;
+         S/P_prod,dP_prod,dQ_prod(depth1), dKV_prod(depth2)
+compute: S/P_cons,dP_cons,dS_prod,dKV_cons,
+         LSE_cons(depth2),dPsum_cons(depth1)
+reduce:  dQ_cons(depth1), bulk_store_prod(depth2)
+```
+
+## Complete main role program
+
+The pseudocode below is operation-level and every collective line is a required
+source instruction family, not permission to call an out-of-line helper.
+
+```python
+if warp==13 and elected:
+  prefetch(desc_Q,desc_K,desc_V,desc_dO)
+  if groups==1: prefetch(desc_dV,desc_dK)
+for epoch in six_epochs_above:
+  elected_init_all_mbarriers(epoch)
+  fence_mbarrier_init_release_cluster(); bar_sync_0()
+
+set_role_register_budget()
+if warp==12: tmem_alloc(512)
+if warp in {0..12 except idle}: named_barrier(5,416); retrieve_tmem_base()
+
+role load_warp_13:
+  for each scheduler task:
+    if count>0:
+      for edge in 0..count-1:
+        qb = indices[begin+edge]
+        acquire(Q_prod)
+        expect(Q_full, D*256 + (D*256 if edge==0 else 0))
+        if edge==0: rank4_tma(K[kv_block,0:D] -> sK)
+        rank4_tma(Q[qb*128,0:D] -> sQ[Q_stage])
+        commit Q
+        acquire(LSE_prod sharing the Q cursor)
+        bulk_g2s_512B(LSE_log2[qb*128:q+128] -> sLSE[stage])
+        advance Q_LSE_prod
+
+        acquire(dO_prod)
+        expect(dO_full, D*256 + (D*256 if edge==0 else 0))
+        if edge==0: rank4_tma(V[kv_block,0:D] -> sV)
+        rank4_tma(dO[qb*128,0:D] -> sdO)
+        commit dO
+        acquire(dPsum_prod sharing the dO cursor)
+        bulk_g2s_512B(dPsum[qb*128:q+128] -> shared)
+        advance dO_dPsum_prod
+      producer_tail(Q,LSE,dO,dPsum)
+
+role mma_warp_12:
+  for each task with count>0:
+    zero_init_dK = True
+    Q0 = wait_advance_Q(); wait_empty(S/P)
+    issue QK(Q0,zero=True); publish S
+    wait dO0; wait_empty(dP); wait_empty(dQ)
+    issue V@dO0.T(zero=True); publish dP
+    toggle shared S/P,dP,dQ producer phase
+    wait_empty(S/P) as the compute-produced P-ready handoff
+    issue P.T@dO0(zero=True); release dO0
+
+    current_Q = Q0
+    for edge in 1..count-1:
+      next_Q = wait_advance_Q()
+      issue QK(next_Q,zero=True); publish S
+      wait dS
+      issue dS.T@current_Q(zero=zero_init_dK); zero_init_dK=False
+      release current_Q
+      issue dS@K(zero=True); publish dQ
+      release dS
+      wait next dO; wait next empty dQ
+      issue V@dO.T(zero=True); publish dP
+      toggle shared producer phase
+      wait_empty(S/P) as P-ready; issue P.T@dO(zero=False); release dO
+      current_Q=next_Q
+
+    publish final S/P full generation after final dV
+    publish dV generation on dKV stage0
+    wait dKV stage1 empty; wait final dS
+    issue dS.T@current_Q(zero=zero_init_dK); publish dK generation
+    issue final dS@K(zero=True); publish dQ
+    release current_Q,dS; toggle producer phases
+
+role compute_warps_4_11:
+  local_ct = threadIdx.x % 256
+  dp_idx = local_ct % 128
+  wg = local_ct // 128
+  for each task:
+    for edge in 0..count-1:
+      wait LSE; wait S
+      T2R_x32(S)                         # two row fragments per thread
+      if physical KV row >= SKV: S=-inf # whole-row tail predicate only
+      packed_fma(S,scale*log2e,-LSE); exp2_fast; BF16 pack P
+      on first repetition: fence_tmem_load; bar3_256
+      R2T_x16(P)
+      fence_tmem_store; fence_shared; bar3_256
+      elected release S; release LSE; advance
+
+      wait dPsum; wait dP
+      T2R_x32(dP); fence_tmem_load; bar3_256
+      packed_sub(dP,dPsum); packed_mul(P,dP); BF16 pack dS
+      acquire dS; R2T_x16(dS)
+      R2S BF16 dS with st.shared.v4.b32
+      # eight 128-bit stores/thread: two x32 repetitions, four stores each;
+      # 256 threads cover the full [KV-row128,Q-row128] BF16 tile using the
+      # bf16_addr(sdS,kv_row,q_row,D=128) integer swizzle
+      fence_tmem_store; advance combined S/P/dP consumer
+      fence_shared; bar3_256
+      release dPsum; elected publish dS; advance
+
+    if count>0:
+      wait dV generation; epilogue(V,scale=None); release/advance dKV
+      wait dK generation; epilogue(K,scale=(softmax_scale if groups==1 else None))
+      release/advance dKV
+    elif groups==1:
+      wg0 first 128 compute threads zero direct dK tile
+      wg1 second 128 compute threads zero direct dV tile
+
+  epilogue(kind):
+    split 256 compute threads into two 128-thread workgroups
+    each workgroup owns half the output feature columns
+    for epi_stage in (1 stage except D128 multi-group has 2):
+      T2R_x32 FP32; fence_tmem_load
+      if direct K: packed multiply by softmax_scale
+      convert to destination dtype (BF16 direct, FP32 multi-group)
+      R2S with st.shared.v4.b32 into sdK=sQ or sdV=sdO
+      # group1 BF16: 4 stores/thread for D64 or 8 for D128 per kind;
+      # one stage, and each workgroup covers [128,D/2]
+      # groupN FP32: 8 stores/thread/stage over [128,32]; one stage for D64,
+      # two stages for D128, repeated independently for K and V
+      fence_shared; bar_sync(1+wg,128)
+      leader warp:
+        if groups==1: rank4 TMA S2G one half-tile
+        else: raw cp.reduce.async.bulk.global.shared.add.f32 16384B
+        for a following stage: bulk_commit; bulk_wait_group_read(0)
+        barrier_arrive(1+wg,160)
+      fence_shared; bar_sync(1+wg,160)
+
+role reduce_warps_0_3:
+  local_rt = threadIdx.x % 128
+  for each task:
+    for edge in 0..count-1:
+      wait dQ
+      T2R_x32 dQ for D/32 repetitions # 2 for D64, 4 for D128
+      fence_tmem_load; sync_warp; elected release dQ; advance
+      for chunk in 0,32,..,D-32:
+        R2S 128x32 FP32 into sdQ[bulk_stage]
+        fence_shared; bar4_128
+        if reduce warp0 elected:
+          cp.reduce.async.bulk.global.shared.add.f32 16384B
+          bulk_commit(); bulk_wait_group_read(1)
+        bar4_128; advance bulk_stage modulo2
+    if count>0:
+      warp0 bulk_wait_group_read(0); bar4_128
+  all reduce warps execute final bulk_wait_group_read(0)
+
+mma owner after all tasks:
+  relinquish allocation permit; bar5_416; free 512 TMEM columns
+compute/reduce roles after all tasks:
+  bar5 arrival
+```
+
+The score tail mask is deliberately whole-row only.  There is no block-size
+input and no per-column sparse mask.  TMA tensor-map clipping handles Q/KV
+sequence tails; explicit global predicates guard direct empty-tile zeroing and
+postprocess stores.
+
+## Preprocess program
+
+The preprocess launch is 256 threads per Q block.  It uses source 128-bit
+loads and FP32 multiply/reduction, not BF16 packed multiplication:
+
+```python
+tile q0 = blockIdx.x*128
+each thread owns a source 128-bit vector and strided repetitions over [128,D]
+acc = sum(float(O)*float(dO))
+warp_reduce within threads_per_row = (128 if D%128==0 else 64)/8
+column-zero owner writes dPsum[row], or zero for padding
+all 256 threads vector-zero dQaccum[128,D]
+thread row<rounded tail writes LSE_log2 = 0 for -inf else LSE*log2(e)
+```
+
+`griddepcontrol_wait` precedes O/dO/LSE reads and launch-dependents follows
+their loads on SM100, matching the source launch dependency protocol.
+
+## Postprocess program
+
+Each 128-thread CTA owns one complete `[128,D]` accumulator tile.  It uses a
+rank-1 shared arena of `max(128*D*4,128*D*2)=128*D*4` bytes: 32768 bytes for
+D64 and 65536 bytes for D128.  There is no D/32 outer pipeline loop.
+
+```python
+each thread issues D/4 cp.async.cg.shared.global 128-bit loads
+cp.async.commit_group; cp.async.wait_group 0; bar.sync 0
+S2R D FP32 values/thread
+D/2 mul.f32x2 and D/2 cvt.rn.bf16x2.f32 per thread
+bar.sync 0
+D/8 st.shared.v4.b32 BF16 stores/thread
+bar.sync 0
+D/8 ld.shared.v4.b32 and predicated st.global.v4.b32 per thread
+```
+
+The same K kernel is instantiated for dQ, dK and dV; dV receives `scale=1`.
+
+## Fixed correctness and benchmark domain
+
+Correctness is the repository-derived 18-case matrix in `spec.py`, including:
+D64/D128; BHSD/BSHD; B/H>1; SQ/SKV tails at 1/127/129/255/257/641;
+fixed, variable and all-empty inverse CSR; scale 0.125; i64 KV strides;
+the 384->385 Q-block group transition; cancellation and sharp-softmax data.
+No case may be skipped.
+
+Performance is the 13-case matrix p00-p12 in `spec.py`: D64/D128, small and
+large KV working sets, B/H parallelism, variable/empty CSR, Q-block counts
+384/385/2048/4096, group counts 1/2/4/8/16, i64 strides, BSHD and explicit
+scale.  Only full `bench_suite` source/TIRx ratios are authoritative.
+
+## Correctness boundary
+
+The source-capability tolerance is calibrated before judging TIRx.  Five fresh
+source executions per numerical class are compared to the chunked sparse FP64
+analytic oracle over this ordered grid:
+
+```text
+{0,2^-20,2^-18,2^-16,2^-14,2^-12,2^-10,2^-9,2^-8,2^-7,
+ 1e-2,2e-2,3e-2} x itself
+```
+
+Choose the lexicographically smallest passing `(max_error,sum_error,atol,rtol)`
+pair for each of dQ/dK/dV and each required intermediate.  TIRx must pass the
+same selected tolerance; it may never widen it.  A required tolerance above
+0.03 is a blocking correctness failure.
+
+Every check also requires exact NaN/+Inf/-Inf classification, exact padding
+zeros, redzones, input immutability, preallocated-output pointer identity, CSR
+immutability and deterministic repeat behavior.  Final dQ/dK/dV, dPsum,
+LSE_log2, dQaccum, and multi-group dK/dV accumulation planes are compared.
+The final gate includes memcheck, initcheck, racecheck and synccheck on c00,
+c08 and c13.
+
+The low-level representation contract is immutable:
+`inspect_low_level_ir(...).ok`, zero function calls, only rank-1 shared
+allocation, no tile primitive/layout, no inline CUDA source/call, no exemptions,
+and no changes under `tirx_kernels/kern`, TVM or low-level-IR policy code.

--- a/.agents/sketch/cudnn/sm100_dsa_sparse_attention_backward.md
+++ b/.agents/sketch/cudnn/sm100_dsa_sparse_attention_backward.md
@@ -1611,7 +1611,7 @@ source's 7-tuple and one build serves every sequence length.
 ## TIRx module and benchmark contract
 
 - `KERNEL_META["name"] = "cudnn_sm100_dsa_sparse_attention_backward"`,
-  category `cudnn`, `compute_capability = 10`.
+  category `cudnn`, `runtime_cuda_archs = ["sm_100a"]`.
 - `get_kernel` returns the four device functions **in launch order**; the launch
   closure preserves that order on one stream.
 - `dkv`, `d_sink` and both workspaces are accumulated into, so the timed closure

--- a/.agents/sketch/cudnn/sm100_gdn_bprop_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn_bprop_f16.md
@@ -1,0 +1,1186 @@
+<!--
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This design sketch documents a modified TIRx port of cuDNN Frontend's
+python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py at commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.
+-->
+
+# cuDNN SM100 GDN BF16/FP16 backward: coarse WASP pipeline sketch
+
+This is a non-executable execution sketch, not Python, a builder API, a
+mathematical reference, or an alternate implementation.  The implementation it
+describes belongs in
+[`tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py`](../../../tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py),
+which becomes the executable source of truth after the correctness gate.
+
+The frozen source is the two-launch `chunk_gdn_bwd_sm100` / `run_bwd` path.
+The anchor specialization is BF16 I/O, `log_gate=True`, `(HQ,HK,HV)=(4,1,1)`,
+`BT=64`, `DK=DV=128`, FP32 state accumulation, no initial/final-state option,
+one CTA per cluster, 384 main threads, 1024 prologue threads, 512 TMEM columns,
+232448 bytes of main dynamic SMEM, and a persistent grid of 152 CTAs on the
+writer's GB200.  Accepted compiled variants are BF16/FP16, GQA/GVA head ratios,
+ragged and zero-length sequences, raw/log/safe gate, beta post-sigmoid or
+in-kernel sigmoid, optional initial/final state gradients, static/dynamic
+scheduling, scratch/generated prologue ordering, non-default scale, and i32/i64
+`cu_seqlens`.  Engine-owned Q/K normalization, checkpoint recomputation,
+grouped-head reduction, and safe-gate parameter reduction are outside this
+direct-kernel port and outside both timed closures.
+
+Writer line-info evidence is preserved in
+`.porting/gdn_bprop_f16/source_lineinfo/`.  The main PTX has SHA256
+`12c3003283614044b611ece116dfdbf481d994e285cc34cf66775aa4bea1be75`,
+20086 lines and 5636 `.loc` records; the prologue PTX has SHA256
+`b0f531ac428d1e5b16a0c38107f9c2232a934202f02ba5c606b59cd605847a7b`,
+764 lines and 166 `.loc` records.  Both `.file` tables point directly into the
+pinned Python source and its helpers, so no generated intermediate source is
+missing.  Counts below are instruction lines minus predicated lines.
+
+## Pipeline at a glance
+
+| Warps | Register target | Source-order role | Principal publication/reuse edges |
+| --- | ---: | --- | --- |
+| 0..3 | 192 | CG0: T-pairwise decay, KK/A epilogues, 8→16→32→64 inverse, dQ/dK scaling and folding, dA/dM masks, scalar dGate/dBeta M-terms | gate/beta, KK/A/dA/dM TMEM, T-inverse, dQ/dK shared staging |
+| 4..7 | 248 | CG1: dstate seed/rescale/restage, dO'/dU/dY' TMEM inputs, `Y=V-cumprod*(K@state)`, dY/dV, dGate/dBeta V-terms, dQ dot, dK fold, state drain | V/dO/state, five sequential dV/dK accumulations, dstate and output staging |
+| 8 | 64 | sole tcgen05 issuer: allocate 512 columns, issue the complete 17-phase reverse-chunk GEMM schedule, then deallocate | all TMEM accumulator/input barriers and split raw-buffer releases |
+| 9 | 64 | persistent scheduler and TensorMap loads for Q/K/V/dO/checkpoint | Q/K/V/dO/state TMA full edges and dynamic scheduler ring |
+| 10 | 64 | first/next scalar gate/beta prefetch, gate-domain prefix, reverse dGate suffix, and in-place dGate/dBeta stores | two-stage gate/beta rings; final `gate_done`/`beta_done` reuse edges |
+| 11 | 64 | current-chunk TensorMap stores in dV -> dQ -> dK order | three output staging rings and immediate bulk-group 2/1/0 releases |
+
+The source dispatch order is warps 0..3, warps 4..7, warp 8, warp 9, warp 10,
+then warp 11.  Every role owns independent pipeline cursors that are initialized
+once per kernel and continue across persistent work items.  Dynamic scheduling
+uses the warp-9 producer and eleven consumer arrivals; the static variant emits
+no ticket atomic and advances by `gridDim.x`.
+
+## Primitive vocabulary and translation boundary
+
+All storage is one-dimensional.  Matrix names below are comments on scalar
+byte/column formulas, never layout values, tile primitives, fragments, or
+first-class views.
+
+```python
+linear_buffer(space, dtype, elements, byte_offset, alignment, lifetime)
+reg_array(dtype, elements)
+smem_byte(base, stage, row, col, stage_bytes, segment_bytes, elem_bytes)
+tmem_cell(base_column, row, column)      # base + column + (row << 16)
+gmem_element(base, scalar_index)
+descriptor_slot(workspace, array, batch) # (array*B+batch)*128 bytes
+raw_smem_descriptor(base_byte, leading_bytes, stride_bytes, swizzle_code)
+```
+
+Directional movement operations are `copy_p2g`, `copy_g2s`, `copy_s2g`,
+`copy_g2r`, `copy_r2g`, `copy_s2r`, `copy_r2s`, `copy_t2r`, and `copy_r2t`.
+Basic computation operations are `fill`, `cast`, `add`, `sub`, `mul`, `fma`,
+`rcp`, `exp2`, `tanh`, `select`, `shuffle`, and `gemm`.  Barrier construction,
+wait/arrive/expect/commit, proxy fences, CTA synchronization, stage/phase
+advancement, register-budget changes, TensorMap replacement, store-group
+commit/wait, and TMEM allocation are schedule operations.
+
+The implementation imports device language only as
+`import tirx_kernels.kern as K`.  It uses no `T`, `Tx`, `I`, `tirx.tile.*`,
+`TilePrimitiveCall`, first-class layout, rank>1 SMEM, inline CUDA source/call,
+or function-call exemption.  A single rank-1 `u8` arena is the only main shared
+allocation; `K.smem_pool(base=arena)` owns only the protocol prefix and all
+payload addresses are explicit scalar byte arithmetic.
+
+## Complete non-executable sketch
+
+```python
+@specialize(
+    IO={"bf16", "f16"}, ACC="f32", BT=64, DK=128, DV=128,
+    Q_STAGES=1, K_STAGES=2, V_STAGES=1, DO_STAGES=1, STATE_STAGES=1,
+    GATE_STAGES=2, BETA_STAGES=2, TINV_STAGES=1, A_STAGES=1,
+    DQ_STAGES=1, DK_STAGES=1, DV_STAGES=1, SCHED_STAGES=2,
+    TMEM_DSTATE_ACC_STAGES=1, TMEM_DVDK_ACC_STAGES=1,
+    TMEM_DSTATE_INP_STAGES=1, TMEM_SHARED_ACC_STAGES=2,
+    TMEM_SHARED_INP_STAGES=2, CLUSTER=(1,1,1),
+    REGS=(CG0=192, CG1=248, SERVICE=64),
+)
+def gdn_bprop_factory(...):
+    return descriptor_order_prologue, persistent_backward
+
+# -----------------------------------------------------------------------
+# Runtime tensors and head specialization
+# -----------------------------------------------------------------------
+q       : gmem[IO, total_T * HQ * DK]
+k       : gmem[IO, total_T * HK * DK]
+v       : gmem[IO, total_T * HV * DV]
+gate    : gmem[f32, total_T * HO]       # raw alpha, ln(alpha), or safe logits
+beta    : gmem[f32_or_IO, total_T * HO] # post-sigmoid or IO logits
+do      : gmem[IO, total_T * HO * DV]
+ckpt    : gmem[IO, rows * HO * DV * DK]
+dq, dk, dv : gmem[IO, total_T * HO * {DK,DK,DV}]
+dgate   : gmem[f32, total_T * HO]
+dbeta   : gmem[f32_or_IO, total_T * HO]
+dstate_in, dstate0_out : optional gmem[f32, B * HO * DV * DK]
+cu_seqlens : gmem[i32_or_i64, B+1]
+work_items : gmem[i32, rows*8]
+work_count : gmem[i32, 1]
+sched_ctr  : optional gmem[i32, 2]
+tmaps      : gmem[u64, 8*B*16]
+
+HO=max(HQ,HV); Q_RATIO=HO//HQ; K_RATIO=HO//HK; V_RATIO=HO//HV
+FIRST_STATE_CHUNK = 0 if USE_INITIAL_STATE else 1
+```
+
+### Prologue launch
+
+```python
+@kernel(grid=(1,1,1), block=(1024,1,1), warps=32, target="sm_100a")
+def descriptor_order_prologue(base_maps[8], workspace, cu_seqlens,
+                              q,k,v,do,ckpt,dq,dk,dv,
+                              item_scratch,work_count,work_items,sched_all,
+                              batch_count,row_strides,checkpoint_every_n):
+    tid=thread_id(); warp=tid//32
+    if ORDER_IN_PROLOGUE:
+        # Variant semantics only: this branch is inactive in the reviewed
+        # anchor, so it carries no instruction-selection annotation.
+        order_arena=linear_buffer(smem,u8,32776,0,16,"order pass")
+        SKEY=0; SKEY_END=16384                    # 4096 i32 keys
+        SIDX=16384; SIDX_END=32768                # 4096 i32 source indices
+        SSPREAD=32768; SSPREAD_END=32776          # min/max i32 pair
+        n=num_generated_rows if ORDER_GENERATE else work_count[0]
+        if ORDER_GENERATE and tid==0: work_count[0]=num_generated_rows
+        if n>4096:
+            for dst in thread_strided_range(n):
+                # Eight fields go directly from generation/global staging to
+                # the final global work table; they never occupy shared memory.
+                for field in range(8):
+                    work_items[dst,field]=(generate_work_field(dst,field)
+                                           if ORDER_GENERATE
+                                           else item_scratch[dst,field])
+        else:
+            if tid==0:
+                store_i32(SSPREAD+0,INT_MAX); store_i32(SSPREAD+4,INT_MIN)
+            padded=next_power_of_two(n); cta_sync()
+            local_min=INT_MAX; local_max=INT_MIN
+            for i in thread_strided_fixed_capacity(4096):
+                if i<n:
+                    key=(generated_num_chunks(i) if ORDER_GENERATE
+                         else item_scratch[i,5]-item_scratch[i,4])
+                    store_i32(SKEY+4*i,key); store_i32(SIDX+4*i,i)
+                    local_min=min(local_min,key); local_max=max(local_max,key)
+                elif i<padded:
+                    store_i32(SKEY+4*i,INT_MIN); store_i32(SIDX+4*i,i)
+            atomic_shared_min(SSPREAD+0,local_min)
+            atomic_shared_max(SSPREAD+4,local_max); cta_sync()
+            if load_i32(SSPREAD+0)!=load_i32(SSPREAD+4):
+                width=2
+                while width<=padded:
+                    distance=width//2
+                    while distance>0:
+                        for i in thread_strided_fixed_capacity(4096):
+                            partner=i^distance
+                            if i<padded and partner>i:
+                                ki=load_i32(SKEY+4*i); kp=load_i32(SKEY+4*partner)
+                                ascending=((i//width)&1)==0
+                                if (ascending and ki<kp) or (not ascending and ki>kp):
+                                    swap_i32(SKEY+4*i,SKEY+4*partner)
+                                    swap_i32(SIDX+4*i,SIDX+4*partner)
+                        cta_sync(); distance//=2
+                    width*=2
+            for dst in thread_strided_range(n):
+                src=dst if load_i32(SSPREAD+0)==load_i32(SSPREAD+4) \
+                    else load_i32(SIDX+4*dst)
+                for field in range(8):
+                    work_items[dst,field]=(generate_work_field(src,field)
+                                           if ORDER_GENERATE
+                                           else item_scratch[src,field])
+        if tid==0:
+            sched_all[0]=0; sched_all[1]=0; sched_all[2]=0; sched_all[3]=0
+
+    # Arrays 0..3 load Q/K/V/dO, array 4 loads checkpoint, arrays 5..7 store
+    # dQ/dK/dV.  Gate/Beta and their outputs are scalar GMEM traffic.
+    for array in static_range(8):
+        if warp==array and elected_lane():
+            checkpoint_prefix=0
+            for batch in dynamic_range(batch_count):
+                bos=copy_g2r(cu_seqlens[batch]); eos=copy_g2r(cu_seqlens[batch+1])
+                # instruction_selection: ld.global.s64 in the reviewed anchor;
+                # extent: selected sequence endpoints (i32 is a non-annotated variant)
+                copy_p2g(base_maps[array], descriptor_slot(workspace,array,batch))
+                # instruction_selection: sixteen st.global.b64; extent: one 128-B map
+                if array==4:
+                    count=0 if eos==bos else ceil_div(eos-bos,64)
+                    replace_address_and_dim2(checkpoint_prefix,count)
+                    checkpoint_prefix += count
+                else:
+                    replace_address_and_dim2(bos,eos-bos)
+                # instruction_selection: tensormap.replace.tile.global_address
+                # and tensormap.replace.tile.global_dim; extent: one field each
+            fence_tensormap_release()
+            # instruction_selection: fence.proxy.tensormap::generic.release.gpu
+```
+
+Descriptor boxes are `[64,1,64]` for Q/K, `[64,1,64]` for V/dO/dQ/dK/dV in
+their channel-major view, and `[64,128,1,1]` for checkpoints.  Every descriptor
+uses 128-byte swizzle and a 128-byte workspace slot.
+
+### Main launch, linear storage, and protocol
+
+```python
+@kernel(grid=(num_sms,1,1), block=(384,1,1), warps=12,
+        cluster=(1,1,1), min_blocks_per_sm=1, target="sm_100a")
+def persistent_backward(workspace,n_desc,a_log,dt_bias,gate,beta,dgate,dbeta,
+                        cu_seqlens,dstate0,dstate_in,work_items,work_count,
+                        sched_ctr,scale):
+    tid=thread_id(); warp=warp_uniform(tid//32); lane=tid&31
+    arena=linear_buffer(smem,u8,232448,0,1024,"whole CTA")
+
+    # Reconciled from the writer PTX's concrete shared operands.
+    BARRIERS=0;       BARRIERS_LAST_WORD=1048
+    SCHED=1056;       SCHED_END=1064
+    TMEM_MAILBOX=1072; TMEM_MAILBOX_END=1076
+    CUMSUMLOG=1152;   CUMSUMLOG_END=1664       # 2 x 64 f32
+    CUMPROD=1664;     CUMPROD_END=2176         # 2 x 64 f32
+    BETA_S=2176;      BETA_S_END=2688           # 2 x 64 f32
+    Q=3072;           Q_END=19456               # 1 x 64 x 128 IO
+    K=19456;          K_END=52224               # 2 x 64 x 128 IO
+    DO=52224;         DO_END=68608               # 1 x 64 x 128 IO
+    STATE=68608;      STATE_END=101376           # 128 x 128 IO
+    TINV=101376;      TINV_END=109568             # 64 x 64 IO
+    KK=109568;        KK_END=117760               # 64 x 64 IO
+    A_DA=117760;      A_DA_END=125952             # A then dA alias
+    DM=125952;        DM_END=134144                # 64 x 64 IO
+    V_U=134144;       V_U_END=150528              # V then U alias
+    DSTATE=150528;    DSTATE_END=183296            # 128 x 128 IO
+    DQ=183296;        DQ_END=199680                # 64 x 128 IO
+    DK=199680;        DK_END=216064
+    DV_DY=216064;     DV_DY_END=232448             # dV stage and dY operand
+    assert DV_DY_END==232448
+
+    # Scalar-reduction aliases are byte-addressed subranges of live payloads.
+    # Their source barriers delimit overwrite from the primary tile lifetime.
+    CG0_DGATE_SCRATCH=109568; CG0_DGATE_SCRATCH_END=110592 # 256 f32 in sKK
+    CG1_V_SCRATCH=183296; CG1_V_SCRATCH_END=185344         # 512 f32 in current sDQ
+    CG1_QDOT_SCRATCH=150528; CG1_QDOT_SCRATCH_END=151552   # 256 f32 in sDstate
+
+
+    def xor128(row,col,elem_bytes):
+        return col ^ ((row&7)*(16//elem_bytes))
+    def io_byte(base,stage,row,channel):
+        segment=channel//64; within=channel%64
+        return base + stage*16384 + 2*(segment*4096 + row*64 + xor128(row,within,2))
+    def f32_ring_byte(base,stage,row): return base + stage*256 + 4*row
+    def state_byte(base,key,value):
+        segment=value//64; within=value%64
+        return base + 2*(segment*8192 + key*64 + xor128(key,within,2))
+    def tmem_cell(base,row,col): return base+col+(row<<16)
+
+    # Descriptor words are raw integer fields: 14-bit shared address,
+    # lead/stride byte fields, bit 46, and swizzle code in bits 61..63.
+    # No helper returns a first-class layout.
+
+    # 75 physical init instructions span the declaration-ordered protocol.
+    # Stages/arrival owners below are the source's exact values.
+    PROTOCOL=(
+      (q_ready,1,1,TMA),(q_mma_done,1,1,MMA),(q_cg1_done,1,128,CG1),
+      (k_ready,2,1,TMA),(k_mma_done,2,1,MMA),(k_cg0_done,2,128,CG0),
+      (v_ready,1,1,TMA),(v_mma_done,1,1,MMA),
+      (do_ready,1,1,TMA),(do_mma_done,1,1,MMA),
+      (state_ready,1,1,TMA),(state_mma_done,1,1,MMA),
+      (gate_ready,2,32,GATE),(gate_done,2,256,CG0_CG1),
+      (beta_ready,2,32,GATE),(beta_done,2,256,CG0_CG1),
+      (dstate_acc_ready,1,1,MMA),(dstate_scale_done,1,128,CG1),
+      (du_scale_ready,1,1,MMA),(du_scale_done,1,128,CG1),
+      (du_total_ready,1,1,MMA),
+      (dk_scale_ready,1,1,MMA),(dk_scale_done,1,128,CG0),
+      (dk_attn_ready,1,1,MMA),(dk_attn_done,1,128,CG0),
+      (dk_total_ready,1,1,MMA),(dk_total_done,1,128,CG1),
+      (dq_scale_ready,1,1,MMA),(dq_scale_done,1,128,CG0),
+      (dq_total_ready,1,1,MMA),(dq_total_done,1,128,CG1),
+      (kk_acc_ready,1,1,MMA),(kk_acc_done,1,128,CG0),
+      (a_acc_ready,1,1,MMA),(k_state_ready,1,1,MMA),
+      (u_acc_ready,1,1,MMA),(dy_acc_ready,1,1,MMA),
+      (da_acc_ready,1,1,MMA),(dm_acc_ready,1,1,MMA),(dm_acc_done,1,128,CG0),
+      (dk_state_ready,1,1,MMA),
+      (dstate_inp_ready,1,128,CG1),(dstate_inp_done,1,1,MMA),
+      (do_prime_ready,1,128,CG1),(du_inp_ready,1,128,CG1),
+      (dyp_inp_ready,1,128,CG1),(y_ready,1,128,CG1),
+      (tinv_ready,1,128,CG0),(a_ready,1,128,CG0),(a_done,1,1,MMA),
+      (u_ready,1,128,CG1),(dstate_smem_ready,1,128,CG1),
+      (state_dot_done,1,128,CG0),(da_ready,1,128,CG0),
+      (dbeta_cg1_ready,1,128,CG1),(dgate_cg1_ready,1,128,CG1),
+      (dq_stage_ready,1,128,CG1),(dq_stage_done,1,32,EPI),
+      (dk_stage_ready,1,128,CG1),(dk_stage_done,1,32,EPI),
+      (dv_stage_ready,1,128,CG1),(dv_stage_done,1,32,EPI),
+      (sdv_done,1,1,MMA),(tmem_done,1,256,CG0_CG1),
+      (sched_ready,2,1,SCHED_PROD),(sched_done,2,11,SCHED_CONS),
+    )
+    for edge in PROTOCOL:
+        if owner_warp(edge) and elected_lane(): init_all_stages(edge)
+        # instruction_selection: mbarrier.init.shared.b64; extent: 75 words
+    fence_mbarrier_init(); cta_sync()
+    # instruction_selection: fence.mbarrier_init.release.cluster then bar.sync 0
+
+    # Physical offsets are declaration-ordered 16-B-aligned allocations; only
+    # the second element of a two-stage ring occupies base+8.
+    BARRIER_OFFSETS=(
+      (q_ready,(0,)),(q_mma_done,(16,)),(q_cg1_done,(32,)),
+      (k_ready,(48,56)),(k_mma_done,(64,72)),(k_cg0_done,(80,88)),
+      (v_ready,(96,)),(v_mma_done,(112,)),(do_ready,(128,)),
+      (do_mma_done,(144,)),(state_ready,(160,)),(state_mma_done,(176,)),
+      (gate_ready,(192,200)),(gate_done,(208,216)),
+      (beta_ready,(224,232)),(beta_done,(240,248)),
+      (dstate_acc_ready,(256,)),(dstate_scale_done,(272,)),
+      (du_scale_ready,(288,)),(du_scale_done,(304,)),(du_total_ready,(320,)),
+      (dk_scale_ready,(336,)),(dk_scale_done,(352,)),
+      (dk_attn_ready,(368,)),(dk_attn_done,(384,)),
+      (dk_total_ready,(400,)),(dk_total_done,(416,)),
+      (dq_scale_ready,(432,)),(dq_scale_done,(448,)),
+      (dq_total_ready,(464,)),(dq_total_done,(480,)),
+      (kk_acc_ready,(496,)),(kk_acc_done,(512,)),(a_acc_ready,(528,)),
+      (k_state_ready,(544,)),(u_acc_ready,(560,)),(dy_acc_ready,(576,)),
+      (da_acc_ready,(592,)),(dm_acc_ready,(608,)),(dm_acc_done,(624,)),
+      (dk_state_ready,(640,)),(dstate_inp_ready,(656,)),
+      (dstate_inp_done,(672,)),(do_prime_ready,(688,)),
+      (du_inp_ready,(704,)),(dyp_inp_ready,(720,)),(y_ready,(736,)),
+      (tinv_ready,(752,)),(a_ready,(768,)),(a_done,(784,)),
+      (u_ready,(800,)),(dstate_smem_ready,(816,)),(state_dot_done,(832,)),
+      (da_ready,(848,)),(dbeta_cg1_ready,(864,)),(dgate_cg1_ready,(880,)),
+      (dq_stage_ready,(896,)),(dq_stage_done,(912,)),
+      (dk_stage_ready,(928,)),(dk_stage_done,(944,)),
+      (dv_stage_ready,(960,)),(dv_stage_done,(976,)),(sdv_done,(992,)),
+      (tmem_done,(1008,)),(sched_ready,(1024,1032)),
+      (sched_done,(1040,1048)),
+    )
+
+    # One 512-column TMEM allocation, exactly filled.
+    DSTATE_ACC=0       # 128 FP32 columns
+    DVDK_ACC=128       # 64 FP32 columns, five sequential productions
+    DSTATE_INP=192     # 64 packed-IO columns
+    SHARED_ACC0=256    # 64 FP32 columns: KK -> K_state -> dY -> dM
+    SHARED_ACC1=320    # 64 FP32 columns: A -> U -> dA
+    SHARED_INP0=384    # 32 packed-IO columns: dO' then dK-state accumulator alias
+    SHARED_INP1=416    # 32 packed-IO columns: dU then dY'
+    Y=448               # packed Y columns 448..479
+    G_K_STATE=480       # packed g_k_state columns 480..511
+    Y_GK_QT=448         # later Q^T aliases the full 448..511 range
+```
+
+Every cursor below advances immediately after capturing its current slot. A
+one-stage cursor therefore flips parity on every use; a two-stage cursor flips
+parity after two uses. This table is the complete source declaration set.
+
+| role | cursors `(initial phase; stages)` | advancement point |
+| --- | --- | --- |
+| warp 11 | `dq,dk,dv=(0;1)`, `sched=(0;2)` | after each current-chunk ready wait; scheduler after each work item |
+| warp 10 | `gate_load,beta_load=(1;2)`, `gate_store,beta_store=(0;2)`, `sched=(0;2)` | load cursors after reserving first/next prefetch slot; store cursors after current done wait; scheduler after item |
+| warp 9 | `q=(1;1)`, `k=(1;2)`, `v=(1;1)`, `do=(1;1)`, `state=(1;1)`, `sched=(1;2)` | after its exact split-done/reuse wait and before the corresponding issue; scheduler is published after all item loads |
+| warp 8 | `kk=(0;1)`, `dk_total=(1;1)`, `du_scale,dk_scale,dk_attn=(0;1)`, `dstate_acc=(0 if dstate input else 1;1)`, `k=(0;2)`, `q,state,v,tinv,do,y,u,da,dv,dm,dstate_smem,dq_scale=(0;1)`, `dq_total=(1;1)`, `a,do_prime,du,dyp,dstate_inp=(0;1)`, `sched=(0;2)` | immediately after each wait/selected slot in the 17-operation issuer sequence; scheduler after item |
+| CG0 | `gate,beta=(0;2)`, `a,tinv=(1;1)`, `k=(0;2)`, `da,dm,cg0_dbeta,dgate,kk,a_ready,dk_scale,dq_scale,dstate_smem,dk_attn=(0;1)`, `sched=(0;2)` | immediately after each matching full/ready wait; `a` also advances at the source reuse wait; scheduler after item |
+| CG1 | `gate,beta=(0;2)`, `v,do,k_state,u,dy,du_scale,du_total,dk_total,dstate_acc,state_dot,dk_state,dq_total=(0;1)`, `dq,sdv,dstate_inp,dk,dv=(1;1)`, `sched=(0;2)` | immediately after the corresponding full/reuse/store-done wait at its separate staging point; scheduler after item |
+
+### Persistent scheduler
+
+The anchor takes the static early return. The ticket atomic and two-stage dynamic
+ring below are explicit variant semantics without an anchor instruction claim.
+
+```python
+def producer_next(tile,cursor):                    # warp 9
+    if not DYNAMIC: return tile+gridDim.x,cursor
+    wait(sched_done[cursor.stage],cursor.phase)
+    if elected_lane():
+        ticket=atomic_add(sched_ctr[0],1)
+        copy_r2s(gridDim.x+ticket,SCHED+4*cursor.stage)
+    warp_sync(); next_tile=copy_s2r(SCHED+4*cursor.stage)
+    if elected_lane(): arrive(sched_ready[cursor.stage])
+    return next_tile,advance(cursor,2)
+
+def consumer_next(tile,cursor):                    # other eleven warps
+    if not DYNAMIC: return tile+gridDim.x,cursor
+    wait(sched_ready[cursor.stage],cursor.phase)
+    next_tile=copy_s2r(SCHED+4*cursor.stage)
+    if elected_lane(): arrive(sched_done[cursor.stage])
+    return next_tile,advance(cursor,2)
+```
+
+### Warp 9: TensorMap loads
+
+```python
+if warp==9:
+    set_register_budget(decrease,64)
+    raw_q=cursor(1,phase=1); raw_k=cursor(2,phase=1)
+    raw_v=cursor(1,phase=1); raw_do=cursor(1,phase=1)
+    state=cursor(1,phase=1); sched=cursor(2,phase=1)
+    while tile<total_tiles:
+        item=decode_eight_i32_fields(work_items[tile])
+        # instruction_selection: two ld.global.v4.b32; extent: one work row
+        if elected_lane():
+            for array in (Q,K,V,DO,CKPT):
+                acquire_tensormap(descriptor(array,item.batch))
+            # instruction_selection: five
+            # fence.proxy.tensormap::generic.acquire.gpu operations
+        for rev in range(item.cend-item.wstart):
+            chunk=item.cend-1-rev
+
+            # K has two consumers and is deliberately loaded before Q.
+            wait(k_mma_done[raw_k.stage],raw_k.phase)
+            wait(k_cg0_done[raw_k.stage],raw_k.phase)
+            k_slot=raw_k.stage; raw_k=advance(raw_k,2)
+            if elected_lane(): expect_bytes(k_ready[k_slot],16384)
+            for channel_half in (0,64):
+                copy_g2s(map_tile(K,item,chunk,channel_half),
+                         arena+io_byte(K,k_slot,0,channel_half),k_ready[k_slot])
+            # instruction_selection: two 3-D TMA loads into one 16-KiB stage
+
+            wait(q_mma_done[raw_q.stage],raw_q.phase)
+            wait(q_cg1_done[raw_q.stage],raw_q.phase)
+            q_slot=raw_q.stage; raw_q=advance(raw_q,1)
+            if elected_lane(): expect_bytes(q_ready[q_slot],16384)
+            for channel_half in (0,64):
+                copy_g2s(map_tile(Q,item,chunk,channel_half),
+                         arena+io_byte(Q,q_slot,0,channel_half),q_ready[q_slot])
+
+            wait(v_mma_done[raw_v.stage],raw_v.phase)
+            v_slot=raw_v.stage; raw_v=advance(raw_v,1)
+            if elected_lane(): expect_bytes(v_ready[v_slot],16384)
+            for channel_half in (0,64):
+                copy_g2s(map_tile(V,item,chunk,channel_half),
+                         arena+io_byte(V_U,v_slot,0,channel_half),v_ready[v_slot])
+
+            wait(do_mma_done[raw_do.stage],raw_do.phase)
+            do_slot=raw_do.stage; raw_do=advance(raw_do,1)
+            if elected_lane(): expect_bytes(do_ready[do_slot],16384)
+            for channel_half in (0,64):
+                copy_g2s(map_tile(DO,item,chunk,channel_half),
+                         arena+io_byte(DO,do_slot,0,channel_half),do_ready[do_slot])
+            # instruction_selection for Q/V/dO: six more 3-D TMA sites
+
+            if chunk>=FIRST_STATE_CHUNK:
+                wait(state_mma_done[state.stage],state.phase)
+                state_slot=state.stage; state=advance(state,1)
+                if elected_lane(): expect_bytes(state_ready[state_slot],32768)
+                for value_half in (0,64):
+                    copy_g2s(map_checkpoint(item,chunk,value_half),
+                             arena+state_byte(STATE,0,value_half),state_ready[state_slot])
+                # instruction_selection: two 4-D TMA loads
+
+        # The producer publishes a scheduler ticket only after every load for
+        # this work item has been issued.
+        tile,sched=producer_next(tile,sched)
+
+    # Producer tail, in source order. These waits prevent a persistent CTA
+    # from exiting while a split consumer or MMA still owns a raw stage.
+    for _ in range(1):
+        wait(q_mma_done[raw_q.stage],raw_q.phase)
+        wait(q_cg1_done[raw_q.stage],raw_q.phase); raw_q=advance(raw_q,1)
+    for _ in range(2):
+        wait(k_mma_done[raw_k.stage],raw_k.phase)
+        wait(k_cg0_done[raw_k.stage],raw_k.phase); raw_k=advance(raw_k,2)
+    for _ in range(1):
+        wait(v_mma_done[raw_v.stage],raw_v.phase); raw_v=advance(raw_v,1)
+    for _ in range(1):
+        wait(do_mma_done[raw_do.stage],raw_do.phase); raw_do=advance(raw_do,1)
+```
+
+### Warp 10: first/next gate-beta prefetch and in-place scalar stores
+
+The instruction annotations in this role describe only the reviewed anchor
+(`log_gate=True`, FP32 post-sigmoid beta). The optional formulas after the code
+state specialization semantics but deliberately make no PTX claim.
+
+```python
+def anchor_prefetch_scalar_chunk(chunk,gate_load,beta_load,item):
+    offset=item.batch_start+chunk*64
+    valid=[offset+lane+32*col < item.batch_end for col in (0,1)]
+
+    gslot=gate_load.stage; gate_load=advance(gate_load,2)
+    vals=[copy_g2r(gate[offset+lane+32*col]) if valid[col] else 0.0
+          for col in (0,1)]
+    # instruction_selection: two predicated ld.global.b32 values per lane
+    for col in (0,1): vals[col] *= RCP_LN2
+    for distance in (1,2,4,8,16):
+        for col in (0,1):
+            prior=shuffle_up(vals[col],distance)
+            if lane>=distance: vals[col]+=prior
+    vals[1]+=shuffle_index(vals[0],31)
+    # instruction_selection: ten shfl.sync.up.b32 and one shfl.sync.idx.b32
+    for col in (0,1):
+        token=lane+32*col
+        copy_r2s(vals[col],CUMSUMLOG+f32_ring_byte(0,gslot,token))
+        copy_r2s(exp2(vals[col]),CUMPROD+f32_ring_byte(0,gslot,token))
+    fence_proxy_async_shared(); arrive(gate_ready[gslot],32)
+
+    bslot=beta_load.stage; beta_load=advance(beta_load,2)
+    for col in (0,1):
+        token=lane+32*col
+        cp_async_g2s_4B(beta[offset+token],BETA_S+f32_ring_byte(0,bslot,token),
+                        copy_bytes=4 if valid[col] else 0)
+    cp_async_arrive_noinc(beta_ready[bslot])
+    # instruction_selection: two cp.async.ca.shared.global sites and one
+    # cp.async.mbarrier.arrive.noinc.shared.b64 per producer iteration
+    return gate_load,beta_load
+
+if warp==10:
+    set_register_budget(decrease,64)
+    gate_load=cursor(2,phase=1); beta_load=cursor(2,phase=1)
+    gate_store=cursor(2,phase=0); beta_store=cursor(2,phase=0)
+    sched=cursor(2,phase=0)
+    while tile<total_tiles:
+        item=decode_work(tile); count=item.cend-item.wstart
+        write_end=min(item.batch_start+item.wend*64,item.batch_end)
+
+        # First prefetch is outside the reverse loop.
+        if count>0:
+            gate_load,beta_load=anchor_prefetch_scalar_chunk(
+                item.cend-1,gate_load,beta_load,item)
+
+        for rev in range(count):
+            # Prefetch the next backward chunk before storing the current one.
+            if rev+1<count:
+                gate_load,beta_load=anchor_prefetch_scalar_chunk(
+                    item.cend-2-rev,gate_load,beta_load,item)
+
+            chunk=item.cend-1-rev; offset=item.batch_start+chunk*64
+            gslot=gate_store.stage
+            wait(gate_done[gslot],gate_store.phase)
+            gate_store=advance(gate_store,2)
+            dg=[copy_s2r(CUMSUMLOG+f32_ring_byte(0,gslot,lane+32*col))
+                for col in (0,1)]
+            for distance in (1,2,4,8,16):
+                for col in (0,1):
+                    later=shuffle_down(dg[col],distance)
+                    if lane<32-distance: dg[col]+=later
+            dg[0]+=shuffle_index(dg[1],0)
+            # instruction_selection: ten shfl.sync.down.b32 and one
+            # shfl.sync.idx.b32; this is the only reverse suffix scan
+            for col in (0,1):
+                token=lane+32*col
+                if offset+token<write_end: copy_r2g(dg[col],dgate[offset+token])
+
+            bslot=beta_store.stage
+            wait(beta_done[bslot],beta_store.phase)
+            beta_store=advance(beta_store,2)
+            for col in (0,1):
+                token=lane+32*col
+                if offset+token<write_end:
+                    copy_s2r_then_g(BETA_S+f32_ring_byte(0,bslot,token),
+                                    dbeta[offset+token])
+            # instruction_selection: shared b32 loads plus predicated
+            # st.global.b32 for both final scalar arrays
+        tile,sched=consumer_next(tile,sched)
+```
+
+Optional gate specializations replace only the anchor's initial transform:
+safe gate uses
+`a_l2=-exp2(a_log*RCP_LN2)*RCP_LN2` and
+`g_log2=a_l2*softplus(gate+dt_bias)`, where softplus is the source's stable
+piecewise `max(x,0)+log1p(exp(-abs(x)))`; raw gate uses
+`log2(gate+1e-10)`. Optional beta-sigmoid loads IO logits, evaluates the tanh
+sigmoid identity, rounds through the IO dtype, and stores FP32 in `BETA_S`;
+the final `dbeta` store casts back to IO. These branches require their own
+line-info export before instruction-level annotations are added.
+
+### Warp 8: TMEM lifetime and source-order GEMM schedule
+
+```python
+if warp==8:
+    set_register_budget(decrease,64)
+    alloc_tmem(TMEM_MAILBOX,512); named_barrier(1,288); tmem=copy_s2r(TMEM_MAILBOX)
+    # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32,
+    # bar.sync 1,288, then ld.shared.b32
+    while tile<total_tiles:
+      item=decode_work(tile)
+      for rev in range(item.cend-item.wstart):
+        chunk=item.cend-1-rev; has_dstate=USE_DSTATE_IN or rev>0
+
+        wait(k_ready); gemm(SHARED_ACC0,K,K.T,accumulate=False); commit(kk_acc_ready)
+        # instruction_selection: tcgen05.mma.cta_group::1.kind::f16;
+        # extent: 8 K=16 issues for [64,64,128], then one delayed tcgen05.commit
+        wait(q_ready); gemm(SHARED_ACC1,Q,K.T,False); commit(a_acc_ready)
+        # instruction_selection: same family/extent, then one delayed commit
+
+        if chunk>=FIRST_STATE_CHUNK:
+            wait(state_ready); wait(kk_acc_done)
+            gemm(SHARED_ACC0,STATE.T,K.T,False); commit(k_state_ready)
+            # instruction_selection: eight tcgen05.mma f16 issues and one commit;
+            # checkpoint ownership intentionally continues through dK-state
+
+        if has_dstate:
+            wait(dstate_inp_ready); wait(dk_total_done)
+            gemm(DVDK_ACC,DSTATE_INP,K.T,False)
+            commit(du_scale_ready); commit(dstate_inp_done)
+            # instruction_selection: eight tcgen05.mma f16 issues and two commits
+        else: wait(dk_total_done)
+
+        wait(do_ready)
+        if chunk>=FIRST_STATE_CHUNK:
+            wait(dq_total_done); gemm(DSTATE_INP,STATE,dO.T,False); commit(dq_scale_ready)
+            # instruction_selection: eight tcgen05.mma f16 issues plus one commit
+
+        wait(a_ready); if has_dstate: wait(du_scale_done)
+        gemm(DVDK_ACC,dO.T,A,accumulate=has_dstate); commit(du_total_ready)
+        # instruction_selection: four tcgen05.mma f16 issues for K=64 plus commit
+
+        wait(do_prime_ready); wait(dstate_scale_done)
+        gemm(DSTATE_ACC,dO_prime.T,Q,accumulate=has_dstate)
+        # instruction_selection: four tcgen05.mma f16 issues; publication delayed
+
+        wait(tinv_ready); wait(y_ready)
+        gemm(SHARED_ACC1,Y.T,TINV.T,False); commit(u_acc_ready)
+        # instruction_selection: four tcgen05.mma f16 issues plus commit
+
+        wait(du_inp_ready)
+        gemm(SHARED_ACC0,dU.T,TINV,False); commit(dy_acc_ready)
+        # instruction_selection: four tcgen05.mma f16 issues plus commit
+
+        wait(u_ready)
+        if has_dstate:
+            wait(dstate_smem_ready); gemm(DVDK_ACC,DSTATE,U.T,False); commit(dk_scale_ready)
+            # instruction_selection: eight tcgen05.mma f16 issues plus commit
+
+        gemm(SHARED_ACC1,dO,U.T,False); commit(da_acc_ready); commit(do_mma_done)
+        # instruction_selection: eight tcgen05.mma f16 issues plus two commits
+        wait(dv_stage_ready)
+        gemm(SHARED_ACC0,dY,U.T,False); commit(dm_acc_ready); commit(v_mma_done)
+        # instruction_selection: eight tcgen05.mma f16 issues plus two commits
+
+        wait(dyp_inp_ready)
+        gemm(DSTATE_ACC,dY_prime.T,K,True); commit(dstate_acc_ready)
+        # instruction_selection: four tcgen05.mma f16 issues plus commit
+
+        if has_dstate: wait(dk_scale_done)
+        wait(da_ready); gemm(DVDK_ACC,Q.T,dA,accumulate=has_dstate)
+        commit(dk_attn_ready); commit(q_mma_done)
+        # instruction_selection: four tcgen05.mma f16 issues plus two commits
+
+        if chunk>=FIRST_STATE_CHUNK: wait(dq_scale_done)
+        else: wait(dq_total_done)
+        gemm(DSTATE_INP,K.T,dA.T,accumulate=(chunk>=FIRST_STATE_CHUNK))
+        commit(dq_total_ready); commit(a_done)
+        # instruction_selection: four tcgen05.mma f16 issues; separate static
+        # accumulate true/false sites, then two commits
+
+        if chunk>=FIRST_STATE_CHUNK:
+            gemm(SHARED_INP0,STATE,dY.T,False); commit(dk_state_ready); commit(state_mma_done)
+            # instruction_selection: eight tcgen05.mma f16 issues plus commits
+        commit(sdv_done)
+
+        wait(dm_acc_done); wait(dk_attn_done)
+        gemm(DVDK_ACC,K.T,dM.T,True); gemm(DVDK_ACC,K.T,dM,True)
+        commit(dk_total_ready); commit(k_mma_done)
+        # instruction_selection: two four-issue tcgen05.mma chains and two commits
+      tile=consumer_next(tile)
+    wait(dk_total_done); wait(tmem_done)
+    relinquish_tmem_alloc_permit(); dealloc_tmem(512)
+    # instruction_selection: tcgen05.relinquish_alloc_permit then
+    # tcgen05.dealloc.cta_group::1.sync.aligned.b32
+```
+
+The anchor PTX contains 112 static `tcgen05.mma.cta_group::1.kind::f16`
+instructions and 24 delayed `tcgen05.commit...mbarrier::arrive::one` sites.
+Those totals include the accumulate-true/false twins but no hidden computation.
+
+### Warps 0..3: CG0 inverse, dot terms, and final scalar fold
+
+```python
+if warp<4:
+    set_register_budget(increase,192); named_barrier(1,288)
+    DSTATE_IN0=1 if USE_DSTATE_IN else 0
+    # This zero fill is once per CTA, before the persistent work loop.
+    for word in thread_strided_range(TINV,8192,128): copy_r2s(0,word)
+    # instruction_selection: lane-strided st.shared.b32 zero fill
+
+    while tile<total_tiles:
+      item=decode_work(tile)
+      for rev in range(item.cend-item.wstart):
+        chunk=item.cend-1-rev; has_dstate=USE_DSTATE_IN or rev>0
+        gate_slot=gate_cursor.stage; wait(gate_ready[gate_slot],gate_cursor.phase)
+        gate_cursor=advance(gate_cursor,2)
+        beta_slot=beta_cursor.stage; wait(beta_ready[beta_slot],beta_cursor.phase)
+        beta_cursor=advance(beta_cursor,2)
+
+        # Explicit lane-owned 64x64 decay fragments.
+        for owned_i_j in 32_values_per_thread:
+            gi=copy_s2r(CUMSUMLOG+f32_ring_byte(0,gate_slot,i))
+            gj=copy_s2r(CUMSUMLOG+f32_ring_byte(0,gate_slot,j))
+            decay[i,j]=exp2(gi-gj) if i>=j else 0
+            strict[i,j]=0 if i==j else decay[i,j]
+        last_gate=copy_s2r(CUMSUMLOG+f32_ring_byte(0,gate_slot,63))
+        for owned_j in 16_column_values:
+            decay_scale[j]=exp2(last_gate-copy_s2r(
+                CUMSUMLOG+f32_ring_byte(0,gate_slot,j)))
+        cumprod_total=copy_s2r(CUMPROD+f32_ring_byte(0,gate_slot,63))
+
+        wait(kk_acc_ready,kk_cursor.phase); kk_cursor=advance(kk_cursor,1)
+        kk=copy_t2r(SHARED_ACC0)
+        for owned_i_j: copy_r2s(cast(kk[i,j]*strict[i,j]*beta[i]),KK[i,j])
+        # Source predicates on the reverse-loop counter, not decoded chunk.
+        # The first K-state wait consumes the initial phase; each qualifying
+        # CG0 epilogue arrival primes the following one-stage reuse phase.
+        if rev < item.cend-FIRST_STATE_CHUNK: arrive(kk_acc_done,128)
+
+        a_slot=a_cursor.stage; a_phase=a_cursor.phase; a_cursor=advance(a_cursor,1)
+        wait(a_acc_ready,a_ready_cursor.phase); a_ready_cursor=advance(a_ready_cursor,1)
+        avec=copy_t2r(SHARED_ACC1)
+        for owned_i_j: a_pack[i,j]=cast(avec[i,j]*decay[i,j]*scale)
+        wait(a_done[a_slot],a_phase)             # mandatory A overwrite guard
+        for owned_i_j: copy_r2s(a_pack[i,j],A_DA[i,j])
+        fence_proxy_async_shared(); arrive(a_ready[a_slot],128)
+
+        # Exact synchronous hierarchical inverse. There are no async-proxy
+        # fences between stages: group barriers make each SMEM stage visible.
+        named_barrier(2,128)                     # pre-inverse
+        if cg0_warp<2: invert_eight_diagonal_8x8_blocks(KK,TINV)
+        named_barrier(2,128)                     # after width 8
+        invert_8x8_to_16x16_with_two_static_m16n8k8(TINV,KK)
+        named_barrier(2,128)                     # after width 16
+        if cg0_warp<2: invert_16x16_to_32x32_with_m16n8k16(TINV,KK)
+        named_barrier(2,128)                     # after width 32
+        if cg0_warp<2:
+            load_two_32x32_halves()
+            named_barrier(3,64)                  # inner 32->64 helper barrier
+            invert_32x32_to_64x64_with_m16n8k16(TINV,KK)
+        named_barrier(2,128)                     # after width 64
+        # instruction_selection: two static
+        # mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32 sites at 8->16;
+        # twenty m16n8k16 sites across later inverse work
+        for owned_i_j:
+            copy_r2s(cast(copy_s2r(TINV[i,j])*beta[j]),TINV[i,j])
+        fence_proxy_async_shared(); arrive(tinv_ready,128)
+
+        if chunk>=FIRST_STATE_CHUNK:
+            wait(dq_scale_ready,dq_scale_cursor.phase)
+            dq_scale_cursor=advance(dq_scale_cursor,1)
+            for fragment in dq_inter_fragments:
+                copy_r2t(copy_t2r(fragment)*cumprod[token]*scale,fragment)
+            tmem_store_wait(); arrive(dq_scale_done,128)
+
+        # Explicit state-dot-dstate loop, including the overwrite-protection
+        # publication consumed by CG1 before it restages sDstate.
+        if has_dstate:
+            wait(dstate_smem_ready,dstate_smem_cursor.phase)
+            dstate_smem_cursor=advance(dstate_smem_cursor,1)
+        state_dot_dstate=0
+        for octet in range(16):
+            for packed_word in range(4):
+                state_dot_dstate=fma(unpack(DSTATE[octet,packed_word]),
+                                     unpack(STATE[octet,packed_word]),
+                                     state_dot_dstate)
+        for distance in (1,2,4,8,16):
+            state_dot_dstate+=shuffle_bfly(state_dot_dstate,distance)
+        arrive(state_dot_done,128)
+
+        # Explicit K-dot-dK-inter loop is fused with dK inter scaling.
+        k_slot=k_cursor.stage; k_cursor=advance(k_cursor,2)
+        k_dot_dk_inter=0
+        if has_dstate:
+            wait(dk_scale_ready,dk_scale_cursor.phase)
+            dk_scale_cursor=advance(dk_scale_cursor,1)
+            for fragment in dk_inter_fragments:
+                scaled=copy_t2r(fragment)*decay_scale[token]
+                copy_r2t(scaled,fragment)
+                for packed_k in corresponding_K_fragment(k_slot):
+                    k_dot_dk_inter=fma(scaled,unpack(packed_k),k_dot_dk_inter)
+            tmem_store_wait(); arrive(dk_scale_done,128)
+            for distance in (1,2,4,8,16):
+                k_dot_dk_inter+=shuffle_bfly(k_dot_dk_inter,distance)
+
+        wait(da_acc_ready,da_cursor.phase); da_cursor=advance(da_cursor,1)
+        for owned_i_j:
+            copy_r2s(cast(copy_t2r(SHARED_ACC1[i,j])*decay[i,j]*scale),A_DA[i,j])
+        fence_proxy_async_shared(); arrive(da_ready,128)
+
+        wait(dm_acc_ready,dm_cursor.phase); dm_cursor=advance(dm_cursor,1)
+        for owned_i_j:
+            dm_value=-copy_t2r(SHARED_ACC0[i,j])*strict[i,j]
+            copy_r2s(cast(dm_value),DM[i,j])
+        fence_proxy_async_shared(); arrive(dm_acc_done,128)
+
+        wait(dk_attn_ready,dk_attn_cursor.phase); dk_attn_cursor=advance(dk_attn_cursor,1)
+        dks=copy_t2r(DVDK_ACC); tmem_load_wait(); arrive(dk_attn_done,128)
+
+        # M-term E=dM_core*M_kk/beta. Row and column reductions remain
+        # separate fixed loops rather than a compound reduction placeholder.
+        row_acc=[0]*8; col_part=[0]*16
+        for pair in range(16):
+            e=unpack(DM[pair])*unpack(KK[pair])*rcp(beta[row(pair)]+1e-10)
+            row_acc[row_bucket(pair)]+=e.lo+e.hi
+            col_part[column_pair(pair)]+=e
+        for distance in (1,2):
+            row_acc[0]+=shuffle_bfly(row_acc[0],distance)
+            row_acc[1]+=shuffle_bfly(row_acc[1],distance)
+
+        # CG1 owns the V partial first; CG0 consumes it in place and adds M.
+        wait(dbeta_cg1_ready,cg0_dbeta_cursor.phase)
+        cg0_dbeta_cursor=advance(cg0_dbeta_cursor,1)
+        for owned_token:
+            db=copy_s2r(BETA_S[beta_slot,token])-row_acc[token]*rcp(beta[token]+1e-10)
+            if BETA_SIGMOID: db*=beta[token]*(1-beta[token])
+            copy_r2s(db,BETA_S[beta_slot,token])
+
+        # K-dot-dKattn is explicit and closes the split raw-K edge exactly once.
+        part_k=[0]*16
+        for sub in (0,1):
+          for matrix_row in range(4):
+            for packed_word in range(4):
+                part_k[fragment_token]+=dks[sub]*unpack(K[k_slot,sub,matrix_row,packed_word])
+        fence_proxy_async_shared(); arrive(k_cg0_done[k_slot],128)
+        dgate_part=col_part-part_k
+        dgate_last=k_dot_dk_inter
+        if (rev+DSTATE_IN0>=1) and (rev < item.cend-FIRST_STATE_CHUNK):
+            dgate_last+=cumprod_total*state_dot_dstate
+        for offset in (4,8,16):
+          for pair in paired_fragment_tokens:
+            send=pair.low if lane_in_high_half(offset) else pair.high
+            pair=pair.keep+shuffle_bfly(send,offset)
+        dgate_partial=(paired_fragment_tokens[0],paired_fragment_tokens[1])
+        if lane==31: dgate_partial.last+=dgate_last
+        copy_r2s(dgate_partial,CG0_DGATE_SCRATCH)
+
+        wait(dgate_cg1_ready,dgate_cursor.phase); dgate_cursor=advance(dgate_cursor,1)
+        for owned_row: CUMSUMLOG[gate_slot,owned_row]-=row_acc[owned_row]
+        named_barrier(2,128)
+        for token in first_64_threads:
+            CUMSUMLOG[gate_slot,token]+=sum(
+                CG0_DGATE_SCRATCH[group,token] for group in range(4))
+
+        # These are CG0's 128 arrivals; together with CG1 they satisfy the
+        # 256-count barriers that warp 10 waits before suffix/store.
+        arrive(gate_done[gate_slot],128); arrive(beta_done[beta_slot],128)
+      tile,sched=consumer_next(tile,sched)
+
+    # A has one stage; drain its final outstanding MMA consumer before exit.
+    for _ in range(1):
+        wait(a_done[a_cursor.stage],a_cursor.phase); a_cursor=advance(a_cursor,1)
+    arrive(tmem_done,128)
+```
+
+### Warps 4..7: CG1 state/value path and separate dV/dQ/dK staging
+
+```python
+if 4<=warp<8:
+    set_register_budget(increase,248); named_barrier(1,288)
+    while tile<total_tiles:
+      item=decode_work(tile); count=item.cend-item.wstart
+
+      if USE_DSTATE_IN and count>0:
+        wait(dstate_inp_done,dstate_inp_cursor.phase)
+        dstate_inp_cursor=advance(dstate_inp_cursor,1)
+        for owned_state_value:
+            seed=copy_g2r(dstate_in[item]) if item.cend==item.num_chunks else 0
+            copy_r2t(seed,DSTATE_ACC); copy_r2t(cast(seed),DSTATE_INP)
+        tmem_store_wait(); arrive(dstate_inp_ready,128)
+        for owned_state_value: copy_t2r_then_s(DSTATE_ACC,DSTATE)
+        fence_proxy_async_shared(); arrive(dstate_smem_ready,128)
+
+      for rev in range(count):
+        chunk=item.cend-1-rev; have_dstate=USE_DSTATE_IN or rev>0
+        gate_slot=gate_cursor.stage; wait(gate_ready[gate_slot],gate_cursor.phase)
+        gate_cursor=advance(gate_cursor,2)
+        beta_slot=beta_cursor.stage; wait(beta_ready[beta_slot],beta_cursor.phase)
+        beta_cursor=advance(beta_cursor,2)
+
+        # There is deliberately no false-path arrival on the first anchor
+        # chunk. Only a real dstate rescale releases this accumulator phase.
+        if have_dstate:
+            for owned_state_value:
+                h=copy_t2r(DSTATE_ACC)*CUMPROD[gate_slot,63]
+                copy_r2t(h,DSTATE_ACC)
+            tmem_store_wait(); arrive(dstate_scale_done,128)
+
+        do_slot=do_cursor.stage; wait(do_ready[do_slot],do_cursor.phase)
+        do_cursor=advance(do_cursor,1)
+        for owned_do_value:
+            dop=unpack(DO[do_slot])*CUMPROD[gate_slot,token]*scale
+            copy_r2t(cast(dop),SHARED_INP0)
+        tmem_store_wait(); arrive(do_prime_ready,128)
+
+        if have_dstate:
+            wait(du_scale_ready,du_scale_cursor.phase)
+            du_scale_cursor=advance(du_scale_cursor,1)
+            for fragment in du_inter_fragments:
+                copy_r2t(copy_t2r(fragment)*decay_scale[token],fragment)
+            tmem_store_wait(); arrive(du_scale_done,128)
+
+        # Y formation has three distinct lowering steps: FP32 K-state scaling,
+        # rounding that product to packed IO, then packed BF16 subtraction.
+        v_slot=v_cursor.stage; wait(v_ready[v_slot],v_cursor.phase)
+        v_cursor=advance(v_cursor,1)
+        if chunk>=FIRST_STATE_CHUNK:
+            wait(k_state_ready,k_state_cursor.phase); k_state_cursor=advance(k_state_cursor,1)
+            for packed_pair:
+                scaled_fp32=copy_t2r(SHARED_ACC0)*CUMPROD[gate_slot,token]
+                scaled_bf16x2=pack_bf16x2_rn(scaled_fp32)
+                y_bf16x2=sub_bf16x2(copy_s2r(V_U[v_slot,packed_pair]),scaled_bf16x2)
+                copy_r2t(y_bf16x2,Y)
+                copy_r2t(scaled_bf16x2,G_K_STATE)
+        else:
+            for packed_pair: copy_s2r_then_t(V_U[v_slot,packed_pair],Y)
+        tmem_store_wait(); arrive(y_ready,128)
+        # instruction_selection in anchor: FP32 mul, cvt.rn.bf16x2.f32,
+        # sub.bf16x2, then two distinct tcgen05.st.sync.aligned.16x128b
+        # sites: 32 packed-IO columns at Y=448..479 and 32 at
+        # G_K_STATE=480..511
+
+        wait(du_total_ready,du_total_cursor.phase); du_total_cursor=advance(du_total_cursor,1)
+        for fragment: copy_r2t(cast(copy_t2r(DVDK_ACC)),SHARED_INP1)
+        tmem_store_wait(); arrive(du_inp_ready,128)
+
+        wait(u_acc_ready,u_cursor.phase); u_cursor=advance(u_cursor,1)
+        for fragment: copy_t2r_then_s_cast(SHARED_ACC1,V_U)
+        fence_proxy_async_shared(); arrive(u_ready,128)
+
+        wait(dy_acc_ready,dy_cursor.phase); dy_cursor=advance(dy_cursor,1)
+        dy=copy_t2r(SHARED_ACC0)
+        for fragment: copy_r2t(cast(-CUMPROD[gate_slot,token]*dy),SHARED_INP1)
+        tmem_store_wait(); arrive(dyp_inp_ready,128)
+
+        # dV is published first and exactly once.
+        dv_slot=dv_cursor.stage; wait(dv_stage_done[dv_slot],dv_cursor.phase)
+        dv_cursor=advance(dv_cursor,1)
+        wait(sdv_done,sdv_cursor.phase); sdv_cursor=advance(sdv_cursor,1)
+        for fragment: copy_r2s(cast(dy),DV_DY[dv_slot])
+        fence_proxy_async_shared(); arrive(dv_stage_ready[dv_slot],128)
+
+        # Reserve dQ now, but publish only after the final dQ TMEM read below.
+        dq_slot=dq_cursor.stage; wait(dq_stage_done[dq_slot],dq_cursor.phase)
+        dq_cursor=advance(dq_cursor,1)
+
+        # CG1 V partials: fixed per-channel products, the explicit 4-warp
+        # reduction, then in-place writes to the real scalar rings.
+        part_y=[0]*16; part_g=[0]*16
+        for sub in (0,1):
+          yvec=copy_t2r(Y[sub])
+          for channel_pair in range(16):
+            part_y[fragment_token]+=dy[sub,channel_pair]*unpack(yvec[channel_pair])
+            if chunk>=FIRST_STATE_CHUNK:
+                part_g[fragment_token]+=dy[sub,channel_pair]*unpack(copy_t2r(G_K_STATE[sub,channel_pair]))
+        for offset in (4,8,16):
+          for pair in paired_fragment_tokens:
+            send=pair.low if lane_in_high_half(offset) else pair.high
+            pair=pair.keep+shuffle_bfly(send,offset)
+        copy_r2s(part_y_and_part_g,CG1_V_SCRATCH)
+        named_barrier(CG1_ID,128)
+        for token in first_64_threads:
+            ysum=sum(CG1_V_SCRATCH[group,token] for group in range(4))
+            gsum=sum(CG1_V_SCRATCH[group,token+256] for group in range(4))
+            BETA_S[beta_slot,token]=ysum*rcp(BETA_S[beta_slot,token]+1e-10)
+            CUMSUMLOG[gate_slot,token]=-gsum if chunk>=FIRST_STATE_CHUNK else 0
+        arrive(beta_done[beta_slot],128); arrive(dbeta_cg1_ready,128)
+        named_barrier(CG1_ID,128)
+
+        # Q is copied to the Y/Q alias for the explicit dQ dot and its split
+        # raw-buffer release occurs only after that copy.
+        for fragment: copy_s2r_then_t(Q,Y_GK_QT)
+        tmem_store_wait(); arrive(q_cg1_done,128)
+        wait(dq_total_ready,dq_total_cursor.phase); dq_total_cursor=advance(dq_total_cursor,1)
+        dq=copy_t2r(DSTATE_INP)
+        for fragment: copy_r2s(cast(dq),DQ[dq_slot])
+        fence_proxy_async_shared(); arrive(dq_total_done,128)
+        arrive(dq_stage_ready[dq_slot],128)          # dQ published second
+
+        part_q=[0]*16
+        for sub in (0,1):
+          for matrix_row in range(4):
+            for packed_word in range(4):
+                part_q[fragment_token]+=dq[sub]*unpack(Q_fragment[sub,matrix_row,packed_word])
+        for offset in (4,8,16):
+          for pair in paired_fragment_tokens:
+            send=pair.low if lane_in_high_half(offset) else pair.high
+            pair=pair.keep+shuffle_bfly(send,offset)
+        copy_r2s(part_q,CG1_QDOT_SCRATCH); named_barrier(CG1_ID,128)
+        for token in first_64_threads:
+            CUMSUMLOG[gate_slot,token]+=sum(
+                CG1_QDOT_SCRATCH[group,token] for group in range(4))
+        arrive(gate_done[gate_slot],128); arrive(dgate_cg1_ready,128)
+
+        if chunk>=item.wstart+1:
+            wait(dstate_acc_ready,dstate_acc_cursor.phase)
+            dstate_acc_cursor=advance(dstate_acc_cursor,1)
+            wait(dstate_inp_done,dstate_inp_cursor.phase)
+            dstate_inp_cursor=advance(dstate_inp_cursor,1)
+            for owned_state_value:
+                h=copy_t2r(DSTATE_ACC); copy_r2t(cast(h),DSTATE_INP)
+            tmem_store_wait(); arrive(dstate_inp_ready,128)
+
+        # dK is reserved/folded last. The state path is multiplied by the
+        # per-token negative cumprod before it is added to the accumulated dK.
+        dk_slot=dk_cursor.stage; wait(dk_stage_done[dk_slot],dk_cursor.phase)
+        dk_cursor=advance(dk_cursor,1)
+        if chunk>=FIRST_STATE_CHUNK:
+            wait(dk_state_ready,dk_state_cursor.phase); dk_state_cursor=advance(dk_state_cursor,1)
+            state_raw=copy_t2r(SHARED_INP0)
+            tmem_load_wait()                    # state-path load completion
+            state_part=state_raw*(-CUMPROD[gate_slot,token])
+        else: state_part=0
+        wait(dk_total_ready,dk_total_cursor.phase); dk_total_cursor=advance(dk_total_cursor,1)
+        total_dk=copy_t2r(DVDK_ACC)
+        tmem_load_wait()                        # distinct total-dK completion
+        arrive(dk_total_done,128); dk=total_dk+state_part
+        for fragment: copy_r2s(cast(dk),DK[dk_slot])
+        fence_proxy_async_shared(); arrive(dk_stage_ready[dk_slot],128) # third
+
+        # Before overwriting the shared dstate image, wait for CG0's explicit
+        # state-dot-dstate loop. The false first-chunk path advances parity only.
+        if chunk>=item.wstart+1:
+            wait(state_dot_done,state_dot_cursor.phase); state_dot_cursor=advance(state_dot_cursor,1)
+            for owned_state_value: copy_t2r_then_s_cast(DSTATE_ACC,DSTATE)
+            fence_proxy_async_shared(); arrive(dstate_smem_ready,128)
+        else: state_dot_cursor=advance(state_dot_cursor,1)
+
+      # Final dstate drain. In the no-dstate-input specialization this is the
+      # single tail arrival that balances the accumulator reuse protocol.
+      if count>0:
+        wait(dstate_acc_ready,dstate_acc_cursor.phase); dstate_acc_cursor=advance(dstate_acc_cursor,1)
+        if USE_DSTATE0 and item.wstart==0: copy_t2r_then_g(DSTATE_ACC,dstate0_out)
+        if not USE_DSTATE_IN: arrive(dstate_scale_done,128)
+      elif USE_DSTATE0 and item.wstart==0:
+        copy_g2g(dstate_in,dstate0_out) if USE_DSTATE_IN else fill_gmem(dstate0_out,0)
+      tile,sched=consumer_next(tile,sched)
+
+    arrive(tmem_done,128)
+    for _ in range(1):
+        wait(dstate_inp_done,dstate_inp_cursor.phase); dstate_inp_cursor=advance(dstate_inp_cursor,1)
+    for _ in range(1):
+        wait(dk_stage_done[dk_cursor.stage],dk_cursor.phase); dk_cursor=advance(dk_cursor,1)
+    for _ in range(1):
+        wait(dv_stage_done[dv_cursor.stage],dv_cursor.phase); dv_cursor=advance(dv_cursor,1)
+```
+
+### Warp 11: direct current-chunk dV -> dQ -> dK TensorMap stores
+
+```python
+if warp==11:
+    set_register_budget(decrease,64)
+    dq=cursor(1,phase=0); dk=cursor(1,phase=0); dv=cursor(1,phase=0)
+    sched=cursor(2,phase=0)
+    while tile<total_tiles:
+      item=decode_work(tile)
+      if elected_lane():
+        for array in (DV,DQ,DK): acquire_tensormap(descriptor(array,item.batch))
+      for rev in range(item.cend-item.wstart):
+        chunk=item.cend-1-rev; writes=chunk<item.wend
+
+        dv_slot=dv.stage; wait(dv_stage_ready[dv_slot],dv.phase); dv=advance(dv,1)
+        if writes:
+            copy_s2g(DV_DY[dv_slot],map_tile(DV,item,chunk)); commit_store_group()
+
+        dq_slot=dq.stage; wait(dq_stage_ready[dq_slot],dq.phase); dq=advance(dq,1)
+        if writes:
+            copy_s2g(DQ[dq_slot],map_tile(DQ,item,chunk)); commit_store_group()
+
+        dk_slot=dk.stage; wait(dk_stage_ready[dk_slot],dk.phase); dk=advance(dk,1)
+        if writes:
+            copy_s2g(DK[dk_slot],map_tile(DK,item,chunk)); commit_store_group()
+        # instruction_selection: six static 3-D TMA store sites (two subtiles
+        # for each logical dV/dQ/dK tile) and three commit-group sites
+
+        wait_store_group(2); arrive(dv_stage_done[dv_slot],32)
+        wait_store_group(1); arrive(dq_stage_done[dq_slot],32)
+        wait_store_group(0); arrive(dk_stage_done[dk_slot],32)
+        # instruction_selection: cp.async.bulk.wait_group.read 2/1/0 followed
+        # immediately by the corresponding 32-lane reuse arrival
+      tile,sched=consumer_next(tile,sched)
+```
+
+There is no pending item and no post-loop store drain. Tail rows are clipped by
+the patched TensorMap dimensions; warm-up chunks execute all three ready waits
+and phase advances but predicate the stores off. A zero-length item skips the
+chunk loop while preserving persistent scheduler parity.
+
+## Logical GEMM inventory
+
+| phase | destination | operation | shape / instruction extent | guard |
+| --- | --- | --- | --- | --- |
+| KK | shared acc 0 | `K @ K^T` | `64x64x128`, 8 tcgen05 issues | always |
+| QK | shared acc 1 | `Q @ K^T` | `64x64x128`, 8 | always |
+| K-state | shared acc 0 | `state^T @ K^T` | `128x64x128`, 8 | entering state |
+| dV inter | dV/dK acc | `dstate^T @ K^T` | `128x64x128`, 8 | has dstate |
+| dQ inter | dQ acc | `state @ dO^T` | `128x64x128`, 8 | entering state |
+| dU intra | dV/dK acc | `dO^T @ A` | `128x64x64`, 4 | always, accumulates inter |
+| dstate Q | dstate acc | `dO'^T @ Q` | `128x128x64`, 4 | always; acc flag by dstate |
+| U | shared acc 1 | `Y^T @ T_inv^T` | `128x64x64`, 4 | always |
+| dY | shared acc 0 | `dU^T @ T_inv` | `128x64x64`, 4 | always |
+| dK inter | dV/dK acc | `dstate_entry @ U^T` | `128x64x128`, 8 | has dstate |
+| dA | shared acc 1 | `dO @ U^T` | `64x64x128`, 8 | always |
+| dM | shared acc 0 | `dY @ U^T` | `64x64x128`, 8 | always |
+| dstate dY | dstate acc | `dY'^T @ K` | `128x128x64`, 4 | always |
+| dK attention | dV/dK acc | `Q^T @ dA` | `128x64x64`, 4 | always |
+| dQ attention | dQ acc | `K^T @ dA^T` | `128x64x64`, 4 | true/false accumulate twin |
+| dK state | shared input alias | `state @ dY^T` | `128x64x128`, 8 | entering state |
+| dK dM pair | dV/dK acc | `K^T@dM^T + K^T@dM` | two `128x64x64`, 4+4 | always |
+
+Every row selects `tcgen05.mma.cta_group::1.kind::f16`; a K extent 128 expands
+to eight issues and K extent 64 to four.  Publications are delayed to the edge
+shown in the role program rather than committed per issue.  The inverse emits two static `mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32`
+sites in the 8-to-16 stage and 20 static
+`mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32` sites in later stages.
+
+## Storage aliases and lifetimes
+
+| alias | physical region | safety edge |
+| --- | --- | --- |
+| CG0 dGate fold scratch / sKK | `109568..110591` (256 f32) | written after dK/K-dot reduction, consumed after `dgate_cg1_ready` and group-2 rendezvous before the next KK payload reuse |
+| CG1 V-term scratch / current sDQ | `183296..185343` (512 f32) | `dq_stage_done` reserves the current dQ stage before V partials; reduction completes before final dQ overwrites and publishes that stage |
+| CG1 Q-dot scratch / sDstate | `150528..151551` (256 f32) | Q-dot reduction completes before `state_dot_done` is waited and the next dstate image overwrites sDstate |
+| A then dA | `117760..125951` | dU consumes A before warp 8 publishes `a_done`; dA is written only after `da_acc_ready` and consumed before next A generation |
+| V then U | `134144..150527` | CG1 reads V into Y, then publishes/reuses the same bytes for U; `v_mma_done` and `u_ready` close both consumers |
+| dV output / dY operand | `216064..232447` | CG1 stages dY as dV; warp 8 reads it for dM/state-path before `sdv_done`, and warp 11 drains the same bytes as dV |
+| shared acc 0 | TMEM `256..319` | ordered `KK -> K_state -> dY -> dM`; each publication is paired with the prior consumer/reuse wait |
+| shared acc 1 | TMEM `320..383` | ordered `A -> U -> dA` under `a_acc_ready/u_acc_ready/da_acc_ready` |
+| shared input 0 | TMEM `384..415` | dO' is consumed by dstate-Q before the dK-state accumulator overwrites it |
+| shared input 1 | TMEM `416..447` | dU is consumed by dY before dY' overwrites it for the dstate update |
+| Y/g_k/QT | TMEM `448..511` | Y is consumed by U, gate-state intermediates finish, then Q transpose is staged for dQ dot |
+
+## Static specialization boundary
+
+| axis | accepted values | emitted-code consequence |
+| --- | --- | --- |
+| I/O dtype | BF16, FP16 | selects operand conversion and tcgen05 f16 dtype encoding; accumulation remains FP32 |
+| `(HQ,HK,HV)` | each divides `HO=max(HQ,HV)` | compile-time head ratios choose TMA coordinates; direct outputs always have HO heads |
+| gate mode | raw alpha, natural log, safe | selects `log2`, multiply by `LOG2_E`, or exp2/tanh safe transform |
+| beta mode | FP32 post-sigmoid, IO logits | logits add tanh sigmoid and the beta chain rule after dGate consumption |
+| state | initial checkpoint, final gradient, initial-gradient output independently represented by validated profiles | changes chunk-0 state path, dstate seed/drain, and zero-length pass-through |
+| scheduler | static, dynamic | dynamic emits the sole global atomic and the two-stage 11-consumer ring |
+| ordering | none, caller scratch, generated | changes only the 1024-thread prologue order body |
+| `cu_seqlens` | i32, i64 | selects endpoint load width and address arithmetic; work items remain i32 |
+| tails/splits | arbitrary nonnegative lengths and `[wstart,wend,cend)` | TensorMap clipping and scalar predicates; warm-up chunks compute but do not write |
+
+## TIRx and validation contract
+
+- Registry name `cudnn_sm100_gdn_bprop_f16`, category `cudnn`, compute
+  capability 10.  `get_kernel` returns prologue then main; both launches and
+  only those launches are timed on each side.
+- Checkpoint construction, work-table creation, allocation, compilation,
+  source import/JIT, and validation stay outside timing.
+- Correctness compares the same input tensors against the pinned source with
+  `torch.assert_close` at BF16 `(rtol=2^-7, atol=2^-10)`, FP16
+  `(2^-10,2^-14)`, and FP32 `(2^-16,2^-20)`, plus exact shape/dtype, NaN/Inf
+  classification, zero-length behavior, and redzones.  An independent FP64
+  recurrence oracle uses the source test suite's RMS caps as a second check.
+- The benchmark suite is the only performance authority.  The complete frozen
+  21-row matrix must report `mean(cudnn_frontend_us)/mean(tirx_us)>0.99` on
+  every row.  PTX/SASS/NCU/codegen evidence is diagnostic only.
+- The representation gate requires a single rank-1 SMEM allocation, no
+  low-level function calls or exemptions, and no changes under
+  `tirx_kernels/kern/`.
+
+## Instruction-selection evidence
+
+| family | anchor static count | consequence |
+| --- | ---: | --- |
+| `mbarrier.init.shared.b64` | 75 | exact physical protocol words |
+| `mbarrier.try_wait.parity...` | 86 | all producer/reuse and consumer/full waits remain explicit |
+| `mbarrier.arrive.shared.b64` | 42 | thread/warp publications and releases |
+| `mbarrier.arrive.expect_tx.shared.b64` | 5 | Q/K/V/dO/checkpoint transaction barriers |
+| `tcgen05.mma.cta_group::1.kind::f16` | 112 | complete logical GEMM table including static twins |
+| `tcgen05.commit...mbarrier::arrive::one` | 24 | delayed chain publications |
+| `mma.sync.aligned.m16n8k8...bf16` | 2 | 8-to-16 inverse stage |
+| `mma.sync.aligned.m16n8k16...bf16` | 20 | later hierarchical inverse stages |
+| 3-D TMA loads / 4-D TMA loads | 8 / 2 | Q/K/V/dO and two checkpoint halves |
+| 3-D TMA stores | 6 | two static sites each for dQ/dK/dV ladder |
+| `ldmatrix` / `stmatrix` | 80 / 64 | register-SMEM operand and epilogue movement |
+| `setmaxnreg` | 6 | two compute groups plus four service warps |
+| `bar.sync` | 15 | CTA and named group rendezvous |
+| `fence.proxy.async.shared::cta` | 12 | generic-to-async SMEM publication |
+
+Placement selects TMA versus register/shared traffic; shape selects tcgen05
+issue multiplicity versus register MMA; and the producer/consumer schedule
+selects transaction completion, delayed tcgen05 commits, or plain arrivals.
+Those are lowering facts from the writer export, not inferences from source
+declarations.

--- a/.agents/sketch/flashinfer/activation/act_and_mul.md
+++ b/.agents/sketch/flashinfer/activation/act_and_mul.md
@@ -324,7 +324,7 @@ module bakes the same values per config.
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "act_and_mul", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - The executable kernel is expressed entirely in plain TIRx: explicit
   `while` grid-stride loops, scalar/vector register buffers, explicit
   global loads/stores, and native `T.ptx.*` forms for every non-trivial

--- a/.agents/sketch/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.md
+++ b/.agents/sketch/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.md
@@ -416,7 +416,7 @@ def prepare_data(dtype, n_experts, m, k, mask_mode):
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "silu_and_mul_nvfp4_experts_quantize", "category":
-  "flashinfer", "compute_capability": 10}`.
+  "flashinfer", "runtime_cuda_archs": ["sm_100a"]}`.
 - The executable kernel is expressed entirely in plain TIRx: explicit `while`
   grid-stride loop, runtime-shape scalar ABI, register tiles, and native
   `T.ptx.*` forms for every non-trivial instruction (`ld.global.v4.b64`,

--- a/.agents/sketch/flashinfer/gemm/tinygemm2_sm100.md
+++ b/.agents/sketch/flashinfer/gemm/tinygemm2_sm100.md
@@ -615,7 +615,7 @@ use automatic stage and `USE_PDL=False`.
 ## TIRx module and validation contract
 
 - `KERNEL_META = {"name": "tinygemm2_sm100", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - The executable kernel is expressed entirely in TIRx: warp uniformization uses
   a u32 `T.thread_id` plus one shared i32 view, followed by
   `T.cuda._shfl_sync`; election uses the pred-only lowering of

--- a/.agents/sketch/flashinfer/kda/recurrent_kda_decode_grouped.md
+++ b/.agents/sketch/flashinfer/kda/recurrent_kda_decode_grouped.md
@@ -616,7 +616,7 @@ if (n == 0) & (vz == 0) & (tid < D):
 ## TIRx module and benchmark contract
 
 * Module: `tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py`,
-  `KERNEL_META["name"] = "recurrent_kda_decode_grouped"`, `compute_capability = 10`.
+  `KERNEL_META["name"] = "recurrent_kda_decode_grouped"`, `runtime_cuda_archs = ["sm_100a"]`.
 * Helpers (`_ptx_*`, non-FTZ scalar math, BF16 pack/convert, shuffles, guarded
   stores) are imported from the one-warp sibling module rather than duplicated.
 * Every global **and shared** access must go through raw PTX with `ptr_to`:

--- a/.agents/sketch/flashinfer/quantization/mxfp4_quantize.md
+++ b/.agents/sketch/flashinfer/quantization/mxfp4_quantize.md
@@ -496,7 +496,7 @@ def prepare_data(dtype, m, k, sf_layout, enable_pdl):
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "mxfp4_quantize", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - The executable kernel is expressed entirely in plain TIRx: explicit `while`
   grid-stride loops, runtime scalar ABI, register tiles, and native `T.ptx.*`
   forms for every non-trivial instruction (`ld.global.v4.u32`,

--- a/.agents/sketch/flashinfer/quantization/mxfp8_quantize.md
+++ b/.agents/sketch/flashinfer/quantization/mxfp8_quantize.md
@@ -540,7 +540,7 @@ def prepare_data(dtype, m, k, sf_layout, enable_pdl):
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "mxfp8_quantize", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - The executable kernel is expressed entirely in plain TIRx: explicit `while`
   grid-stride loops, runtime scalar ABI, register tiles, and native `T.ptx.*`
   forms for every non-trivial instruction (`ld.global.v4.u32`,

--- a/.agents/sketch/flashinfer/quantization/nvfp4_quantize.md
+++ b/.agents/sketch/flashinfer/quantization/nvfp4_quantize.md
@@ -466,7 +466,7 @@ def prepare_data(dtype, m, k, sf_layout, fuse_silu):
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "nvfp4_quantize", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - The executable kernel is expressed entirely in plain TIRx: explicit `while`
   grid-stride loops, runtime scalar ABI, register tiles, and native `T.ptx.*`
   forms for every non-trivial instruction (`ld.global.v4.u32`,

--- a/.agents/sketch/flashinfer/quantization/nvfp4_quantize_per_token.md
+++ b/.agents/sketch/flashinfer/quantization/nvfp4_quantize_per_token.md
@@ -327,7 +327,7 @@ def prepare_data(dtype, m, k, sf_layout, zero_row):
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "nvfp4_quantize_per_token", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - The executable kernel is expressed entirely in plain TIRx: explicit `while`
   column-stride loops, runtime scalar ABI, register tiles, one static 16-byte
   smem buffer, `bar.sync` barriers, and native `T.ptx.*` forms for every

--- a/.agents/sketch/flashinfer/topk/fast_topk_clusters.md
+++ b/.agents/sketch/flashinfer/topk/fast_topk_clusters.md
@@ -881,7 +881,7 @@ calls the source's launcher makes (`:557-558`).
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "fast_topk_clusters", "category": "flashinfer",
-  "compute_capability": 10}`; device symbol `fast_topk_clusters_kernel`.
+  "runtime_cuda_archs": ["sm_100a"]}`; device symbol `fast_topk_clusters_kernel`.
 - Plain TIRx only: a dynamic shared allocation carved by explicit views, explicit
   loops, and native `T.ptx.*` forms for every key operation. Global and shared
   memory are reached exclusively through `T.ptx.ld/st.*` on

--- a/.agents/sketch/flashinfer/topk/filtered_topk.md
+++ b/.agents/sketch/flashinfer/topk/filtered_topk.md
@@ -634,7 +634,7 @@ and why SM89/SM120 cannot run this path at all.
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "filtered_topk", "category": "flashinfer",
-  "compute_capability": 10}`; device symbols `filtered_topk` and
+  "runtime_cuda_archs": ["sm_100a"]}`; device symbols `filtered_topk` and
   `filtered_topk_finalize`.
 - Plain TIRx only: a `T.SMEMPool` arena at the source's byte offsets, explicit
   loops, and native `T.ptx.*` forms for every key operation. Global and shared

--- a/.agents/sketch/flashinfer/topk/radix_topk_multi_cta.md
+++ b/.agents/sketch/flashinfer/topk/radix_topk_multi_cta.md
@@ -623,7 +623,7 @@ race past the acquire before thread 0 published the phase bump.
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "radix_topk_multi_cta", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - Plain TIRx only: a `T.SMEMPool` arena at the source's byte offsets, explicit
   `while`/stepped `T.serial` loops, and native `T.ptx.*` forms for every key
   operation. Global and shared memory are reached exclusively through

--- a/.agents/sketch/flashinfer/topk/radix_topk_single_cta.md
+++ b/.agents/sketch/flashinfer/topk/radix_topk_single_cta.md
@@ -810,7 +810,7 @@ def EMIT_RaggedTransform(i, key, pos):   # `offset` was loaded once per row in S
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "radix_topk_single_cta", "category": "flashinfer",
-  "compute_capability": 10}`.
+  "runtime_cuda_archs": ["sm_100a"]}`.
 - The kernel is expressed entirely in plain TIRx: `T.SMEMPool` arena with the
   source's byte offsets, explicit `while` block-strided loops, register
   buffers, and native `T.ptx.*` forms for the key operations

--- a/.agents/sketch/flashinfer/topk/stable_sort_topk_by_value.md
+++ b/.agents/sketch/flashinfer/topk/stable_sort_topk_by_value.md
@@ -352,7 +352,7 @@ finalize kernel already carries. The byte total must match the column above.
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "stable_sort_topk_by_value", "category": "flashinfer",
-  "compute_capability": 10}`; device symbol `stable_sort_topk_by_value`.
+  "runtime_cuda_archs": ["sm_100a"]}`; device symbol `stable_sort_topk_by_value`.
 - Plain TIRx only: a `T.SMEMPool` arena, explicit loops, and native `T.ptx.*`
   forms for every key operation. Global and shared memory are reached exclusively
   through `T.ptx.ld/st.*` on `buffer.ptr_to([...])` — never a native

--- a/.agents/sketch/msa/sparse_atten_fwd_nvfp4_kv.md
+++ b/.agents/sketch/msa/sparse_atten_fwd_nvfp4_kv.md
@@ -1830,7 +1830,7 @@ epilogue decode), `tok_idx < q_tokens_per_group` (the TMA per-warp partition),
 ## TIRx module and benchmark contract
 
 `KERNEL_META["name"] = "msa_sparse_atten_fwd_nvfp4_kv_sm100"`, category `msa`,
-`compute_capability = 10`.
+`runtime_cuda_archs = ["sm_100a"]`.
 
 `prepare_data` builds packed FP4 K/V, random E4M3 scale bytes in a positive
 finite band, the CSR payload, the work list and a frozen qsplit assignment, and

--- a/.agents/sketch/msa/sparse_prepare_flat_schedule.md
+++ b/.agents/sketch/msa/sparse_prepare_flat_schedule.md
@@ -445,7 +445,7 @@ emission tail is one atomic plus six stores per work item.
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "msa_sparse_prepare_flat_schedule_sm100", "category":
-  "msa", "compute_capability": 10}`.
+  "msa", "runtime_cuda_archs": ["sm_100a"]}`.
 - Plain TIRx only: explicit loops, scalar registers via `T.alloc_local`, and
   native `T.ptx.*` forms for every key operation. Global memory is reached
   exclusively through `T.ptx.ld/st.*` on `buffer.ptr_to([...])`, never a native

--- a/.agents/sketch/msa/sparse_prepare_fwd_split_atomic.md
+++ b/.agents/sketch/msa/sparse_prepare_fwd_split_atomic.md
@@ -311,7 +311,7 @@ dominated instead by CTAs that take the first branch and retire.
 ## TIRx module and benchmark contract
 
 - `KERNEL_META = {"name": "msa_sparse_prepare_fwd_split_atomic_sm100", "category":
-  "msa", "compute_capability": 10}`.
+  "msa", "runtime_cuda_archs": ["sm_100a"]}`.
 - Plain TIRx only: a `T.SMEMPool()` arena for `sRow`, explicit loops, scalar
   registers via `T.alloc_local`, and native `T.ptx.*` forms for every key
   operation. Global **and shared** memory are reached exclusively through

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/size-swizzles-and-fragments-physically.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/size-swizzles-and-fragments-physically.md
@@ -45,6 +45,15 @@ traffic. One kernel with zero shared allocation ran at nearly double the
 reference's conflict rate; removing the branch around a guarded store took its
 conflicts to zero against the reference's 612.
 
+In a measured attention-backward compute role, retaining one 64-value dP
+fragment across two publication stages produced a 24-byte stack and dynamic
+local traffic even though the role kept the reference's 136-register temporal
+budget. Restoring the reference's two stage-local 32-value fragments removed
+the stack and every static local load/store without changing the budget. All 18
+correctness configurations passed; the previously worst benchmark ratio moved
+from 0.960x to 1.022x, and the complete 13-row matrix passed at a 1.007x
+minimum.
+
 ## Boundary
 
 Smaller is not automatically better when it adds synchronization or breaks

--- a/.agents/skills/tirx-kernel-integration/SKILL.md
+++ b/.agents/skills/tirx-kernel-integration/SKILL.md
@@ -47,7 +47,22 @@ A discoverable module under `tirx_kernels/<category>/` should normally expose:
 KERNEL_META = {
     "name": "kernel_name",
     "category": "gemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a"],
+    "reference_requirements": (
+        {
+            "package": "upstream-reference",
+            "git": {
+                "url": "https://github.com/example/upstream-reference.git",
+                "commit": "0123456789abcdef0123456789abcdef01234567",
+            },
+            "import": "upstream_reference",
+        },
+        {
+            "package": "nvidia-cutlass-dsl",
+            "specifier": ">=4.8.0.dev0,<4.9",
+            "import": "cutlass",
+        },
+    ),
 }
 
 CONFIGS = [
@@ -80,7 +95,20 @@ def run_bench(
 
 Important:
 
-- `compute_capability=10` means SM100. Do not write `100`.
+- `runtime_cuda_archs` is an exact allowlist, not a minimum or architecture
+  family. List every architecture actually supported; never fall through from
+  `sm_100a` to `sm_103a` or `sm_107a`.
+- Omit `reference_requirements` when correctness uses only in-repo or framework
+  oracles. Do not declare a dependency used only by `run_bench`.
+- In each reference requirement, `package` is the install/distribution name and
+  `import` is the Python import name. At least one of `specifier` or `git` is
+  required. Specifiers use PEP 440 (`==`, `>=`, `<`; never bare `=`), and Git
+  commits are full lowercase SHAs. When both are present, both must match.
+- `reference-dependencies.json` is an installation recipe, not kernel metadata
+  authority. Correctness run/skip decisions come only from `KERNEL_META`.
+- A missing import/distribution, version mismatch, or unverifiable/mismatched Git
+  identity skips correctness before GPU compile/run. Once metadata is satisfied,
+  reference import or runtime failures are test failures, not skips.
 - `KERNEL_META["name"]` must be globally unique and is the CLI kernel name.
 - `category` is discovered from package directories. A new category needs an
   `__init__.py`; registry infrastructure directories are intentionally skipped.
@@ -436,7 +464,9 @@ Both forms regenerate `baseline.md`. Never copy a run JSON over `baseline.json`.
 - For a new source family, are `LICENSE`, `NOTICE` when applicable, `licenses/`,
   `pyproject.toml`, README, and the path-bound license checker synchronized?
 - Do the license checker, its self-test, and the pre-commit license hook pass?
-- Is `compute_capability` encoded as `10` for SM100 rather than `100`?
+- Does `runtime_cuda_archs` enumerate only exact architectures actually supported?
+- Does `reference_requirements` include every correctness-only external dependency,
+  with no benchmark-only dependencies or coarse category-level assumptions?
 - Do optional dependencies remain lazy so import discovery succeeds?
 - Are `CONFIGS` and optional `BENCH_CONFIGS` serving their distinct purposes?
 - Does the bench-suite config reference valid labels and set `default` deliberately?

--- a/LICENSE
+++ b/LICENSE
@@ -214,7 +214,7 @@ tirx_kernels/cudnn/ (ports of NVIDIA/cudnn-frontend kernels; the upstream
                      licenses/LICENSE.cudnn-frontend.txt)
 tirx_kernels/flashinfer/ (ports of flashinfer-ai/flashinfer kernels, including
                           kernels FlashInfer itself derived from NVIDIA
-                          TensorRT-LLM; except the BSD-3 file listed below)
+                          TensorRT-LLM; except the BSD-3 files listed below)
 
 
 MIT License
@@ -236,5 +236,7 @@ tirx_kernels/flashattention/ (ports of Dao-AILab/flash-attention kernels; the
                               licenses/AUTHORS.flash-attention.txt)
 tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py (full license text is
                               reproduced in the file header)
+tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py (full license text is reproduced
+                              in the file header)
 tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py
                              (full license text is reproduced in the file header)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ contract and results.
   [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py),
   [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
-  [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
+  [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),
+  [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
 - **CSA compression:**
   [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
 - **Sparse attention:**
@@ -59,6 +60,7 @@ contract and results.
   [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py),
   [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py),
   [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py),
+  [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py),
   [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
 
 ### FlashAttention ports
@@ -116,7 +118,8 @@ Grouped by the FlashInfer Python entry point each port backs.
   [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py),
   [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
 - **`flashinfer.gemm`:**
-  [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py)
+  [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py),
+  [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py)
 - **`flashinfer.topk`:**
   [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py),
   [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py),
@@ -259,8 +262,11 @@ mod.run_bench(M=1024, N=1024, K=1024) # profile (needs a GPU)
 func = mod.get_kernel(M=1024, N=1024, K=1024)  # the TIRx PrimFunc
 ```
 
-Each module also provides `KERNEL_META` (name / category / `compute_capability`)
-and `CONFIGS` (the test/bench parameter sweeps) that the registry and CLI use.
+Each module also provides `KERNEL_META`: its name, category, exact
+`runtime_cuda_archs`, and optional correctness-only `reference_requirements`.
+The registry and test harness reject unsupported architectures before compile,
+and skip correctness before GPU work when a declared reference package, version,
+or Git source identity is unavailable. `CONFIGS` contains the test parameter sweep.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = "Apache-2.0 AND BSD-3-Clause AND MIT"
 license-files = ["LICENSE", "NOTICE", "licenses/*.txt"]
 # tvm, torch, triton are runtime dependencies managed externally (not on PyPI)
-dependencies = ["pyyaml>=6.0"]
+dependencies = ["packaging>=23.0", "pyyaml>=6.0"]
 
 [tool.pytest.ini_options]
 addopts = "-n 16"

--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -117,6 +117,13 @@ FILE_OVERRIDES = {
             'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"',
         ),
     },
+    "tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py": {
+        "spdx": "Apache-2.0 AND BSD-3-Clause",
+        "required_text": (
+            "Redistribution and use in source and binary forms",
+            'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"',
+        ),
+    },
     # Transcribes cub::BlockRadixSort, which FlashInfer's topk kernels instantiate.
     "tirx_kernels/flashinfer/utils/block_radix_sort.py": {
         "spdx": "Apache-2.0 AND BSD-3-Clause",
@@ -238,6 +245,7 @@ def self_test() -> int:
     bsa_combine = "tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py"
     gdn = "tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py"
     gdn_cp = "tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py"
+    bmm_fp8_rubin = "tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py"
     bsd_port = (
         "# Copyright (c) 2025 Upstream\n"
         "# Redistribution and use in source and binary forms\n"
@@ -306,6 +314,27 @@ def self_test() -> int:
             gdn_cp,
             bsd_port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fi),
             False,
+        ),
+        (
+            "valid bmm_fp8_rubin BSD port",
+            bmm_fp8_rubin,
+            bsd_port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fi),
+            False,
+        ),
+        (
+            "bmm_fp8_rubin tagged plain Apache-2.0",
+            bmm_fp8_rubin,
+            bsd_port.format(spdx="Apache-2.0", **fi),
+            True,
+        ),
+        (
+            "bmm_fp8_rubin missing BSD disclaimer",
+            bmm_fp8_rubin,
+            bsd_port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fi).replace(
+                'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"',
+                "missing disclaimer",
+            ),
+            True,
         ),
         (
             "deepgemm tagged plain Apache-2.0",

--- a/tests/test_bench_suite_ab.py
+++ b/tests/test_bench_suite_ab.py
@@ -95,9 +95,7 @@ def test_paired_report_allows_different_gpus_across_workloads() -> None:
 
 
 def test_paired_report_allows_empty_baselines_when_references_are_disabled() -> None:
-    before = _payload(
-        "before", "before-rev", [_row("kernel", "config", "GPU-a", [10.0, 10.0])]
-    )
+    before = _payload("before", "before-rev", [_row("kernel", "config", "GPU-a", [10.0, 10.0])])
     after = copy.deepcopy(before)
     after["label"] = "after"
     after["git"]["tirx-kernels"] = "after-rev"
@@ -221,9 +219,7 @@ def test_current_contract_uses_after_kern_without_rebinding_before_kern(monkeypa
     kern_root.mkdir(parents=True)
     (kern_root / "__init__.py").write_text("MARKER = 'after'\n")
     (package_root / "ab_kern_isolation.py").write_text(
-        "import tirx_kernels.kern as K\n"
-        "KERN_MARKER = K.MARKER\n"
-        "CONFIGS = [{'label': 'same'}]\n"
+        "import tirx_kernels.kern as K\nKERN_MARKER = K.MARKER\nCONFIGS = [{'label': 'same'}]\n"
     )
 
     before_kern = ModuleType("tirx_kernels.kern")

--- a/tests/test_bench_suite_run.py
+++ b/tests/test_bench_suite_run.py
@@ -3,6 +3,12 @@
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from tirx_kernels.bench_suite import ratio_diff
 from tirx_kernels.bench_suite import run as bench_run
 
 _OUR_CHILD_PID = 4001
@@ -62,3 +68,134 @@ def test_mixed_own_and_foreign_memory_counts_only_foreign(monkeypatch):
         ],
     )
     assert pool._occupied_indices() == {"0"}
+
+
+def test_gpu_compile_profile_supports_sm107(monkeypatch):
+    fake_nvml = SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetHandleByIndex=lambda index: index,
+        nvmlDeviceGetName=lambda _handle: "NVIDIA Graphics Device",
+        nvmlDeviceGetCudaComputeCapability=lambda _handle: (10, 7),
+        nvmlDeviceGetNumGpuCores=lambda _handle: 216 * 128,
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", fake_nvml)
+
+    assert bench_run.gpu_compile_profile({"0", "1"}) == {
+        "name": "NVIDIA Graphics Device",
+        "compute_capability": [10, 7],
+        "cuda_arch": "sm_107a",
+        "num_sms": 216,
+    }
+
+
+def test_gpu_compile_profile_supports_sm103(monkeypatch):
+    fake_nvml = SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetHandleByIndex=lambda index: index,
+        nvmlDeviceGetName=lambda _handle: "NVIDIA GB300",
+        nvmlDeviceGetCudaComputeCapability=lambda _handle: (10, 3),
+        nvmlDeviceGetNumGpuCores=lambda _handle: 152 * 128,
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", fake_nvml)
+
+    assert bench_run.gpu_compile_profile({"0", "1"}) == {
+        "name": "NVIDIA GB300",
+        "compute_capability": [10, 3],
+        "cuda_arch": "sm_103a",
+        "num_sms": 152,
+    }
+
+
+def test_gpu_compile_profile_rejects_mixed_arch_pool(monkeypatch):
+    fake_nvml = SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetHandleByIndex=lambda index: index,
+        nvmlDeviceGetName=lambda handle: f"GPU {handle}",
+        nvmlDeviceGetCudaComputeCapability=lambda handle: (10, 0) if handle == 0 else (10, 7),
+        nvmlDeviceGetNumGpuCores=lambda handle: (148 if handle == 0 else 216) * 128,
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", fake_nvml)
+
+    with pytest.raises(ValueError, match="heterogeneous compile profiles"):
+        bench_run.gpu_compile_profile({"0", "1"})
+
+
+def test_validate_workload_archs_accepts_exact_arch(monkeypatch):
+    records = {"kernel": SimpleNamespace(runtime_cuda_archs=("sm_100a",))}
+    monkeypatch.setattr(bench_run, "kernel_index", lambda strict: records)
+
+    bench_run.validate_workload_archs([{"kernel": "kernel"}], "sm_100a")
+
+
+def test_partition_workloads_by_arch_keeps_only_exact_matches(monkeypatch):
+    records = {
+        "blackwell": SimpleNamespace(runtime_cuda_archs=("sm_100a",)),
+        "rubin": SimpleNamespace(runtime_cuda_archs=("sm_107a",)),
+    }
+    monkeypatch.setattr(bench_run, "kernel_index", lambda strict: records)
+    workloads = [{"kernel": "blackwell"}, {"kernel": "rubin"}]
+
+    supported, incompatible = bench_run.partition_workloads_by_arch(workloads, "sm_107a")
+
+    assert supported == [{"kernel": "rubin"}]
+    assert incompatible == [{"kernel": "blackwell"}]
+
+
+def test_expected_keys_scopes_default_roster_to_arch(monkeypatch):
+    records = {
+        "blackwell": SimpleNamespace(runtime_cuda_archs=("sm_100a",)),
+        "rubin": SimpleNamespace(runtime_cuda_archs=("sm_107a",)),
+    }
+    monkeypatch.setattr(bench_run, "kernel_index", lambda strict: records)
+    monkeypatch.setattr(
+        ratio_diff,
+        "_load_config_dir",
+        lambda: [
+            {"kernel": "blackwell", "config": "blackwell_config"},
+            {"kernel": "rubin", "config": "rubin_config"},
+        ],
+    )
+
+    keys, errors = ratio_diff._expected_keys("sm_107a")
+
+    assert errors == []
+    assert keys == {("rubin", "rubin_config")}
+
+
+def test_default_roster_includes_curated_rubin_bmm():
+    workloads = bench_run.load_config_dir()
+    labels = {workload["config"] for workload in workloads if workload["kernel"] == "bmm_fp8_rubin"}
+
+    assert labels == {
+        "bench_t2_e4m3_bf16_b1_m512_n4096_k2720",
+        "bench_t4_e5m2_fp16_b1_m1024_n4096_k3072",
+        "bench_t7_e4m3_fp32_b2_m4096_n1024_k3072",
+    }
+
+
+def test_default_roster_is_available_on_sm103_and_sm107():
+    workloads = bench_run.load_config_dir()
+
+    sm107, sm107_incompatible = bench_run.partition_workloads_by_arch(workloads, "sm_107a")
+    sm103, sm103_incompatible = bench_run.partition_workloads_by_arch(workloads, "sm_103a")
+    sm100, sm100_incompatible = bench_run.partition_workloads_by_arch(workloads, "sm_100a")
+
+    assert len(sm107) == 260
+    assert sm107_incompatible == []
+    assert len(sm103) == 257
+    assert len(sm103_incompatible) == 3
+    assert {workload["kernel"] for workload in sm103_incompatible} == {"bmm_fp8_rubin"}
+    assert len(sm100) == 257
+    assert len(sm100_incompatible) == 3
+    assert {workload["kernel"] for workload in sm100_incompatible} == {"bmm_fp8_rubin"}
+
+
+def test_validate_workload_archs_rejects_mismatch_before_prepare(monkeypatch):
+    records = {"rubin": SimpleNamespace(runtime_cuda_archs=("sm_107a",))}
+    monkeypatch.setattr(bench_run, "kernel_index", lambda strict: records)
+
+    with pytest.raises(ValueError, match=r"sm_100a.*rubin"):
+        bench_run.validate_workload_archs([{"kernel": "rubin"}], "sm_100a")

--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -10,6 +10,21 @@ import tirx_kernels.kern as K
 from tvm.tirx.stmt_functor import StmtExprVisitor
 
 
+def test_kernel_target_honors_prepared_compile_arch(monkeypatch):
+    @K.kernel(warps=1, arch="sm_100a", grid=False)
+    def probe(out: K.gptr("float32")):
+        K.ptx.st.global_.f32(out.ptr_to([0]), K.float32(1.0))
+
+    monkeypatch.delenv("TIRX_PREPARE_CUDA_ARCH", raising=False)
+    assert probe.target().arch == "sm_100a"
+
+    monkeypatch.setenv("TIRX_PREPARE_CUDA_ARCH", "sm_103a")
+    assert probe.target().arch == "sm_103a"
+
+    monkeypatch.setenv("TIRX_PREPARE_CUDA_ARCH", "sm_107a")
+    assert probe.target().arch == "sm_107a"
+
+
 def _tir(build_body):
     @K.kernel(warps=1, arch="sm_100a", grid=False)
     def probe(out: K.gptr("float32")):

--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
+from typing import ClassVar
+
 import pytest
 
 import tirx_kernels.kern as K
@@ -121,6 +123,47 @@ def test_correctness_runner_does_not_rebuild_an_already_checked_kernel():
             assert params == {"value": 3}
 
     run_kernel_test("probe", {"label": "case", "value": 3}, registry={"probe": KernelModule})
+
+
+def test_correctness_runner_skips_before_calling_kernel_when_reference_is_unmet(monkeypatch):
+    from unittest import SkipTest
+
+    from tirx_kernels import reference_requirements as refs
+
+    class KernelModule:
+        KERNEL_META: ClassVar[dict[str, object]] = {
+            "reference_requirements": (
+                {"package": "missing", "specifier": ">=1", "import": "missing"},
+            )
+        }
+
+        @staticmethod
+        def run_test(**_params):
+            raise AssertionError("kernel ran despite an unmet correctness reference")
+
+    refs.probe_reference_requirement.cache_clear()
+    monkeypatch.setattr(refs.importlib.util, "find_spec", lambda _name: None)
+    with pytest.raises(SkipTest, match="unsatisfied reference requirements"):
+        run_kernel_test("probe", {}, registry={"probe": KernelModule})
+
+
+def test_correctness_runner_does_not_hide_runtime_reference_errors(monkeypatch):
+    from tirx_kernels import reference_requirements as refs
+
+    class KernelModule:
+        KERNEL_META: ClassVar[dict[str, object]] = {
+            "reference_requirements": (
+                {"package": "example", "specifier": ">=1", "import": "example"},
+            )
+        }
+
+        @staticmethod
+        def run_test(**_params):
+            raise ImportError("reference import failed after metadata probe")
+
+    monkeypatch.setattr(refs, "unmet_reference_requirements", lambda _value: ())
+    with pytest.raises(ImportError, match="reference import failed"):
+        run_kernel_test("probe", {}, registry={"probe": KernelModule})
 
 
 def test_kern_smem_descriptor_uniformity_stays_in_low_level_contract():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tirx_kernels import reference_requirements as refs
+from tirx_kernels import registry
+
+
+def _meta(**updates):
+    meta = {"name": "kernel", "category": "basic", "runtime_cuda_archs": ["sm_100a"]}
+    meta.update(updates)
+    return meta
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ((), "must be list"),
+        ([], "must not be empty"),
+        (["sm_100a", 100], "entries must be strings"),
+        (["SM_100a"], "canonical sm_* strings"),
+        (["sm_100x"], "canonical sm_* strings"),
+        (["sm_100a", "sm_100a"], "entries must be unique"),
+    ],
+)
+def test_runtime_cuda_archs_validation(value, message):
+    errors = registry._validate_meta(
+        _meta(runtime_cuda_archs=value), category="basic", owner="test"
+    )
+    assert any(message in error for error in errors)
+
+
+def test_runtime_cuda_archs_are_required():
+    meta = _meta()
+    meta.pop("runtime_cuda_archs")
+    errors = registry._validate_meta(meta, category="basic", owner="test")
+    assert "'runtime_cuda_archs' must be list" in errors
+
+
+def test_exact_architectures_are_stored_in_source_index():
+    index = registry.kernel_index(strict=True)
+    assert index
+    assert all(record.runtime_cuda_archs for record in index.values())
+    assert index["bmm_fp8_rubin"].runtime_cuda_archs == ("sm_107a",)
+    counts = {
+        archs: sum(record.runtime_cuda_archs == archs for record in index.values())
+        for archs in (
+            ("sm_100a",),
+            ("sm_107a",),
+            ("sm_100a", "sm_103a", "sm_107a"),
+        )
+    }
+    assert counts == {
+        ("sm_100a",): 6,
+        ("sm_107a",): 1,
+        ("sm_100a", "sm_103a", "sm_107a"): 89,
+    }
+
+
+def test_reference_requirements_are_stored_in_source_index():
+    index = registry.kernel_index(strict=True)
+
+    def packages(name):
+        return tuple(item.package for item in index[name].reference_requirements)
+
+    expected_by_category = {
+        "cudnn": ("nvidia-cudnn-frontend", "nvidia-cutlass-dsl"),
+        "deepep": ("deep-ep",),
+        "deepgemm": ("deep-gemm",),
+        "flashattention": ("flash-attn-4", "nvidia-cutlass-dsl"),
+        "flashinfer": ("flashinfer-python", "nvidia-cutlass-dsl"),
+        "msa": ("msa", "nvidia-cutlass-dsl", "quack-kernels"),
+    }
+    for name, record in index.items():
+        if record.category in expected_by_category:
+            assert packages(name) == expected_by_category[record.category]
+
+    assert {
+        name: packages(name) for name, record in index.items() if record.category == "basic"
+    } == {
+        "allgather_gemm": (),
+        "fp16_bf16_gemm": (),
+        "gemm_reduce_scatter": (),
+        "nvfp4_gemm": ("flashinfer-python", "nvidia-cutlass-dsl"),
+        "rmsnorm": ("flashinfer-python", "nvidia-cutlass-dsl"),
+    }
+    assert {
+        name: packages(name) for name, record in index.items() if record.category == "flashmla"
+    } == {
+        "flash_mla_sparse_fwd": (),
+        "sparse_flashmla_decode_head64": ("flash-mla",),
+        "sparse_flashmla_prefill_head128_phase1": (),
+        "sparse_flashmla_prefill_head128_small_topk_phase1": (),
+        "sparse_flashmla_prefill_head64_phase1": (),
+    }
+
+    fla = index["agent_evolved_kda_forward_b1_t8192_h96"].reference_requirements
+    assert [(item.package, item.import_name) for item in fla] == [("flash-linear-attention", "fla")]
+    assert fla[0].git.commit == "9c8e42e762fce087c27b673af4922795d9edb85e"
+
+    msa = index["msa_sparse_atten_fwd_sm100"].reference_requirements
+    assert [(item.package, item.specifier) for item in msa] == [
+        ("msa", None),
+        ("nvidia-cutlass-dsl", "==4.5.3"),
+        ("quack-kernels", "==0.5.0"),
+    ]
+    assert index["cudnn_sm100_gdn_bprop_f16"].reference_requirements[1].specifier == (
+        "==4.8.0.dev0"
+    )
+    assert index["flash_mla_sparse_fwd"].reference_requirements == ()
+
+
+def test_runtime_cuda_archs_must_match_source_index(monkeypatch):
+    record = registry.KernelRecord(
+        name="kernel",
+        category="basic",
+        runtime_cuda_archs=("sm_100a",),
+        reference_requirements=(),
+        module_name="tirx_kernels.basic.kernel",
+        source_path=Path(__file__),
+    )
+    module = SimpleNamespace(KERNEL_META=_meta(runtime_cuda_archs=["sm_103a"]))
+    monkeypatch.setattr(registry.importlib, "import_module", lambda _name: module)
+
+    with pytest.raises(ValueError, match="runtime runtime_cuda_archs"):
+        registry._import_record(record, strict=True)
+
+
+def test_reference_requirements_must_match_source_index(monkeypatch):
+    requirement = refs.ReferenceRequirement(
+        package="example", import_name="example", specifier="==1.0"
+    )
+    record = registry.KernelRecord(
+        name="kernel",
+        category="basic",
+        runtime_cuda_archs=("sm_100a",),
+        reference_requirements=(requirement,),
+        module_name="tirx_kernels.basic.kernel",
+        source_path=Path(__file__),
+    )
+    module = SimpleNamespace(KERNEL_META=_meta())
+    monkeypatch.setattr(registry.importlib, "import_module", lambda _name: module)
+
+    with pytest.raises(ValueError, match="runtime reference_requirements"):
+        registry._import_record(record, strict=True)
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ([], "must be tuple"),
+        ((), "must not be empty"),
+        (({"package": "pkg", "import": "pkg"},), "at least one"),
+        (({"package": "pkg", "specifier": "=1.0", "import": "pkg"},), "invalid"),
+        (({"package": "pkg", "specifier": ">=1", "import": "bad-name"},), "canonical"),
+        (
+            (
+                {
+                    "package": "pkg",
+                    "git": {"url": "https://example.test/repo.git", "commit": "abc"},
+                    "import": "pkg",
+                },
+            ),
+            "full lowercase Git SHA",
+        ),
+        (
+            (
+                {"package": "pkg", "specifier": ">=1", "import": "pkg"},
+                {"package": "PKG", "specifier": "<2", "import": "pkg.other"},
+            ),
+            "duplicates",
+        ),
+    ],
+)
+def test_reference_requirements_validation(value, message):
+    errors = registry._validate_meta(
+        _meta(reference_requirements=value), category="basic", owner="test"
+    )
+    assert any(message in error for error in errors)
+
+
+def test_discover_kernels_rejects_noncanonical_arch():
+    with pytest.raises(ValueError, match="invalid exact CUDA architecture"):
+        registry.discover_kernels(cuda_arch="sm100")
+
+
+def test_probe_reference_requirement_reports_missing_import(monkeypatch):
+    requirement = refs.ReferenceRequirement(package="missing", import_name="missing")
+    refs.probe_reference_requirement.cache_clear()
+    monkeypatch.setattr(refs.importlib.util, "find_spec", lambda _name: None)
+    assert "is unavailable" in refs.probe_reference_requirement(requirement)
+
+
+def test_probe_reference_requirement_checks_distribution_version(monkeypatch):
+    requirement = refs.ReferenceRequirement(
+        package="example", import_name="example", specifier=">=4.5.3,<4.6"
+    )
+    refs.probe_reference_requirement.cache_clear()
+    monkeypatch.setattr(refs.importlib.util, "find_spec", lambda _name: SimpleNamespace())
+    monkeypatch.setattr(refs.importlib.metadata, "version", lambda _name: "4.8.0.dev0")
+    assert "installed version is 4.8.0.dev0" in refs.probe_reference_requirement(requirement)
+
+
+def test_probe_reference_requirement_checks_git_identity(monkeypatch):
+    requirement = refs.ReferenceRequirement(
+        package="example",
+        import_name="example",
+        git=refs.GitRequirement(url="https://github.com/example/project.git", commit="1" * 40),
+    )
+    refs.probe_reference_requirement.cache_clear()
+    monkeypatch.setattr(refs.importlib.util, "find_spec", lambda _name: SimpleNamespace())
+    monkeypatch.setattr(
+        refs,
+        "_git_identity",
+        lambda _requirement, _module_spec: ("git@github.com:example/project.git", "1" * 40),
+    )
+    assert refs.probe_reference_requirement(requirement) is None

--- a/tests/test_runner_cuda_compile.py
+++ b/tests/test_runner_cuda_compile.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+from __future__ import annotations
+
+import pytest
+
+from tirx_kernels import runner
+
+
+def test_offline_cuda_compile_defaults_to_nvrtc(monkeypatch) -> None:
+    monkeypatch.delenv(runner.TVM_CUDA_COMPILE_MODE_ENV, raising=False)
+    monkeypatch.delenv(runner.TVM_CUDA_NVRTC_EXTRA_OPTS_ENV, raising=False)
+
+    assert runner._offline_cuda_compile_parameters("sm_107a") == {
+        "target_format": "cubin",
+        "arch": "sm_107a",
+        "options": None,
+        "compiler": "nvrtc",
+    }
+
+
+def test_offline_cuda_compile_allows_explicit_nvcc(monkeypatch) -> None:
+    monkeypatch.setenv(runner.TVM_CUDA_COMPILE_MODE_ENV, "nvcc")
+    monkeypatch.setenv(runner.TVM_CUDA_NVRTC_EXTRA_OPTS_ENV, "-lineinfo")
+
+    assert runner._offline_cuda_compile_parameters("sm_107a") == {
+        "target_format": "fatbin",
+        "arch": ["-gencode", "arch=compute_107a,code=sm_107a"],
+        "options": ["-lineinfo"],
+        "compiler": "nvcc",
+    }
+
+
+def test_offline_cuda_compile_rejects_unknown_mode(monkeypatch) -> None:
+    monkeypatch.setenv(runner.TVM_CUDA_COMPILE_MODE_ENV, "unknown")
+
+    with pytest.raises(
+        ValueError, match=r"Invalid TVM_CUDA_COMPILE_MODE: unknown\. Expected 'nvcc' or 'nvrtc'\."
+    ):
+        runner._offline_cuda_compile_parameters("sm_107a")

--- a/tirx_kernels/_protocol.py
+++ b/tirx_kernels/_protocol.py
@@ -18,7 +18,13 @@ KERNEL_META : dict
       buckets are named for their upstream project; ``basic`` holds native
       TIRx kernels, and ``agent_evolved`` holds curated kernels selected from
       measured agent-evolution runs.
-    - "compute_capability" (int): minimum SM version (e.g. 10 for sm100a)
+    - "runtime_cuda_archs" (list[str]): exact CUDA architectures on which the
+      kernel is allowed to compile and run (e.g. ["sm_100a"]).
+    Optional keys:
+    - "reference_requirements" (tuple[dict, ...]): correctness-only external
+      reference contracts. Each item has distribution "package", Python
+      "import", and at least one PEP 440 "specifier" or exact "git" identity
+      with a canonical URL and full commit SHA.
 
 CONFIGS : list[dict]
     Each dict has a "label" key (str) plus arbitrary kernel-specific

--- a/tirx_kernels/agent_evolved/kda_forward_b1_t8192_h96.py
+++ b/tirx_kernels/agent_evolved/kda_forward_b1_t8192_h96.py
@@ -14,6 +14,7 @@ TMEM, and assigns one work item to each (batch, head).  Evolution history and
 measurement artifacts remain in the run tree rather than becoming a second
 source of truth here.
 """
+
 import ctypes
 import math
 import os
@@ -136,21 +137,43 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
         smem = K.smem_pool()
         s_tmem_addr = smem.alloc((1,), K.i32, align=4)
         # ---- pipelines / barriers ---------------------------------------
-        p_stage = K.Pipeline(smem, 2, full="tma", empty="tcgen05", init_empty=2)  # loader -> prep ; G1_0 (mma0) + V1 (after G5, mma1) -> loader
+        p_stage = K.Pipeline(
+            smem, 2, full="tma", empty="tcgen05", init_empty=2
+        )  # loader -> prep ; G1_0 (mma0) + V1 (after G5, mma1) -> loader
         p_v = K.Pipeline(smem, 1, full="tma", empty="tcgen05")  # loader -> mma(G3) ; G3 -> loader
-        p_prep = K.Pipeline(smem, 2, full="mbar", empty="tcgen05", init_full=256)  # prep(8 warps) -> mma ; G7 -> prep (KG)
-        p_j1 = K.Pipeline(smem, 1, full="mbar", empty="tcgen05", init_full=256)  # prep(8 warps) -> mma ; G1_1 -> prep
-        p_beta = K.Pipeline(smem, 2, full="mbar", empty="mbar", init_full=32, init_empty=128)  # loader -> cg0
-        p_g1 = K.Pipeline(smem, 2, full="tcgen05", empty="mbar", init_empty=128)  # G1_0 (D0, two TMEM buffers) -> cg0 ; cg0 (D0 read) -> mma0
+        p_prep = K.Pipeline(
+            smem, 2, full="mbar", empty="tcgen05", init_full=256
+        )  # prep(8 warps) -> mma ; G7 -> prep (KG)
+        p_j1 = K.Pipeline(
+            smem, 1, full="mbar", empty="tcgen05", init_full=256
+        )  # prep(8 warps) -> mma ; G1_1 -> prep
+        p_beta = K.Pipeline(
+            smem, 2, full="mbar", empty="mbar", init_full=32, init_empty=128
+        )  # loader -> cg0
+        p_g1 = K.Pipeline(
+            smem, 2, full="tcgen05", empty="mbar", init_empty=128
+        )  # G1_0 (D0, two TMEM buffers) -> cg0 ; cg0 (D0 read) -> mma0
         m_g1b = K.TCGen05Bar(smem, 1)  # G1_1 (D1) done -> cg0
         m_g1b.init(1)
-        p_g1b = K.MBarrier(smem, 1)  # D1 consumed by cg0 (Akk and Aqk halves) -> mma1 may overwrite it with the next G1_1
+        p_g1b = K.MBarrier(
+            smem, 1
+        )  # D1 consumed by cg0 (Akk and Aqk halves) -> mma1 may overwrite it with the next G1_1
         p_g1b.init(128)
-        p_t = K.Pipeline(smem, 1, full="mbar", empty="tcgen05", init_full=128)  # cg0 -> mma ; G4'' (mma1, after G3) -> cg0
-        p_aqk = K.Pipeline(smem, 1, full="mbar", empty="tcgen05", init_full=64)  # cg0 warps 2/3 -> mma1 (Aqk rows in the stage Y region; the region is recycled by prep after G7)
-        p_u = K.Pipeline(smem, 1, full="tcgen05", empty="mbar", init_empty=128)  # G4 -> cg1 ; cg1 -> mma(G3)
-        p_o = K.Pipeline(smem, 1, full="tcgen05", empty="mbar", init_empty=128)  # G6 -> cg1 ; cg1 -> mma(G5)
-        p_osm = K.Pipeline(smem, 1, full="mbar", empty="mbar", init_full=128, init_empty=1)  # cg1 -> storer -> cg1
+        p_t = K.Pipeline(
+            smem, 1, full="mbar", empty="tcgen05", init_full=128
+        )  # cg0 -> mma ; G4'' (mma1, after G3) -> cg0
+        p_aqk = K.Pipeline(
+            smem, 1, full="mbar", empty="tcgen05", init_full=64
+        )  # cg0 warps 2/3 -> mma1 (Aqk rows in the stage Y region; the region is recycled by prep after G7)
+        p_u = K.Pipeline(
+            smem, 1, full="tcgen05", empty="mbar", init_empty=128
+        )  # G4 -> cg1 ; cg1 -> mma(G3)
+        p_o = K.Pipeline(
+            smem, 1, full="tcgen05", empty="mbar", init_empty=128
+        )  # G6 -> cg1 ; cg1 -> mma(G5)
+        p_osm = K.Pipeline(
+            smem, 1, full="mbar", empty="mbar", init_full=128, init_empty=1
+        )  # cg1 -> storer -> cg1
         m_v1 = K.TCGen05Bar(smem, 1)  # V1 done (mma1) -> cg1
         m_v1.init(1)
         m_v1b = K.MBarrier(smem, 1)  # V1 bf16 copy in TM_UB ready (cg1) -> mma1 (G4'')
@@ -180,8 +203,12 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
         # destination precision.  End-of-chunk decay still uses fp32 factors and fp32 state.
         s_gate_r = smem.alloc((4, D_HEAD), K.bf16, align=16)  # [chunk&3]=bf16(2^R0)
         s_gate_e = smem.alloc((4, D_HEAD), K.f32, align=16)  # [chunk&3]=2^G2_63
-        s_part = smem.alloc((2, 8, D_HEAD), K.f32, align=16)  # gate-scan partial totals, [chunk&1][group]
-        s_norm = smem.alloc((2, 2, CHUNK), K.f32, align=16)  # [stage][0]=rstd_k[t], [1]=rstd_q[t]*scale (prep-private per warp)
+        s_part = smem.alloc(
+            (2, 8, D_HEAD), K.f32, align=16
+        )  # gate-scan partial totals, [chunk&1][group]
+        s_norm = smem.alloc(
+            (2, 2, CHUNK), K.f32, align=16
+        )  # [stage][0]=rstd_k[t], [1]=rstd_q[t]*scale (prep-private per warp)
 
         # The inverse never writes TB's strictly-upper 32x32 block; zero s_T once
         # so that block stays the required zero operand in every chunk.
@@ -190,7 +217,11 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
             for i in range(4):
                 K.assign(zpad[i], K.uint32(0))
             K.ptx["st.shared.v4.b32"](
-                s_T.ptr_to(K.thread_id() >> 3, (K.thread_id() & 7) * 8), zpad[0], zpad[1], zpad[2], zpad[3]
+                s_T.ptr_to(K.thread_id() >> 3, (K.thread_id() & 7) * 8),
+                zpad[0],
+                zpad[1],
+                zpad[2],
+                zpad[3],
             )
         K.ptx[FENCE_ASYNC]()
         with K.If(K.thread_id() == 0), K.Then():
@@ -258,12 +289,20 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
 
         def lds128(view, row, col, words, base):
             K.ptx["ld.shared.v4.b32"](
-                words[base], words[base + 1], words[base + 2], words[base + 3], view.ptr_to(row, col)
+                words[base],
+                words[base + 1],
+                words[base + 2],
+                words[base + 3],
+                view.ptr_to(row, col),
             )
 
         def sts128(view, row, col, words, base):
             K.ptx["st.shared.v4.b32"](
-                view.ptr_to(row, col), words[base], words[base + 1], words[base + 2], words[base + 3]
+                view.ptr_to(row, col),
+                words[base],
+                words[base + 1],
+                words[base + 2],
+                words[base + 3],
             )
 
         def f2(a, b):
@@ -283,7 +322,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
             st_prep = K.PipelineState(2, phase=1)  # producer of p_prep
             st_j1 = K.PipelineState(1, phase=1)  # producer of p_j1
             lane = K.lane_id()
-            r_grp = K.local_scalar("int32", init=K.warp_id_in_role())  # token group 0..7 (one warp each)
+            r_grp = K.local_scalar(
+                "int32", init=K.warp_id_in_role()
+            )  # token group 0..7 (one warp each)
             col0 = lane * 4  # channels 4*lane .. 4*lane+3
             hi_block = K.local_scalar("int32", init=K.Cast("int32", (K.warp_id_in_role() >= 4)))
             work = K.local_scalar("int32", init=K.cta_id())
@@ -304,13 +345,17 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                 return offs
 
             xo_stage = row_offsets(STAGE_ROWS)
-            xo_adj = (lane >> 4) * ((STAGE_ROWS - CHUNK) * 128)  # xo_64[i] == xo_stage[i] - xo_adj (64-row tiles)
+            xo_adj = (lane >> 4) * (
+                (STAGE_ROWS - CHUNK) * 128
+            )  # xo_64[i] == xo_stage[i] - xo_adj (64-row tiles)
             # row norms: lanes 0..15 own this warp's eight k rows, lanes 16..31 its eight q rows, two lanes per
             # row, each lane one 64-column swizzle atom.  The atom's eight 16-byte chunks are summed in the
             # order j ^ (row & 7) ^ (atom << 2) (the sum does not care), which keeps the eight lanes of a
             # quarter-warp (four rows x two atoms) on eight distinct chunk positions: conflict-free LDS.128.
             norm_row = (lane >> 4) * CHUNK + r_grp * 8 + ((lane & 15) >> 1)
-            norm_off = K.local_scalar("int32", init=(lane & 1) * (STAGE_ROWS * 128) + norm_row * 128)
+            norm_off = K.local_scalar(
+                "int32", init=(lane & 1) * (STAGE_ROWS * 128) + norm_row * 128
+            )
             norm_x = K.local_scalar("int32", init=((norm_row & 7) ^ ((lane & 1) << 2)) << 4)
             norm_is_q = lane >= 16
             norm_wr = (lane & 1) == 0
@@ -330,11 +375,15 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                 K.ptx.ld.global_.f32(ea, a_log.ptr_to([h_idx]))
                 ea_l2 = K.local_scalar("float32")
                 K.ptx.ex2.approx.ftz.f32(ea_l2, ea * K.float32(LOG2E))  # exp(A_log)
-                hea = K.local_scalar("float32", init=ea_l2 * K.float32(0.5))  # exp(A_log)/2 for tanh sigmoid
+                hea = K.local_scalar(
+                    "float32", init=ea_l2 * K.float32(0.5)
+                )  # exp(A_log)/2 for tanh sigmoid
                 bias = K.alloc_local([4], "float32")
                 bw = K.alloc_local([4], "uint32")
                 K.ptx[LDG_V4](bw[0], bw[1], bw[2], bw[3], dt_bias.ptr_to([h_idx * D_HEAD + col0]))
-                biash = K.alloc_local([4], "float32")  # bias * exp(A_log)/2: the tanh argument is one fma
+                biash = K.alloc_local(
+                    [4], "float32"
+                )  # bias * exp(A_log)/2: the tanh argument is one fma
                 for j in range(4):
                     K.assign(bias[j], K.reinterpret("float32", bw[j]))
                     K.assign(biash[j], bias[j] * hea)
@@ -343,7 +392,8 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                 gw = K.alloc_local([16], "uint32")
                 g_base = K.local_scalar(
                     "int64",
-                    init=(K.Cast("int64", b_idx) * K.int64(T) * K.int64(H) + K.Cast("int64", h_idx)) * K.int64(D_HEAD)
+                    init=(K.Cast("int64", b_idx) * K.int64(T) * K.int64(H) + K.Cast("int64", h_idx))
+                    * K.int64(D_HEAD)
                     + K.Cast("int64", col0),
                 )
 
@@ -351,14 +401,16 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     for i in range(8):
                         t = r_grp * 8 + i
                         K.ptx["ld.global.L1::no_allocate.v2.b32"](
-                            gw[2 * i], gw[2 * i + 1],
+                            gw[2 * i],
+                            gw[2 * i + 1],
                             g.ptr_to([g_base + K.Cast("int64", nn * CHUNK + t) * K.int64(HK)]),
                         )
 
                 def issue_g_load_token(nn, i):
                     t = r_grp * 8 + i
                     K.ptx["ld.global.L1::no_allocate.v2.b32"](
-                        gw[2 * i], gw[2 * i + 1],
+                        gw[2 * i],
+                        gw[2 * i + 1],
                         g.ptr_to([g_base + K.Cast("int64", nn * CHUNK + t) * K.int64(HK)]),
                     )
 
@@ -369,9 +421,7 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     for j in range(4):
                         wj = gw[2 * i] if j < 2 else gw[2 * i + 1]
                         gv = bf16_lo(wj) if j % 2 == 0 else bf16_hi(wj)
-                        sg = K.idioms.sigmoid_tanh_approx_f32(
-                            tanh_input=gv * hea + biash[j]
-                        )
+                        sg = K.idioms.sigmoid_tanh_approx_f32(tanh_input=gv * hea + biash[j])
                         if i == 0:
                             K.assign(G[j], sg * K.float32(NEG5LOG2E))
                         else:
@@ -396,7 +446,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     # (pass 1 of this chunk already ran, fused into the previous chunk's pass 2: G = cumsum)
                     _t = rng("P.scan_a")
                     # block totals -> smem partials [r][k]
-                    K.ptx["st.shared.v4.f32"](K.address_of(s_part[n & 1, r_grp, col0]), G[28], G[29], G[30], G[31])
+                    K.ptx["st.shared.v4.f32"](
+                        K.address_of(s_part[n & 1, r_grp, col0]), G[28], G[29], G[30], G[31]
+                    )
                     rng_end(_t)
                     _t = rng("P.scan_bar1")
                     K.ptx.bar.sync(K.uint32(BAR_PREP), K.uint32(BAR_PREP_N))
@@ -412,7 +464,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                         K.assign(E63[j], K.float32(0.0))
                     pw = K.alloc_local([4], "float32")
                     for rr in range(8):
-                        K.ptx["ld.shared.v4.f32"](pw[0], pw[1], pw[2], pw[3], K.address_of(s_part[n & 1, rr, col0]))
+                        K.ptx["ld.shared.v4.f32"](
+                            pw[0], pw[1], pw[2], pw[3], K.address_of(s_part[n & 1, rr, col0])
+                        )
                         if rr == 2:
                             for j in range(4):
                                 K.assign(R0[j], E63[j])
@@ -437,7 +491,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                         gvr = K.alloc_local([2], "uint32")
                         pack_bf16x2(gvr[0], gv8[0], gv8[1])
                         pack_bf16x2(gvr[1], gv8[2], gv8[3])
-                        K.ptx["st.shared.v2.b32"](K.address_of(s_gate_r[n & 3, col0]), gvr[0], gvr[1])
+                        K.ptx["st.shared.v2.b32"](
+                            K.address_of(s_gate_r[n & 3, col0]), gvr[0], gvr[1]
+                        )
                         K.ptx["st.shared.v4.f32"](
                             K.address_of(s_gate_e[n & 3, col0]), gv8[4], gv8[5], gv8[6], gv8[7]
                         )
@@ -448,8 +504,15 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     for j in range(4):
                         K.assign(Rsel[j], K.Select(hi_block != 0, R1[j], R0[j]))
                         K.ptx.ex2.approx.ftz.f32(fpr[j], E63[j] - Rsel[j])
-                    for j in range(4):  # lo threads: f10 = 1 (their "own-reference" tile is the stage tile)
-                        K.ptx.ex2.approx.ftz.f32(f10[j], K.Select(hi_block != 0, (R1[j] - R0[j]) * K.float32(0.5), K.float32(0.0)))
+                    for j in range(
+                        4
+                    ):  # lo threads: f10 = 1 (their "own-reference" tile is the stage tile)
+                        K.ptx.ex2.approx.ftz.f32(
+                            f10[j],
+                            K.Select(
+                                hi_block != 0, (R1[j] - R0[j]) * K.float32(0.5), K.float32(0.0)
+                            ),
+                        )
                         K.assign(f10[j], f10[j] * f10[j])
                     fprb = K.alloc_local([2], "uint32")
                     f10b = K.alloc_local([2], "uint32")
@@ -476,7 +539,11 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     nw = K.alloc_local([4], "uint32")
                     for j in range(8):
                         K.ptx["ld.shared.v4.b32"](
-                            nw[0], nw[1], nw[2], nw[3], K.ptx.addr(base_k, norm_off + (K.int32(16 * j) ^ norm_x))
+                            nw[0],
+                            nw[1],
+                            nw[2],
+                            nw[3],
+                            K.ptx.addr(base_k, norm_off + (K.int32(16 * j) ^ norm_x)),
                         )
                         for pp in range(4):
                             xv = f2(bf16_lo(nw[pp]), bf16_hi(nw[pp]))
@@ -490,29 +557,64 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     )
                     nother = K.local_scalar("uint32")
                     K.ptx.shfl_sync.bfly.b32(
-                        nother, K.reinterpret("uint32", nhalf), K.uint32(1), K.uint32(0x1F), K.uint32(0xFFFFFFFF)
+                        nother,
+                        K.reinterpret("uint32", nhalf),
+                        K.uint32(1),
+                        K.uint32(0x1F),
+                        K.uint32(0xFFFFFFFF),
                     )
                     nr = K.local_scalar("float32")
-                    K.ptx.rsqrt.approx.ftz.f32(nr, (nhalf + K.reinterpret("float32", nother)) + K.float32(1e-6))
+                    K.ptx.rsqrt.approx.ftz.f32(
+                        nr, (nhalf + K.reinterpret("float32", nother)) + K.float32(1e-6)
+                    )
                     with K.If(norm_is_q), K.Then():
                         K.assign(nr, nr * scale)
                     with K.If(norm_wr), K.Then():
                         K.ptx.st.shared.f32(
-                            K.address_of(s_norm[st_stage.stage, lane >> 4, r_grp * 8 + ((lane & 15) >> 1)]), nr
+                            K.address_of(
+                                s_norm[st_stage.stage, lane >> 4, r_grp * 8 + ((lane & 15) >> 1)]
+                            ),
+                            nr,
                         )
                     K.ptx["bar.warp.sync"](K.uint32(0xFFFFFFFF))
                     rq = K.alloc_local([8], "float32")
                     rk = K.alloc_local([8], "float32")
-                    K.ptx["ld.shared.v4.f32"](rk[0], rk[1], rk[2], rk[3], K.address_of(s_norm[st_stage.stage, 0, r_grp * 8]))
-                    K.ptx["ld.shared.v4.f32"](rk[4], rk[5], rk[6], rk[7], K.address_of(s_norm[st_stage.stage, 0, r_grp * 8 + 4]))
-                    K.ptx["ld.shared.v4.f32"](rq[0], rq[1], rq[2], rq[3], K.address_of(s_norm[st_stage.stage, 1, r_grp * 8]))
-                    K.ptx["ld.shared.v4.f32"](rq[4], rq[5], rq[6], rq[7], K.address_of(s_norm[st_stage.stage, 1, r_grp * 8 + 4]))
+                    K.ptx["ld.shared.v4.f32"](
+                        rk[0],
+                        rk[1],
+                        rk[2],
+                        rk[3],
+                        K.address_of(s_norm[st_stage.stage, 0, r_grp * 8]),
+                    )
+                    K.ptx["ld.shared.v4.f32"](
+                        rk[4],
+                        rk[5],
+                        rk[6],
+                        rk[7],
+                        K.address_of(s_norm[st_stage.stage, 0, r_grp * 8 + 4]),
+                    )
+                    K.ptx["ld.shared.v4.f32"](
+                        rq[0],
+                        rq[1],
+                        rq[2],
+                        rq[3],
+                        K.address_of(s_norm[st_stage.stage, 1, r_grp * 8]),
+                    )
+                    K.ptx["ld.shared.v4.f32"](
+                        rq[4],
+                        rq[5],
+                        rq[6],
+                        rq[7],
+                        K.address_of(s_norm[st_stage.stage, 1, r_grp * 8 + 4]),
+                    )
                     rng_end(_t)
                     _t = rng("P.wait_bufs")
                     # buffers this chunk writes: KG[stage] (after G7 two chunks ago), J1 (after G1_1 last chunk)
                     p_prep.empty.wait(st_prep.stage, st_prep.phase)
                     p_j1.empty.wait(st_j1.stage, st_j1.phase)
-                    K.ptx[FENCE_ASYNC]()  # async-proxy (MMA) reads of those tiles precede our generic writes
+                    K.ptx[
+                        FENCE_ASYNC
+                    ]()  # async-proxy (MMA) reads of those tiles precede our generic writes
                     rng_end(_t)
                     _t = rng("P.pass2")
                     # ---------------- pass 2: gated operand tiles ---------------
@@ -583,11 +685,15 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
         # CG0: Akk epilogue, hierarchical inverse (-> TB bf16), G3 issue.      warps 8-11
         # =====================================================================
         with cg0:
-            st_g1 = K.PipelineState(2, phase=0)  # consumer p_g1.full ; producer p_g1.empty (same index)
+            st_g1 = K.PipelineState(
+                2, phase=0
+            )  # consumer p_g1.full ; producer p_g1.empty (same index)
             st_g1b = K.PipelineState(1, phase=0)  # consumer of m_g1b (D1 done)
             st_t = K.PipelineState(1, phase=1)  # producer p_t
             st_beta = K.PipelineState(2, phase=0)  # consumer p_beta
-            st_tc = K.PipelineState(1, phase=0)  # consumer of p_t.full (this warpgroup's own T, all 128 arrivals)
+            st_tc = K.PipelineState(
+                1, phase=0
+            )  # consumer of p_t.full (this warpgroup's own T, all 128 arrivals)
             st_v = K.PipelineState(1, phase=0)  # consumer of p_v.full (G3)
             st_ue = K.PipelineState(1, phase=1)  # waits p_u.empty before G3 overwrites U^T
             st_aqk0 = K.PipelineState(1, phase=1)  # producer of p_aqk (warps 2/3)
@@ -610,6 +716,7 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                             K.uint32(0),
                             K.ptx.pred(K.uint32(1) if (accumulate or kp != 0) else K.uint32(0)),
                         )
+
             tmem = tmem_preamble()
             tid1 = K.tid_in_role()
             lane = K.lane_id()
@@ -683,7 +790,14 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
             def mma_k16(acc, a, b, acc_off, b_off, accumulate):
                 c = [acc[acc_off + i] for i in range(4)] if accumulate else [K.float32(0.0)] * 4
                 K.ptx[MMA_K16](
-                    *(acc[acc_off + i] for i in range(4)), a[0], a[1], a[2], a[3], b[b_off], b[b_off + 1], *c
+                    *(acc[acc_off + i] for i in range(4)),
+                    a[0],
+                    a[1],
+                    a[2],
+                    a[3],
+                    b[b_off],
+                    b[b_off + 1],
+                    *c,
                 )
 
             def inverse_8_to_16(av, b16):
@@ -771,7 +885,11 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                 # accumulator pair (acc[2pp], acc[2pp+1]) sits at column 8*(pp>>1) + 2*(lane&3) + {0,1}
                 bq = K.alloc_local([8], "float32")
                 for qq in range(4):
-                    K.ptx["ld.shared.v2.f32"](bq[2 * qq], bq[2 * qq + 1], K.address_of(s_beta[stg, 8 * qq + 2 * (lane & 3)]))
+                    K.ptx["ld.shared.v2.f32"](
+                        bq[2 * qq],
+                        bq[2 * qq + 1],
+                        K.address_of(s_beta[stg, 8 * qq + 2 * (lane & 3)]),
+                    )
                 scaled = K.local_scalar("uint64")
                 for p in range(4):
                     q0 = 2 * (p >> 1)
@@ -805,7 +923,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                             bcol[2 * p],
                             bcol[2 * p + 1],
                         )
-                        pack_bf16x2(wds[2 * m + p], K.cuda.float2_x(scaled), K.cuda.float2_y(scaled))
+                        pack_bf16x2(
+                            wds[2 * m + p], K.cuda.float2_x(scaled), K.cuda.float2_y(scaled)
+                        )
                 for m in range(4):
                     sts128(s_T, trow, tc0 + 8 * m, wds, 4 * m)
 
@@ -822,7 +942,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
             bar_inv()
 
             acc32 = K.alloc_local([32], "float32")
-            wds = K.alloc_local([32], "uint32")  # [0..15] Akk/TB/W words, [16..31] Aqk D1 words (warps 2/3)
+            wds = K.alloc_local(
+                [32], "uint32"
+            )  # [0..15] Akk/TB/W words, [16..31] Aqk D1 words (warps 2/3)
             work = K.local_scalar("int32", init=K.cta_id())
             with K.While(work < num_work):
                 with K.serial(NCH) as n:
@@ -841,7 +963,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     acc_b = K.alloc_local([32], "float32")
                     ld32(acc32, TM_D0 + stg * 64)
                     K.ptx[WAIT_LD]()
-                    p_g1.empty.arrive(st_g1.stage)  # D0 buffer consumed: mma0 may run G1_0 of chunk n+2 into it
+                    p_g1.empty.arrive(
+                        st_g1.stage
+                    )  # D0 buffer consumed: mma0 may run G1_0 of chunk n+2 into it
                     st_g1.advance()
 
                     def akk_rows(acc, row_base, col_base, diag_shift):
@@ -897,7 +1021,10 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                             with K.If(lane < 16), K.Then():
                                 dshift = K.Select(lw == 2, K.int32(0), K.int32(16))
                                 for j in range(32):
-                                    K.assign(acc_b[j], K.Select(j <= lane + dshift, acc_b[j], K.float32(0.0)))
+                                    K.assign(
+                                        acc_b[j],
+                                        K.Select(j <= lane + dshift, acc_b[j], K.float32(0.0)),
+                                    )
                                 for p in range(16):
                                     pack_bf16x2(wds[16 + p], acc_b[2 * p], acc_b[2 * p + 1])
                             p_g1b.arrive(0)  # Aqk half of D1 consumed
@@ -933,7 +1060,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     _t = rng("C0.t64")
                     # ---- last merge writes TB = T * beta_j (bf16) straight into s_T: warps 0/1 compute
                     # T21 with mma.sync, warps 2/3 convert the diagonal blocks T11 / T22 meanwhile ----
-                    p_t.empty.wait(st_t.stage, st_t.phase)  # G3 of the previous chunk finished reading s_T
+                    p_t.empty.wait(
+                        st_t.stage, st_t.phase
+                    )  # G3 of the previous chunk finished reading s_T
                     K.ptx[FENCE_ASYNC]()
                     with K.If(lw < 2):
                         with K.Then():
@@ -949,7 +1078,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     # ---- G3: U^T = V^T TB^T, issued here by warp 0 (no handoff); TB is released by G4'' ----
                     _t = rng("C0.g3")
                     with K.If(lw == 0), K.Then():
-                        p_t.full.wait(st_tc.stage, st_tc.phase)  # every cg0 thread's TB stores are published
+                        p_t.full.wait(
+                            st_tc.stage, st_tc.phase
+                        )  # every cg0 thread's TB stores are published
                         st_tc.advance()
                         p_v.full.wait(st_v.stage, st_v.phase)
                         p_u.empty.wait(st_ue.stage, st_ue.phase)
@@ -1099,7 +1230,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                             hc = half * 64
                             hs = half * 32
                             ld32b(fr, TM_S + hc)
-                            K.ptx[TC_LD32](*(fr[32 + i] for i in range(32)), tmem_at2(TM_S + hc + 32))
+                            K.ptx[TC_LD32](
+                                *(fr[32 + i] for i in range(32)), tmem_at2(TM_S + hc + 32)
+                            )
                             K.ptx[WAIT_LD]()
                             for sub in range(2):
                                 qc = hc + 32 * sub
@@ -1108,13 +1241,25 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                                 # supply the eight resident-state decay factors.
                                 for m in range(4):
                                     K.ptx["ld.shared.v4.b32"](
-                                        bfac[0], bfac[1], bfac[2], bfac[3], K.address_of(s_gate_r[nstg, qc + 8 * m])
+                                        bfac[0],
+                                        bfac[1],
+                                        bfac[2],
+                                        bfac[3],
+                                        K.address_of(s_gate_r[nstg, qc + 8 * m]),
                                     )
                                     K.ptx["ld.shared.v4.f32"](
-                                        fac[0], fac[1], fac[2], fac[3], K.address_of(s_gate_e[nstg, qc + 8 * m])
+                                        fac[0],
+                                        fac[1],
+                                        fac[2],
+                                        fac[3],
+                                        K.address_of(s_gate_e[nstg, qc + 8 * m]),
                                     )
                                     K.ptx["ld.shared.v4.f32"](
-                                        fac[4], fac[5], fac[6], fac[7], K.address_of(s_gate_e[nstg, qc + 8 * m + 4])
+                                        fac[4],
+                                        fac[5],
+                                        fac[6],
+                                        fac[7],
+                                        K.address_of(s_gate_e[nstg, qc + 8 * m + 4]),
                                     )
                                     for p in range(4):
                                         pack_bf16x2(
@@ -1122,11 +1267,7 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                                             fr[fb + 8 * m + 2 * p],
                                             fr[fb + 8 * m + 2 * p + 1],
                                         )
-                                        K.ptx.mul.rn.bf16x2(
-                                            wds[4 * m + p],
-                                            wds[4 * m + p],
-                                            bfac[p],
-                                        )
+                                        K.ptx.mul.rn.bf16x2(wds[4 * m + p], wds[4 * m + p], bfac[p])
                                         mul2(
                                             state_pair,
                                             fr[fb + 8 * m + 2 * p],
@@ -1134,11 +1275,19 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                                             fac[2 * p],
                                             fac[2 * p + 1],
                                         )
-                                        K.assign(fr[fb + 8 * m + 2 * p], K.cuda.float2_x(state_pair))
-                                        K.assign(fr[fb + 8 * m + 2 * p + 1], K.cuda.float2_y(state_pair))
-                                K.ptx[TC_ST16](tmem_at2(TM_ST + hs + 16 * sub), *(wds[i] for i in range(16)))
+                                        K.assign(
+                                            fr[fb + 8 * m + 2 * p], K.cuda.float2_x(state_pair)
+                                        )
+                                        K.assign(
+                                            fr[fb + 8 * m + 2 * p + 1], K.cuda.float2_y(state_pair)
+                                        )
+                                K.ptx[TC_ST16](
+                                    tmem_at2(TM_ST + hs + 16 * sub), *(wds[i] for i in range(16))
+                                )
                             st32b(TM_S + hc, fr)
-                            K.ptx[TC_ST32](tmem_at2(TM_S + hc + 32), *(fr[32 + i] for i in range(32)))
+                            K.ptx[TC_ST32](
+                                tmem_at2(TM_S + hc + 32), *(fr[32 + i] for i in range(32))
+                            )
                         K.ptx[WAIT_ST]()
                         m_s.arrive(0)
                     st_pn.advance()
@@ -1160,7 +1309,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                 # G1_0 of every chunk, issued as soon as prep publishes the chunk (double-buffered D0)
                 st_prep = K.PipelineState(2, phase=0)
                 st_g1 = K.PipelineState(2, phase=1)  # producer p_g1
-                st_stg = K.PipelineState(2, phase=0)  # ledger for p_stage.empty commits (G1_0 reads X0/Q0 rows)
+                st_stg = K.PipelineState(
+                    2, phase=0
+                )  # ledger for p_stage.empty commits (G1_0 reads X0/Q0 rows)
                 tmem = tmem_preamble()
 
                 def mma_ss(dcol, a_desc, a_off, b_desc, b_off, n_k, idesc, accumulate):
@@ -1195,11 +1346,15 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                         st_prep.advance()
                         rng_end(_t)
                         _t = rng("M0.g1")
-                        mma_ss(TM_D0 + stg * 64, dA, offA, dA, shifted(offA, OFF_Y0), 8, ID_G1, False)
+                        mma_ss(
+                            TM_D0 + stg * 64, dA, offA, dA, shifted(offA, OFF_Y0), 8, ID_G1, False
+                        )
                         pr = elect_local()
                         p_g1.full.arrive(st_g1.stage, pred=pr)  # D0 done (G1_0)
                         st_g1.advance()
-                        p_stage.empty.arrive(st_stg.stage, pred=pr)  # G1_0 finished reading the stage's X0/Q0 rows
+                        p_stage.empty.arrive(
+                            st_stg.stage, pred=pr
+                        )  # G1_0 finished reading the stage's X0/Q0 rows
                         st_stg.advance()
                         rng_end(_t)
                     K.assign(work, work + num_ctas)
@@ -1213,7 +1368,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                 st_j1 = K.PipelineState(1, phase=0)
                 st_g1b_e = K.PipelineState(1, phase=1)  # producer-side wait on p_g1b (D1 consumed)
                 st_v1b = K.PipelineState(1, phase=0)  # consumer of m_v1b (V1 bf16 copy ready)
-                st_t1 = K.PipelineState(1, phase=0)  # ledger for p_t.empty commits (G4'' is TB's last reader)
+                st_t1 = K.PipelineState(
+                    1, phase=0
+                )  # ledger for p_t.empty commits (G4'' is TB's last reader)
                 st_aqk = K.PipelineState(1, phase=0)
                 st_u = K.PipelineState(1, phase=1)  # producer p_u.full
                 st_o = K.PipelineState(1, phase=1)  # producer p_o
@@ -1292,7 +1449,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                         _t = rng("M1.wait_g5")
                         m_s.wait(0, st_s.phase)
                         st_s.advance()
-                        p_prep.full.wait(st_prep.stage, st_prep.phase)  # Q0/X0 rows of this chunk published
+                        p_prep.full.wait(
+                            st_prep.stage, st_prep.phase
+                        )  # Q0/X0 rows of this chunk published
                         p_o.empty.wait(st_o.stage, st_o.phase)
                         rng_end(_t)
                         _t = rng("M1.g5")
@@ -1301,7 +1460,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                         mma_ts(TM_V1, TM_ST, dA, offA, 8, ID_G56, False)
                         pr = elect_local()
                         m_v1.arrive(0, pred=pr)  # V1 done -> cg1 converts it
-                        p_stage.empty.arrive(st_stage.stage, pred=pr)  # stage fully consumed (G5 + V1)
+                        p_stage.empty.arrive(
+                            st_stage.stage, pred=pr
+                        )  # stage fully consumed (G5 + V1)
                         st_stage.advance()
                         rng_end(_t)
                         # ---- G4'': U^T -= V1b TB^T (after G3 landed in U^T and cg1 published V1b) --------
@@ -1366,7 +1527,9 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                         _t = rng("L.issue")
                         with K.If(elected()), K.Then():
                             p_stage.full.arrive(st_stage.stage, tx_count=KQ_BYTES)
-                            mb = K.cuda.cvta_generic_to_shared(p_stage.full.ptr_to([st_stage.stage]))
+                            mb = K.cuda.cvta_generic_to_shared(
+                                p_stage.full.ptr_to([st_stage.stage])
+                            )
                             for tmap, row0 in ((k_map, 0), (q_map, 64)):
                                 for d0 in (0, 64):
                                     K.ptx[TMA_LD](
@@ -1396,7 +1559,12 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                             bu = K.local_scalar("uint16")
                             K.ptx.ld.global_.nc.u16(
                                 bu,
-                                beta.ptr_to([(K.Cast("int64", tok0) + K.Cast("int64", t)) * K.int64(H) + K.Cast("int64", h_idx)]),
+                                beta.ptr_to(
+                                    [
+                                        (K.Cast("int64", tok0) + K.Cast("int64", t)) * K.int64(H)
+                                        + K.Cast("int64", h_idx)
+                                    ]
+                                ),
                             )
                             bfv = K.reinterpret("float32", K.Cast("uint32", bu) << K.uint32(16))
                             sg = K.idioms.sigmoid_tanh_approx_f32(bfv)
@@ -1415,9 +1583,12 @@ def make_kernel(H: int, T: int, B: int, num_ctas: int, iket: bool = False):
                     K.ptx.prefetch.tensormap(K.address_of(o_map))
                     K.ptx.prefetch.tensormap(K.address_of(v_map))
                 work = K.local_scalar("int32", init=K.cta_id())
+
                 def issue_v(tok0, h_idx):
                     _t = rng("L.wait_v")
-                    p_v.empty.wait(st_v.stage, st_v.phase)  # single v stage: free once G3 of the previous chunk completed
+                    p_v.empty.wait(
+                        st_v.stage, st_v.phase
+                    )  # single v stage: free once G3 of the previous chunk completed
                     rng_end(_t)
                     with K.If(elected()), K.Then():
                         p_v.full.arrive(st_v.stage, tx_count=V_BYTES)
@@ -1570,14 +1741,22 @@ class KDAForwardConfig:
 
 
 _EVOLVE_CONFIG = KDAForwardConfig()
-CONFIGS = [
-    {field.name: getattr(_EVOLVE_CONFIG, field.name) for field in fields(KDAForwardConfig)}
-]
+CONFIGS = [{field.name: getattr(_EVOLVE_CONFIG, field.name) for field in fields(KDAForwardConfig)}]
 
 KERNEL_META = {
     "name": "agent_evolved_kda_forward_b1_t8192_h96",
     "category": "agent_evolved",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flash-linear-attention",
+            "git": {
+                "url": "https://github.com/fla-org/flash-linear-attention.git",
+                "commit": "9c8e42e762fce087c27b673af4922795d9edb85e",
+            },
+            "import": "fla",
+        },
+    ),
     "provenance": {
         "generator": "hmz",
         "run": "kda_forward_b1_t8192_h96-20260829-023306",
@@ -1602,12 +1781,7 @@ def _num_ctas(cfg: KDAForwardConfig) -> int:
 
 def get_kernel(**kwargs: Any):
     cfg = _cfg(**kwargs)
-    return make_kernel(
-        cfg.num_heads,
-        cfg.seq_len,
-        cfg.batch_size,
-        _num_ctas(cfg),
-    ).func
+    return make_kernel(cfg.num_heads, cfg.seq_len, cfg.batch_size, _num_ctas(cfg)).func
 
 
 def _gate_parameters(
@@ -1635,9 +1809,9 @@ def _gate_parameters(
 def _randn_bf16(
     shape: tuple[int, ...], *, device: torch.device, generator: torch.Generator
 ) -> torch.Tensor:
-    return (
-        torch.randn(shape, dtype=torch.float32, device=device, generator=generator) * 0.5
-    ).to(torch.bfloat16)
+    return (torch.randn(shape, dtype=torch.float32, device=device, generator=generator) * 0.5).to(
+        torch.bfloat16
+    )
 
 
 def prepare_data(**kwargs: Any) -> dict[str, Any]:
@@ -1649,20 +1823,13 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
     generator = torch.Generator(device=device)
     generator.manual_seed(cfg.seed)
     a_log, dt_bias = _gate_parameters(cfg, device=device, generator=generator)
-    vector_shape = (
-        cfg.batch_size,
-        cfg.seq_len,
-        cfg.num_heads,
-        cfg.key_head_dim,
-    )
+    vector_shape = (cfg.batch_size, cfg.seq_len, cfg.num_heads, cfg.key_head_dim)
     q = _randn_bf16(vector_shape, device=device, generator=generator)
     k = _randn_bf16(vector_shape, device=device, generator=generator)
     v = _randn_bf16(vector_shape, device=device, generator=generator)
     g = _randn_bf16(vector_shape, device=device, generator=generator)
     beta = _randn_bf16(
-        (cfg.batch_size, cfg.seq_len, cfg.num_heads),
-        device=device,
-        generator=generator,
+        (cfg.batch_size, cfg.seq_len, cfg.num_heads), device=device, generator=generator
     )
     out = torch.empty_like(v)
     tensors = {"q": q, "k": k, "v": v, "g": g, "out": out}
@@ -1708,7 +1875,9 @@ def _assert_sm100() -> None:
         raise SkipTest("CUDA is required for agent-evolved KDA forward")
     capability = torch.cuda.get_device_capability()
     if capability[0] != 10:
-        raise SkipTest(f"agent-evolved KDA forward requires compute capability 10.x, got {capability}")
+        raise SkipTest(
+            f"agent-evolved KDA forward requires compute capability 10.x, got {capability}"
+        )
 
 
 @contextmanager
@@ -1765,7 +1934,9 @@ def check_correctness(outputs: dict[str, Any], **kwargs: Any) -> None:
             raise AssertionError(f"{name} output contains non-finite values")
     if not torch.equal(first, actual):
         max_abs = float((first.float() - actual.float()).abs().max())
-        raise AssertionError(f"identical launches are not exactly repeatable; max abs diff={max_abs}")
+        raise AssertionError(
+            f"identical launches are not exactly repeatable; max abs diff={max_abs}"
+        )
     torch.testing.assert_close(actual, reference, atol=5e-2, rtol=5e-2)
     diff_rms = torch.sqrt(torch.mean((actual.float() - reference.float()).square()))
     reference_rms = torch.sqrt(torch.mean(reference.float().square()))
@@ -1794,10 +1965,7 @@ def run_test(**kwargs: Any) -> None:
 
     reference = _run_fla_reference(case)
     torch.cuda.synchronize()
-    check_correctness(
-        {"first": first, "actual": actual, "reference": reference},
-        **kwargs,
-    )
+    check_correctness({"first": first, "actual": actual, "reference": reference}, **kwargs)
 
 
 def prepare_bench(**kwargs: Any):

--- a/tirx_kernels/basic/allgather_gemm.py
+++ b/tirx_kernels/basic/allgather_gemm.py
@@ -982,8 +982,7 @@ def _make_device_kernel():
     )(test_mma_ss_tma_2sm_persistent)
 
 
-KERNEL_META = {"name": "allgather_gemm", "category": "basic", "compute_capability": 10}
-
+KERNEL_META = {"name": "allgather_gemm", "category": "basic", "runtime_cuda_archs": ["sm_100a"]}
 CONFIGS = make_configs(ALLGATHER_GEMM_MODEL_SHAPES)
 
 

--- a/tirx_kernels/basic/fp16_bf16_gemm.py
+++ b/tirx_kernels/basic/fp16_bf16_gemm.py
@@ -647,7 +647,11 @@ def make_kernel(dtype: str, M: int, N: int, Kdim: int):
     return _make_device_kernel(dtype, M, N, Kdim).func
 
 
-KERNEL_META = {"name": "fp16_bf16_gemm", "category": "basic", "compute_capability": 10}
+KERNEL_META = {
+    "name": "fp16_bf16_gemm",
+    "category": "basic",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+}
 CONFIGS = [
     {"dtype": d, "M": s, "N": s, "K": s, "label": f"{d}_{s}x{s}x{s}"}
     for d in ["fp16", "bf16"]

--- a/tirx_kernels/basic/gemm_reduce_scatter.py
+++ b/tirx_kernels/basic/gemm_reduce_scatter.py
@@ -652,9 +652,7 @@ def _make_device_kernel(config: GemmRSConfig, *, chain_dispatch: bool = False):
         mma_role = specialization.role("mma", [8, 9], regs=None, when=cbx == 0)
         specialization.role("idle", [10], regs=None)
         tma_scheduler_role = specialization.role("tma_scheduler", [11], regs=None)
-        producer_regs = specialization.register_scope(
-            "producer_regs", warps=range(8, 12), regs=56
-        )
+        producer_regs = specialization.register_scope("producer_regs", warps=range(8, 12), regs=56)
         consumer_regs = specialization.register_scope("consumer_regs", warps=range(8), regs=224)
 
         def fetch_next():
@@ -993,7 +991,11 @@ def build_kernel(config: GemmRSConfig | None = None) -> tvm.IRModule:
     return tvm.IRModule({FUSED_DEVICE_ENTRYPOINT: device.func})
 
 
-KERNEL_META = {"name": "gemm_reduce_scatter", "category": "basic", "compute_capability": 10}
+KERNEL_META = {
+    "name": "gemm_reduce_scatter",
+    "category": "basic",
+    "runtime_cuda_archs": ["sm_100a"],
+}
 _RELAUNCH_COUNT = 20
 
 CONFIGS = make_configs(GEMM_RS_MODEL_SHAPES)

--- a/tirx_kernels/basic/nvfp4_gemm.py
+++ b/tirx_kernels/basic/nvfp4_gemm.py
@@ -989,7 +989,22 @@ class _Runner:
         self.lib(*[descriptor.ptr for descriptor in self._maps], alpha.view(-1))
 
 
-KERNEL_META = {"name": "nvfp4_gemm", "category": "basic", "compute_capability": 10}
+KERNEL_META = {
+    "name": "nvfp4_gemm",
+    "category": "basic",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 CONFIGS = [
     {"M": s, "N": s, "K": s, "label": f"{s}x{s}x{s}"} for s in [1024, 2048, 4096, 8192, 16384]
 ]

--- a/tirx_kernels/basic/rmsnorm.py
+++ b/tirx_kernels/basic/rmsnorm.py
@@ -28,7 +28,22 @@ def prepare_data(batch_size, dim):
     )
 
 
-KERNEL_META = {"name": "rmsnorm", "category": "basic", "compute_capability": 10}
+KERNEL_META = {
+    "name": "rmsnorm",
+    "category": "basic",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 CONFIGS = [
     {"hidden_size": hs, "batch_size": bs, "label": f"hs{hs}_bs{bs}"}
     for hs in [128, 4096, 5120, 8192]

--- a/tirx_kernels/bench/__main__.py
+++ b/tirx_kernels/bench/__main__.py
@@ -366,7 +366,7 @@ def main():
         default=None,
         help="Write JSON results to this file instead of stdout",
     )
-    parser.add_argument("--cc", type=int, default=None, help="Compute capability filter")
+    parser.add_argument("--arch", type=str, default=None, help="Exact CUDA architecture filter")
     parser.add_argument(
         "--warmup",
         type=int,
@@ -444,16 +444,17 @@ def main():
         except KeyError:
             print(f"ERROR: kernel '{args.kernel}' not found.", file=sys.stderr)
             sys.exit(1)
-        if args.cc is not None and mod.KERNEL_META.get("compute_capability") != args.cc:
+        runtime_cuda_archs = tuple(mod.KERNEL_META.get("runtime_cuda_archs", ()))
+        if args.arch is not None and args.arch not in runtime_cuda_archs:
             print(
-                f"ERROR: kernel '{args.kernel}' compute_capability="
-                f"{mod.KERNEL_META.get('compute_capability')} != filter {args.cc}",
+                f"ERROR: kernel '{args.kernel}' runtime_cuda_archs={runtime_cuda_archs!r} "
+                f"does not include filter {args.arch!r}",
                 file=sys.stderr,
             )
             sys.exit(1)
         all_kernels = {args.kernel: mod}
     else:
-        all_kernels = discover_kernels(min_compute_capability=args.cc)
+        all_kernels = discover_kernels(cuda_arch=args.arch)
 
     # Each kernel's run_bench() manages its own Proton session via bench(timer=...).
     # No global proton session needed.

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -15,7 +15,11 @@ replace the direct verdict. The same flag exists on
 registered kernel has one file. Files with `default_suite: true` select one to
 three representative single-GPU rows with `default: true`; curated three-row
 files label them `small`, `medium`, and `large`. The current default roster is
-191 rows across 65 device kernels.
+263 rows across 90 device kernels: 260 rows from 89 kernels validated on
+`sm_100a`, `sm_103a`, and `sm_107a`, plus 3 rows from the `sm_107a`-only Rubin
+BMM. Thus an SM107 run selects all 263 rows, while SM100 and SM103 runs retain
+the 260-row subset.
+GPU runs retain only rows registered for the pool's exact architecture.
 
 With no `--workloads`, the suite writes the selected rows to
 `.bench-suite/workloads.generated.yaml`. Inspect that file before freezing a
@@ -25,7 +29,9 @@ baseline.
 python -m tirx_kernels.bench_suite --check-imports
 ```
 
-The import check resolves selected kernels without compiling or using a GPU.
+The import check resolves every selected kernel across architectures without
+compiling or using a GPU; execution filters the default roster to the exact GPU
+architecture.
 
 ## Environment
 
@@ -92,9 +98,10 @@ otherwise incomparable rows fail. A complete matrix discovers crossings;
 after that, rerun only configs that are missing, changed, failed, or polluted.
 An explicit workload file or filter records a targeted selection, so the gate
 requires exactly those after rows while still requiring the immutable before
-baseline to contain the complete 191-row roster. Do not rerun clean passing rows
-or splice selected samples into the baseline. Byte-identical CUDA, fatbin, and
-final SASS already establish implementation alignment.
+baseline to contain the complete roster for the run's exact CUDA architecture.
+Do not rerun clean passing rows or splice selected samples into the baseline.
+Byte-identical CUDA, fatbin, and final SASS already establish implementation
+alignment.
 
 ## Run a same-GPU paired A/B
 

--- a/tirx_kernels/bench_suite/ab.py
+++ b/tirx_kernels/bench_suite/ab.py
@@ -407,6 +407,30 @@ def run_ab(
         util_threshold=util_threshold,
         mem_threshold=mem_threshold,
     )
+    from tirx_kernels.bench_suite.run import (
+        gpu_compile_profile,
+        partition_workloads_by_arch,
+        validate_workload_archs,
+    )
+
+    cuda_arch = gpu_compile_profile({index for index, _uuid in gpu_rows})["cuda_arch"]
+    selection = copy.deepcopy(selection)
+    if selection["mode"] == "default":
+        workloads, incompatible_workloads = partition_workloads_by_arch(workloads, cuda_arch)
+        if not workloads:
+            raise ValueError(f"default roster has no workloads for {cuda_arch}")
+        if incompatible_workloads:
+            incompatible_kernels = {workload["kernel"] for workload in incompatible_workloads}
+            print(
+                f"[bench-suite ab] selected {len(workloads)} {cuda_arch} default workload(s); "
+                f"excluded {len(incompatible_workloads)} workload(s) across "
+                f"{len(incompatible_kernels)} incompatible kernel(s)"
+            )
+    else:
+        validate_workload_archs(workloads, cuda_arch)
+    selection["cuda_arch"] = cuda_arch
+    selection["keys"] = [[workload["kernel"], workload["config"]] for workload in workloads]
+
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
     raw_campaign_name = label or f"{before_revision[:8]}-{after_revision[:8]}"
     campaign_name = "".join(

--- a/tirx_kernels/bench_suite/config/cudnn/cudnn_sm100_bsa_backward_blk128.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/cudnn_sm100_bsa_backward_blk128.yaml
@@ -1,0 +1,16 @@
+kernel: cudnn_sm100_bsa_backward_blk128
+selection_rationale: The curated rows span the smallest D64 direct launch, a production multi-head D128 direct case, and the largest multi-group Q workload; all other required porting-gate rows remain explicitly benchable.
+configs:
+  - {config: p00_b1_h1_d64_sq128_skv4096_kv16, default: true, selection_role: small}
+  - {config: p01_b1_h1_d128_sq512_skv4096_kv16, default: false}
+  - {config: p02_b2_h8_d128_sq4096_skv8191_kv32, default: true, selection_role: medium}
+  - {config: p03_b1_h8_d64_sq4097_skv8191_maxkv32_var, default: false}
+  - {config: p04_b2_h4_d128_sq4097_skv8191_maxkv32_empty, default: false}
+  - {config: p05_b1_h4_d64_sq1024_skv32768_kv128, default: false}
+  - {config: p06_b1_h8_d128_sq2048_skv65536_kv256, default: false}
+  - {config: p07_b1_h4_d128_sq49152_skv8192_kv32_qb384_g1, default: false}
+  - {config: p08_b1_h4_d128_sq49153_skv8191_maxkv32_var_qb385_g2, default: false}
+  - {config: p09_b1_h2_d64_sq262144_skv8192_kv32_qb2048_g4, default: false}
+  - {config: p10_b1_h1_d128_sq524288_skv8192_maxkv32_var_qb4096_g16_i64kv, default: false}
+  - {config: p11_b1_h2_d128_sq524288_skv8192_kv32_qb4096_g8, default: true, selection_role: large}
+  - {config: p12_b1_h4_d128_sq8192_skv4096_kv16_bshd_scale0125, default: false}

--- a/tirx_kernels/bench_suite/config/cudnn/dsa/cudnn_sm100_dsa_sparse_attention_backward.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/dsa/cudnn_sm100_dsa_sparse_attention_backward.yaml
@@ -1,23 +1,41 @@
-# The upstream benchmark sweep (benchmark/dsa/benchmark_dsa_sparse_attention_backward.py:
-# seqlens x topks, seqlen_kv == seqlen_q, bf16, sink on, full-length topk_length)
-# mirrored onto both compiled head-dim programs. This 16-row matrix is the
-# performance gate's required set.
+# Keep this kernel available for targeted development, but do not put it in the
+# default benchmark or registry-correctness roster. Its pinned cuDNN-frontend
+# reference, FlashAttentionDSABackwardSm100, has a deterministic device-memory
+# bug on sm_107a (CUDA 13.4 / PTX 9.4) that depends on prior kernels compiled in
+# the same process. The minimal known failing order is the three blockscaled
+# dGEMM/dGLU defaults, the first two non-blockscaled dGEMM/dGLU defaults, then
+# the three DSA defaults below. The final d576_h32_bf16_sq8192_t512_len launch
+# fails inside the external CuTe kernel; all four TIRx stages have synchronized
+# successfully before that reference launch.
+#
+# CUDA_LAUNCH_BLOCKING=1 attributes the failure to the call through
+# _interface_sm100.py:218. Compute Sanitizer reports 16 invalid 8-byte global
+# reads at FlashAttentionDSABackwardSm100+0x1e80: threads 560..575 of block 8191
+# read consecutively beyond an 807,403,520-byte allocation, beginning exactly
+# at its end. Running this DSA case alone can therefore look green merely
+# because the allocator/module history differs. Do not re-enable defaults
+# until the upstream reference is fixed and both the ordered reproducer and
+# Compute Sanitizer pass in one process.
+#
+# The full upstream benchmark sweep remains listed for explicit targeted runs:
+# seqlens x topks, seqlen_kv == seqlen_q, bf16, sink on, full-length topk_length,
+# mirrored onto both compiled head-dim programs.
 kernel: cudnn_sm100_dsa_sparse_attention_backward
-selection_rationale: d512/h64 and d576/h32 are separately compiled programs with different TMEM alias maps, tail MMAs and barrier assignments, so the defaults pair the source benchmark's lightest and heaviest d512 shapes with a mid-sweep d576 shape; the full 16-row matrix is that sweep on both programs and is what the port gate requires.
+default_suite: false
 configs:
-  - {config: d512_h64_bf16_sq4096_t128_len, default: true, selection_role: small}
+  - {config: d512_h64_bf16_sq4096_t128_len, default: false}
   - {config: d512_h64_bf16_sq4096_t512_len, default: false}
   - {config: d512_h64_bf16_sq4096_t1024_len, default: false}
   - {config: d512_h64_bf16_sq4096_t2048_len, default: false}
   - {config: d512_h64_bf16_sq8192_t128_len, default: false}
   - {config: d512_h64_bf16_sq8192_t512_len, default: false}
   - {config: d512_h64_bf16_sq8192_t1024_len, default: false}
-  - {config: d512_h64_bf16_sq8192_t2048_len, default: true, selection_role: large}
+  - {config: d512_h64_bf16_sq8192_t2048_len, default: false}
   - {config: d576_h32_bf16_sq4096_t128_len, default: false}
   - {config: d576_h32_bf16_sq4096_t512_len, default: false}
   - {config: d576_h32_bf16_sq4096_t1024_len, default: false}
   - {config: d576_h32_bf16_sq4096_t2048_len, default: false}
   - {config: d576_h32_bf16_sq8192_t128_len, default: false}
-  - {config: d576_h32_bf16_sq8192_t512_len, default: true, selection_role: medium}
+  - {config: d576_h32_bf16_sq8192_t512_len, default: false}
   - {config: d576_h32_bf16_sq8192_t1024_len, default: false}
   - {config: d576_h32_bf16_sq8192_t2048_len, default: false}

--- a/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn_bprop_f16.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn_bprop_f16.yaml
@@ -1,0 +1,25 @@
+# Complete performance-path matrix for the cuDNN Frontend GDN backward port.
+kernel: cudnn_sm100_gdn_bprop_f16
+selection_rationale: The selected defaults cover an underfilled small launch, the representative 8192-token path, and the largest upstream multi-batch sweep point; the full matrix additionally covers FP16, ragged tails with a zero-length sequence, grouped query/value heads, safe gate, beta sigmoid, state I/O, dynamic scheduling, both prologue ordering modes, and the upstream batch and sequence-length sweeps at 64 heads.
+configs:
+  - {config: perf_basic_b1_s2048_h16, default: true, selection_role: small}
+  - {config: perf_basic_b1_s8192_h16, default: true, selection_role: medium}
+  - {config: perf_fp16_b1_s8192_h16, default: false}
+  - {config: perf_ragged_b3_h16, default: false}
+  - {config: perf_gqa_b1_s8192_hq64_hk16_hv16, default: false}
+  - {config: perf_gva_b1_s8192_hq16_hk16_hv64, default: false}
+  - {config: perf_safe_b1_s8192_h16, default: false}
+  - {config: perf_beta_b1_s8192_h16, default: false}
+  - {config: perf_state_b1_s8192_h16, default: false}
+  - {config: perf_dynamic_b4_s2048_h64, default: false}
+  - {config: perf_order_scratch_b4_s2048_h64, default: false}
+  - {config: perf_order_generate_b4_s2048_h64, default: false}
+  - {config: perf_b4_s2048_h64, default: false}
+  - {config: perf_b4_s4096_h64, default: false}
+  - {config: perf_b4_s8192_h64, default: false}
+  - {config: perf_b4_s16384_h64, default: false}
+  - {config: perf_b4_s32768_h64, default: true, selection_role: large}
+  - {config: perf_b1_s8192_h64, default: false}
+  - {config: perf_b2_s8192_h64, default: false}
+  - {config: perf_b8_s8192_h64, default: false}
+  - {config: perf_b16_s8192_h64, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/gemm/bmm_fp8_rubin.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/gemm/bmm_fp8_rubin.yaml
@@ -1,0 +1,52 @@
+kernel: bmm_fp8_rubin
+default_suite: true
+selection_rationale: The selected rows grow total BxMxNxK work while covering both FP8 input formats, all three output dtypes, 2x1 and 2x2 clusters, and both M-major and N-major raster orders.
+configs:
+  - {config: bench_t0_e4m3_bf16_b1_m256_n10304_k2688, default: false}
+  - {config: bench_t0_e4m3_fp16_b1_m256_n10304_k2688, default: false}
+  - {config: bench_t0_e4m3_fp32_b1_m256_n10304_k2688, default: false}
+  - {config: bench_t0_e5m2_bf16_b1_m256_n10304_k2688, default: false}
+  - {config: bench_t0_e5m2_fp16_b1_m256_n10304_k2688, default: false}
+  - {config: bench_t0_e5m2_fp32_b1_m256_n10304_k2688, default: false}
+  - {config: bench_t1_e4m3_bf16_b4_m256_n4096_k2688, default: false}
+  - {config: bench_t1_e4m3_fp16_b4_m256_n4096_k2688, default: false}
+  - {config: bench_t1_e4m3_fp32_b4_m256_n4096_k2688, default: false}
+  - {config: bench_t1_e5m2_bf16_b4_m256_n4096_k2688, default: false}
+  - {config: bench_t1_e5m2_fp16_b4_m256_n4096_k2688, default: false}
+  - {config: bench_t1_e5m2_fp32_b4_m256_n4096_k2688, default: false}
+  - {config: bench_t2_e4m3_bf16_b1_m512_n4096_k2720, default: true, selection_role: small}
+  - {config: bench_t2_e4m3_fp16_b1_m512_n4096_k2720, default: false}
+  - {config: bench_t2_e4m3_fp32_b1_m512_n4096_k2720, default: false}
+  - {config: bench_t2_e5m2_bf16_b1_m512_n4096_k2720, default: false}
+  - {config: bench_t2_e5m2_fp16_b1_m512_n4096_k2720, default: false}
+  - {config: bench_t2_e5m2_fp32_b1_m512_n4096_k2720, default: false}
+  - {config: bench_t3_e4m3_bf16_b2_m512_n4096_k2688, default: false}
+  - {config: bench_t3_e4m3_fp16_b2_m512_n4096_k2688, default: false}
+  - {config: bench_t3_e4m3_fp32_b2_m512_n4096_k2688, default: false}
+  - {config: bench_t3_e5m2_bf16_b2_m512_n4096_k2688, default: false}
+  - {config: bench_t3_e5m2_fp16_b2_m512_n4096_k2688, default: false}
+  - {config: bench_t3_e5m2_fp32_b2_m512_n4096_k2688, default: false}
+  - {config: bench_t4_e4m3_bf16_b1_m1024_n4096_k3072, default: false}
+  - {config: bench_t4_e4m3_fp16_b1_m1024_n4096_k3072, default: false}
+  - {config: bench_t4_e4m3_fp32_b1_m1024_n4096_k3072, default: false}
+  - {config: bench_t4_e5m2_bf16_b1_m1024_n4096_k3072, default: false}
+  - {config: bench_t4_e5m2_fp16_b1_m1024_n4096_k3072, default: true, selection_role: medium}
+  - {config: bench_t4_e5m2_fp32_b1_m1024_n4096_k3072, default: false}
+  - {config: bench_t5_e4m3_bf16_b1_m2048_n4096_k3072, default: false}
+  - {config: bench_t5_e4m3_fp16_b1_m2048_n4096_k3072, default: false}
+  - {config: bench_t5_e4m3_fp32_b1_m2048_n4096_k3072, default: false}
+  - {config: bench_t5_e5m2_bf16_b1_m2048_n4096_k3072, default: false}
+  - {config: bench_t5_e5m2_fp16_b1_m2048_n4096_k3072, default: false}
+  - {config: bench_t5_e5m2_fp32_b1_m2048_n4096_k3072, default: false}
+  - {config: bench_t6_e4m3_bf16_b1_m4096_n1024_k3072, default: false}
+  - {config: bench_t6_e4m3_fp16_b1_m4096_n1024_k3072, default: false}
+  - {config: bench_t6_e4m3_fp32_b1_m4096_n1024_k3072, default: false}
+  - {config: bench_t6_e5m2_bf16_b1_m4096_n1024_k3072, default: false}
+  - {config: bench_t6_e5m2_fp16_b1_m4096_n1024_k3072, default: false}
+  - {config: bench_t6_e5m2_fp32_b1_m4096_n1024_k3072, default: false}
+  - {config: bench_t7_e4m3_bf16_b2_m4096_n1024_k3072, default: false}
+  - {config: bench_t7_e4m3_fp16_b2_m4096_n1024_k3072, default: false}
+  - {config: bench_t7_e4m3_fp32_b2_m4096_n1024_k3072, default: true, selection_role: large}
+  - {config: bench_t7_e5m2_bf16_b2_m4096_n1024_k3072, default: false}
+  - {config: bench_t7_e5m2_fp16_b2_m4096_n1024_k3072, default: false}
+  - {config: bench_t7_e5m2_fp32_b2_m4096_n1024_k3072, default: false}

--- a/tirx_kernels/bench_suite/config/flashmla/flash_mla_sparse_fwd.yaml
+++ b/tirx_kernels/bench_suite/config/flashmla/flash_mla_sparse_fwd.yaml
@@ -1,3 +1,6 @@
+# Dispatcher alias over the three sparse_flashmla_prefill_* TIRx device kernels,
+# which own the default measured rows. Keep this alias explicit-only to avoid
+# measuring the same device kernels twice; external FlashMLA remains the reference.
 kernel: flash_mla_sparse_fwd
 default_suite: false
 configs:

--- a/tirx_kernels/bench_suite/ratio_diff.py
+++ b/tirx_kernels/bench_suite/ratio_diff.py
@@ -77,11 +77,18 @@ def _key(row: dict, *, location: str) -> tuple[str, str]:
     return kernel, config
 
 
-def _expected_keys() -> tuple[set[tuple[str, str]], list[str]]:
+def _expected_keys(cuda_arch: str | None = None) -> tuple[set[tuple[str, str]], list[str]]:
     selected: list[tuple[str, str]] = []
     errors: list[str] = []
     try:
         workloads = _load_config_dir()
+        if cuda_arch is not None:
+            try:
+                from tirx_kernels.bench_suite.run import partition_workloads_by_arch
+            except ModuleNotFoundError:  # Support direct script execution.
+                from run import partition_workloads_by_arch
+
+            workloads, _incompatible = partition_workloads_by_arch(workloads, cuda_arch)
     except Exception as error:
         return set(), [f"default workload discovery failed: {error}"]
     for index, workload in enumerate(workloads):
@@ -219,7 +226,11 @@ def _records(payload: Any, label: str) -> tuple[dict[tuple[str, str], list[dict]
 
 
 def _validate_record_set(
-    records: dict[tuple[str, str], list[dict]], expected: set[tuple[str, str]], label: str
+    records: dict[tuple[str, str], list[dict]],
+    expected: set[tuple[str, str]],
+    label: str,
+    *,
+    allow_unexpected: bool = False,
 ) -> list[str]:
     errors: list[str] = []
     for kernel, config in sorted(expected):
@@ -227,8 +238,9 @@ def _validate_record_set(
         if len(matches) != 1:
             detail = "missing" if not matches else f"duplicate ({len(matches)})"
             errors.append(f"{kernel}/{config}: {label} result is {detail}")
-    for kernel, config in sorted(set(records) - expected):
-        errors.append(f"{kernel}/{config}: {label} result is unexpected")
+    if not allow_unexpected:
+        for kernel, config in sorted(set(records) - expected):
+            errors.append(f"{kernel}/{config}: {label} result is unexpected")
     return errors
 
 
@@ -396,12 +408,7 @@ def _compare_run_provenance(
         errors.append("provenance: references_enabled differs between before and after")
     else:
         errors.extend(
-            _compare_mapping(
-                before,
-                after,
-                "baselines",
-                allow_empty=not before_references,
-            )
+            _compare_mapping(before, after, "baselines", allow_empty=not before_references)
         )
 
     before_pipeline = before.get("pipeline")
@@ -513,11 +520,23 @@ def build_report(
     before_payload, before_label = _load_payload(baseline_path)
     after_payload, after_label = _load_payload(current)
     default_keys: set[tuple[str, str]] = set()
+    cuda_arch: str | None = None
     if paired:
         expected, failures = _paired_expected_keys(before_payload, after_payload)
         selection_mode = "paired"
     else:
-        default_keys, failures = _expected_keys()
+        selection = after_payload.get("selection")
+        raw_cuda_arch = selection.get("cuda_arch") if isinstance(selection, dict) else None
+        selection_arch_errors: list[str] = []
+        if raw_cuda_arch is not None:
+            if not isinstance(raw_cuda_arch, str) or not raw_cuda_arch:
+                selection_arch_errors.append(
+                    "after: selection.cuda_arch must be a non-empty string"
+                )
+            else:
+                cuda_arch = raw_cuda_arch
+        default_keys, failures = _expected_keys(cuda_arch)
+        failures.extend(selection_arch_errors)
         expected, selection_mode, selection_errors = _selected_after_keys(
             after_payload, default_keys
         )
@@ -527,7 +546,12 @@ def build_report(
     failures.extend(before_errors)
     failures.extend(after_errors)
     failures.extend(
-        _validate_record_set(before_records, expected if paired else default_keys, "before")
+        _validate_record_set(
+            before_records,
+            expected if paired else default_keys,
+            "before",
+            allow_unexpected=not paired and cuda_arch is not None,
+        )
     )
     failures.extend(_validate_record_set(after_records, expected, "after"))
     failures.extend(

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -648,6 +648,13 @@ def gpu_compile_profile(indices: set[str]) -> dict:
             core_count = int(pynvml.nvmlDeviceGetNumGpuCores(handle))
             if compute_capability == (10, 0):
                 cores_per_sm = 128
+                cuda_arch = "sm_100a"
+            elif compute_capability == (10, 3):
+                cores_per_sm = 128
+                cuda_arch = "sm_103a"
+            elif compute_capability == (10, 7):
+                cores_per_sm = 128
+                cuda_arch = "sm_107a"
             else:
                 raise ValueError(
                     f"GPU {index} {name!r} has unsupported compile profile "
@@ -662,7 +669,7 @@ def gpu_compile_profile(indices: set[str]) -> dict:
                 {
                     "name": name,
                     "compute_capability": list(compute_capability),
-                    "cuda_arch": "sm_100a",
+                    "cuda_arch": cuda_arch,
                     "num_sms": core_count // cores_per_sm,
                 }
             )
@@ -679,6 +686,34 @@ def gpu_compile_profile(indices: set[str]) -> dict:
             f"one profile per prepared child, got {profiles}"
         )
     return first
+
+
+def partition_workloads_by_arch(
+    workloads: list[dict], cuda_arch: str
+) -> tuple[list[dict], list[dict]]:
+    """Partition workloads by an exact registered CUDA architecture."""
+    records = kernel_index(strict=True)
+    supported: list[dict] = []
+    incompatible: list[dict] = []
+    for workload in workloads:
+        destination = (
+            supported
+            if cuda_arch in records[workload["kernel"]].runtime_cuda_archs
+            else incompatible
+        )
+        destination.append(workload)
+    return supported, incompatible
+
+
+def validate_workload_archs(workloads: list[dict], cuda_arch: str) -> None:
+    """Reject workloads that are not registered for the selected exact architecture."""
+    _supported, incompatible_workloads = partition_workloads_by_arch(workloads, cuda_arch)
+    incompatible = sorted({workload["kernel"] for workload in incompatible_workloads})
+    if incompatible:
+        raise ValueError(
+            f"selected GPU architecture {cuda_arch} is unsupported by workload kernel(s): "
+            + ", ".join(incompatible)
+        )
 
 
 # ── Workload execution ───────────────────────────────────────────────────────
@@ -2419,6 +2454,36 @@ def main() -> None:
             print(f"[bench-suite]   gpu {idx}: {err}", file=sys.stderr)
         sys.exit(1)
 
+    pool = GpuPool(
+        allowed=usable, util_threshold=args.util_threshold, mem_threshold=args.mem_threshold
+    )
+    n_gpus = len(usable)
+    compile_profile = gpu_compile_profile(usable)
+    cuda_arch = compile_profile["cuda_arch"]
+    if selection["mode"] == "default":
+        workloads, incompatible_workloads = partition_workloads_by_arch(workloads, cuda_arch)
+        if not workloads:
+            print(
+                f"[bench-suite] default roster has no workloads for {cuda_arch}.", file=sys.stderr
+            )
+            sys.exit(2)
+        if incompatible_workloads:
+            incompatible_kernels = {workload["kernel"] for workload in incompatible_workloads}
+            print(
+                f"[bench-suite] selected {len(workloads)} {cuda_arch} default workload(s); "
+                f"excluded {len(incompatible_workloads)} workload(s) across "
+                f"{len(incompatible_kernels)} incompatible kernel(s)",
+                flush=True,
+            )
+    else:
+        try:
+            validate_workload_archs(workloads, cuda_arch)
+        except ValueError as error:
+            print(f"[bench-suite] incompatible workload architecture: {error}", file=sys.stderr)
+            sys.exit(2)
+    selection["cuda_arch"] = cuda_arch
+    selection["keys"] = [[workload["kernel"], workload["config"]] for workload in workloads]
+
     max_required_gpus = max(workload.get("num_gpus", 1) for workload in workloads)
     if max_required_gpus > len(usable):
         print(
@@ -2427,12 +2492,6 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(2)
-
-    pool = GpuPool(
-        allowed=usable, util_threshold=args.util_threshold, mem_threshold=args.mem_threshold
-    )
-    n_gpus = len(usable)
-    compile_profile = gpu_compile_profile(usable)
     _repo_git = collect_repo_git()
     label = args.label or _repo_git.get("tirx-kernels") or _repo_git.get("tir") or "local"
     agg_note = (

--- a/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py
@@ -355,7 +355,18 @@ def _benchmark_configs():
 KERNEL_META = {
     "name": "cudnn_sm100_dense_blockscaled_gemm_persistent_amax",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _correctness_configs()

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/__init__.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/data.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/data.py
@@ -1,0 +1,696 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Inputs, direct launch wiring, and sparse analytic validation for BSA backward."""
+
+import math
+
+import torch
+
+from tirx_kernels.cudnn._reference import load_reference_module
+
+from . import spec
+
+_REDZONE_ELEMENTS = 256
+_REDZONE_F32 = 12345.25
+_REDZONE_BF16 = -77.0
+_LOG2_E = math.log2(math.e)
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_256B = 2
+_TOLERANCES = {
+    "sum_odo": (2**-18, 2**-18),
+    "scaled_lse": (2**-15, 2**-15),
+    "dq_acc": (3e-2, 3e-2),
+    "dk_acc": (2**-7, 2**-7),
+    "dv_acc": (3e-2, 3e-2),
+    "dq": (2**-9, 2**-9),
+    "dk": (2**-9, 2**-9),
+    "dv": (3e-2, 3e-2),
+}
+
+
+def _oracle_tolerance(config, name):
+    if config["data_mode"] == "sharp_softmax":
+        sharp = {
+            "dq_acc": (3 / 16, 3 / 16),
+            "dq": (2**-5, 2**-5),
+            "dk": (2**-4, 2**-4),
+            "dv": (2**-6, 2**-6),
+        }
+        if name in sharp:
+            return sharp[name]
+    return _TOLERANCES[name]
+
+
+_SOURCE_PAIR_TOLERANCES = {"dq": (2**-10, 2**-7), "dk": (2**-10, 2**-7), "dv": (2**-10, 2**-7)}
+
+
+class _AlignedTensorMap:
+    """Host storage for one 64-byte-aligned 128-byte TensorMap payload."""
+
+    def __init__(self):
+        import ctypes
+
+        self._storage = ctypes.create_string_buffer(128 + 64)
+        base = ctypes.addressof(self._storage)
+        self.ptr = ctypes.c_void_p((base + 63) & ~63)
+
+
+def _encode_tensormap(
+    tensor, dtype, global_dims, global_strides, box_dims, *, swizzle=_TMA_SWIZZLE_128B
+):
+    import ctypes
+
+    import tvm
+
+    rank = len(global_dims)
+    descriptor = _AlignedTensorMap()
+    tvm.get_global_func("runtime.cuTensorMapEncodeTiled")(
+        descriptor.ptr,
+        dtype,
+        rank,
+        ctypes.c_void_p(int(tensor.data_ptr())),
+        *global_dims,
+        *global_strides,
+        *box_dims,
+        *((1,) * rank),
+        0,
+        swizzle,
+        _TMA_L2_256B,
+        0,
+    )
+    return descriptor
+
+
+def _as_bhsd(tensor, config):
+    """Return a logical BHSD view while preserving the user's physical ABI."""
+    return tensor.transpose(1, 2) if config["tensor_layout"] == "bshd" else tensor
+
+
+def _build_tensor_maps(inputs, output, config):
+    """Encode rank-4 BF16 TensorMaps for the selected BHSD/BSHD ABI."""
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    head_dim = int(config["head_dim"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+
+    seq_axis, head_axis = (1, 2) if config["tensor_layout"] == "bshd" else (2, 1)
+
+    def tensor_map(tensor, seqlen, box_features):
+        element_size = tensor.element_size()
+        strides = tuple(
+            int(tensor.stride(axis) * element_size) for axis in (seq_axis, head_axis, 0)
+        )
+        return _encode_tensormap(
+            tensor,
+            "bfloat16",
+            (head_dim, seqlen, heads, batch),
+            strides,
+            (box_features, 128, 1, 1),
+            swizzle=3 if box_features == 64 else 2,
+        )
+
+    return {
+        "q": tensor_map(inputs["q"], seqlen_q, 64),
+        "k": tensor_map(inputs["k"], seqlen_kv, 64),
+        "v": tensor_map(inputs["v"], seqlen_kv, 64),
+        "do": tensor_map(inputs["do"], seqlen_q, 64),
+        "dv": tensor_map(output["dv"], seqlen_kv, head_dim // 2),
+        "dk": tensor_map(output["dk"], seqlen_kv, head_dim // 2),
+    }
+
+
+def _roundup128(value):
+    return (value + 127) // 128 * 128
+
+
+def _bucket_size(config, q_blocks):
+    explicit = config.get("bucket_size_blocks")
+    if explicit is not None and int(explicit) > 0:
+        return int(explicit)
+    if q_blocks >= 4096 and int(config["num_heads"]) <= 1:
+        return 256
+    return 512 if q_blocks >= 2048 else 384
+
+
+def _pattern_values(config):
+    maximum = int(config["kv_blocks"])
+    mode = config["block_count_mode"]
+    if mode == "fixed":
+        return (maximum,)
+    text = config.get("block_count_pattern")
+    if text is None:
+        return (0, 1, maximum) if mode == "variable_empty" else (1, max(1, maximum // 2), maximum)
+    values = []
+    for item in text.split(","):
+        item = item.strip()
+        if item == "max":
+            values.append(maximum)
+        elif item == "mid":
+            values.append(max(1, maximum // 2))
+        else:
+            values.append(int(item))
+    return tuple(values)
+
+
+def _make_metadata(config, *, q_blocks, kv_blocks, device):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    maximum = int(config["kv_blocks"])
+    if maximum > kv_blocks:
+        raise ValueError("kv_blocks exceeds the physical KV block count")
+
+    rows = batch * heads * q_blocks
+    row_ids = torch.arange(rows, dtype=torch.int64, device=device)
+    slots = torch.arange(maximum, dtype=torch.int64, device=device)
+    block_index = (row_ids[:, None] * 7 + slots[None, :]) % kv_blocks
+    if maximum and maximum < kv_blocks:
+        contains_tail = (block_index == kv_blocks - 1).any(dim=1)
+        block_index[~contains_tail, -1] = kv_blocks - 1
+    if q_blocks == 3 and maximum == 3 and kv_blocks == 4:
+        # c07 deliberately makes the four inverse-CSR task lengths 3/2/1/0.
+        block_index[:] = torch.tensor((0, 1, 2), dtype=torch.int64, device=device)
+    block_index = block_index.to(torch.int32).reshape(batch, heads, q_blocks, maximum)
+
+    values = _pattern_values(config)
+    if config["block_count_mode"] != "variable_empty" and 0 in values:
+        raise ValueError("zero block counts require block_count_mode='variable_empty'")
+    pattern_shift = (
+        1
+        if config["block_count_mode"] == "variable_empty" and any(value != 0 for value in values)
+        else 0
+    )
+    counts = torch.tensor(values, dtype=torch.int32, device=device)[
+        (row_ids + pattern_shift) % len(values)
+    ]
+    counts = counts.reshape(batch, heads, q_blocks).contiguous()
+    if config["block_count_mode"] == "fixed":
+        block_nums = None
+        block_sparse_num = maximum
+    else:
+        block_nums = counts
+        block_sparse_num = 0
+    return block_index.contiguous(), counts, block_nums, block_sparse_num
+
+
+def _strided_bhsd(generator, shape, *, use_i64):
+    batch, heads, seqlen, dim = shape
+    base = torch.randn(
+        batch * heads * seqlen * dim, generator=generator, dtype=torch.bfloat16, device="cuda"
+    )
+    base.mul_(0.125)
+    if not use_i64:
+        return base.reshape(shape)
+    if batch != 1 or heads != 1:
+        raise ValueError("the explicit Int64 KV-stride probe requires singleton batch and head")
+    # The pinned CuTeDSL source marks batch/head/sequence compact-dynamic and
+    # therefore rejects an artificial >INT32 stride on either singleton mode.
+    # Keep this case source-comparable; the flag still selects the special
+    # large-index configs, while every target byte address is formed in Int64.
+    return base.reshape(shape)
+
+
+def _guarded_tensor(shape, dtype, fill):
+    count = math.prod(shape)
+    storage = torch.full((count + 2 * _REDZONE_ELEMENTS,), fill, dtype=dtype, device="cuda")
+    tensor = storage[_REDZONE_ELEMENTS : _REDZONE_ELEMENTS + count].reshape(shape)
+    return tensor, storage
+
+
+def _workspace_layout(config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    head_dim = int(config["head_dim"])
+    q128 = _roundup128(int(config["seqlen_q"]))
+    k128 = _roundup128(int(config["seqlen_kv"]))
+    n = batch * heads
+    sizes = {
+        "sum_odo": n * q128,
+        "scaled_lse": n * q128,
+        "dq_acc": n * q128 * head_dim,
+        "dk_acc": n * k128 * head_dim,
+        "dv_acc": n * k128 * head_dim,
+    }
+    offsets = {}
+    cursor = 0
+    for name in ("sum_odo", "scaled_lse", "dq_acc", "dk_acc", "dv_acc"):
+        offsets[name] = cursor
+        cursor += sizes[name]
+    return q128, k128, sizes, offsets, cursor
+
+
+def _new_mutable_state(config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    head_dim = int(config["head_dim"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    q128, k128, sizes, offsets, total = _workspace_layout(config)
+    workspace, workspace_storage = _guarded_tensor((total,), torch.float32, _REDZONE_F32)
+    workspace.zero_()
+    q_shape = (
+        (batch, seqlen_q, heads, head_dim)
+        if config["tensor_layout"] == "bshd"
+        else (batch, heads, seqlen_q, head_dim)
+    )
+    kv_shape = (
+        (batch, seqlen_kv, heads, head_dim)
+        if config["tensor_layout"] == "bshd"
+        else (batch, heads, seqlen_kv, head_dim)
+    )
+    dq, dq_storage = _guarded_tensor(q_shape, torch.bfloat16, _REDZONE_BF16)
+    dk, dk_storage = _guarded_tensor(kv_shape, torch.bfloat16, _REDZONE_BF16)
+    dv, dv_storage = _guarded_tensor(kv_shape, torch.bfloat16, _REDZONE_BF16)
+    dq.fill_(float("nan"))
+    dk.zero_()
+    dv.zero_()
+    return {
+        "workspace": workspace,
+        "workspace_storage": workspace_storage,
+        "dq": dq,
+        "dk": dk,
+        "dv": dv,
+        "dq_storage": dq_storage,
+        "dk_storage": dk_storage,
+        "dv_storage": dv_storage,
+        "workspace_sizes": sizes,
+        "workspace_offsets": offsets,
+        "q8": q128,
+        "k8": k128,
+    }
+
+
+def _workspace_fields(state, config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    head_dim = int(config["head_dim"])
+    q128 = state["q8"]
+    k128 = state["k8"]
+    workspace = state["workspace"]
+    offsets = state["workspace_offsets"]
+    sizes = state["workspace_sizes"]
+
+    def field(name, shape):
+        start = offsets[name]
+        return workspace[start : start + sizes[name]].reshape(shape)
+
+    def striped(name, padded):
+        physical = field(name, (batch, heads, padded // 128, head_dim // 4, 128, 4))
+        return physical.permute(0, 1, 2, 4, 3, 5).reshape(batch, heads, padded, head_dim)
+
+    return {
+        "sum_odo": field("sum_odo", (batch, heads, q128)),
+        "scaled_lse": field("scaled_lse", (batch, heads, q128)),
+        "dq_acc": striped("dq_acc", q128),
+        "dv_acc": striped("dv_acc", k128),
+        "dk_acc": striped("dk_acc", k128),
+    }
+
+
+def prepare_data(**config):
+    if not torch.cuda.is_available():
+        import unittest
+
+        raise unittest.SkipTest("CUDA is required")
+    spec.validate_config(config)
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    head_dim = int(config["head_dim"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    q_blocks = (seqlen_q + 127) // 128
+    physical_kv_blocks = (seqlen_kv + 127) // 128
+    bucket_size = _bucket_size(config, q_blocks)
+    generator = torch.Generator(device="cuda").manual_seed(int(config["seed"]))
+
+    amplitude = 0.125
+    if config["data_mode"] == "cancellation":
+        amplitude = 0.5
+    elif config["data_mode"] == "sharp_softmax":
+        amplitude = 1.5
+
+    def random_bhsd(shape):
+        value = torch.randn(*shape, generator=generator, dtype=torch.bfloat16, device="cuda")
+        value.mul_(amplitude)
+        return value
+
+    q = random_bhsd((batch, heads, seqlen_q, head_dim))
+    k = _strided_bhsd(
+        generator, (batch, heads, seqlen_kv, head_dim), use_i64=bool(config["use_int64_kv_strides"])
+    )
+    v = _strided_bhsd(
+        generator, (batch, heads, seqlen_kv, head_dim), use_i64=bool(config["use_int64_kv_strides"])
+    )
+    k.mul_(amplitude / 0.125)
+    v.mul_(amplitude / 0.125)
+    do = random_bhsd((batch, heads, seqlen_q, head_dim))
+    if config["data_mode"] == "cancellation":
+        signs = torch.where(
+            torch.arange(head_dim, device="cuda") % 2 == 0,
+            torch.tensor(1.0, device="cuda"),
+            torch.tensor(-1.0, device="cuda"),
+        ).to(torch.bfloat16)
+        do.mul_(signs)
+
+    block_index, counts, block_nums, block_sparse_num = _make_metadata(
+        config, q_blocks=q_blocks, kv_blocks=physical_kv_blocks, device="cuda"
+    )
+    softmax_scale = (
+        1.0 / math.sqrt(head_dim)
+        if config["softmax_scale"] is None
+        else float(config["softmax_scale"])
+    )
+    interface = load_reference_module("cudnn.block_sparse_attention._interface")
+    use_bshd = config["tensor_layout"] == "bshd"
+    q_forward = q.transpose(1, 2).contiguous() if use_bshd else q
+    k_forward = k.transpose(1, 2).contiguous() if use_bshd else k
+    v_forward = v.transpose(1, 2).contiguous() if use_bshd else v
+    do_forward = do.transpose(1, 2).contiguous() if use_bshd else do
+    o_user, lse = interface.bsa_attn_fwd(
+        q_forward,
+        k_forward,
+        v_forward,
+        block_index,
+        block_sparse_num,
+        block_sizes=None,
+        q2k_block_nums=block_nums,
+        allow_empty_block_nums=config["block_count_mode"] == "variable_empty",
+        softmax_scale=softmax_scale,
+        pack_gqa=False,
+        return_lse=True,
+        layout=config["tensor_layout"],
+        kv_splits=1,
+    )
+    bucketed_offsets, bucketed_indices, num_q_groups, max_rows = interface._build_bucketed_k2q_csr(
+        block_index,
+        block_sparse_num,
+        physical_kv_blocks,
+        bucket_size_blocks=bucket_size,
+        q2k_block_nums=block_nums,
+    )
+    torch.cuda.synchronize()
+
+    tirx = _new_mutable_state(config)
+    source = _new_mutable_state(config)
+    inputs = {
+        "q": q_forward,
+        "k": k_forward,
+        "v": v_forward,
+        "do": do_forward,
+        "o": o_user,
+        "lse": lse,
+        "block_index": block_index,
+        "counts": counts,
+        "block_nums": block_nums,
+        "block_sparse_num": block_sparse_num,
+        "bucketed_offsets": bucketed_offsets,
+        "bucketed_indices": bucketed_indices,
+        "softmax_scale": softmax_scale,
+    }
+    return {
+        "config": dict(config),
+        "inputs": inputs,
+        "derived": {
+            "q_blocks": q_blocks,
+            "kv_blocks": physical_kv_blocks,
+            "bucket_size_blocks": bucket_size,
+            "num_q_groups": int(num_q_groups),
+            "max_k2q_rows_per_group": int(max_rows),
+            "tasks_per_group": physical_kv_blocks,
+        },
+        "tirx": tirx,
+        "source": source,
+        "oracle": None,
+    }
+
+
+def reset_mutable_state(state):
+    state["workspace"].zero_()
+    state["dq"].fill_(float("nan"))
+    state["dk"].zero_()
+    state["dv"].zero_()
+
+
+def tirx_launch(executables, data):
+    inputs = data["inputs"]
+    output = data["tirx"]
+    config = data["config"]
+    maps = _build_tensor_maps(inputs, output, config)
+    edge_stride = int(inputs["bucketed_indices"].shape[-1])
+    direct_dkv = int(data["derived"]["num_q_groups"]) == 1
+
+    def launch():
+        if not direct_dkv:
+            # Multi-group dK/dV use global FP32 bulk reductions. Host-side zeroing is
+            # part of the source launch contract and keeps every closure call
+            # deterministic, including repeated benchmark invocations.
+            output["workspace"][output["workspace_offsets"]["dk_acc"] :].zero_()
+        executables[0](
+            inputs["o"].reshape(-1),
+            inputs["do"].reshape(-1),
+            inputs["lse"].reshape(-1),
+            output["workspace"],
+        )
+        executables[1](
+            maps["q"].ptr,
+            maps["k"].ptr,
+            maps["v"].ptr,
+            maps["do"].ptr,
+            maps["dv"].ptr,
+            maps["dk"].ptr,
+            output["dk"].reshape(-1),
+            output["dv"].reshape(-1),
+            inputs["bucketed_offsets"].reshape(-1),
+            inputs["bucketed_indices"].reshape(-1),
+            output["workspace"],
+            edge_stride,
+            inputs["softmax_scale"],
+        )
+        executables[2](output["workspace"], output["dq"].reshape(-1), inputs["softmax_scale"])
+        if not direct_dkv:
+            executables[3](output["workspace"], output["dk"].reshape(-1), inputs["softmax_scale"])
+            executables[4](output["workspace"], output["dv"].reshape(-1), 1.0)
+
+    launch.tensor_maps = maps
+    return launch
+
+
+def _analytic_oracle(data, row_chunk=32):
+    if data["oracle"] is not None:
+        return data["oracle"]
+    config = data["config"]
+    inputs = data["inputs"]
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    head_dim = int(config["head_dim"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    q_blocks = data["derived"]["q_blocks"]
+    maximum = int(config["kv_blocks"])
+    scale = float(inputs["softmax_scale"])
+    device = inputs["q"].device
+
+    q64 = _as_bhsd(inputs["q"], config).to(torch.float64)
+    k64 = _as_bhsd(inputs["k"], config).to(torch.float64)
+    v64 = _as_bhsd(inputs["v"], config).to(torch.float64)
+    do64 = _as_bhsd(inputs["do"], config).to(torch.float64)
+    o64 = _as_bhsd(inputs["o"], config).to(torch.float64)
+    dq = torch.zeros_like(q64)
+    dk = torch.zeros_like(k64)
+    dv = torch.zeros_like(v64)
+    sum_odo = (o64 * do64).sum(dim=-1)
+    lse64 = inputs["lse"].to(torch.float64)
+    scaled_lse = torch.where(torch.isneginf(lse64), torch.zeros_like(lse64), lse64 * _LOG2_E)
+
+    total_rows = batch * heads * q_blocks
+    row_ids_all = torch.arange(total_rows, dtype=torch.int64, device=device)
+    token_offsets = torch.arange(128, dtype=torch.int64, device=device)
+    q_offsets = torch.arange(128, dtype=torch.int64, device=device)
+    for start in range(0, total_rows, row_chunk):
+        row_ids = row_ids_all[start : start + row_chunk]
+        bh = row_ids // q_blocks
+        qb = row_ids - bh * q_blocks
+        b = bh // heads
+        h = bh - b * heads
+        count = inputs["counts"].reshape(-1)[row_ids].to(torch.int64)
+        sparse_blocks = inputs["block_index"].reshape(total_rows, maximum)[row_ids].to(torch.int64)
+        kv_tokens = sparse_blocks[:, :, None] * 128 + token_offsets[None, None, :]
+        slot_valid = torch.arange(maximum, device=device)[None, :] < count[:, None]
+        kv_valid = slot_valid[:, :, None] & (kv_tokens < seqlen_kv)
+        kv_safe = kv_tokens.clamp(0, seqlen_kv - 1)
+        k_sel = k64[b[:, None, None], h[:, None, None], kv_safe].reshape(
+            row_ids.numel(), maximum * 128, head_dim
+        )
+        v_sel = v64[b[:, None, None], h[:, None, None], kv_safe].reshape(
+            row_ids.numel(), maximum * 128, head_dim
+        )
+        kv_valid = kv_valid.reshape(row_ids.numel(), maximum * 128)
+
+        q_tokens = qb[:, None] * 128 + q_offsets[None, :]
+        q_valid = q_tokens < seqlen_q
+        q_safe = q_tokens.clamp(0, seqlen_q - 1)
+        q_sel = q64[b[:, None], h[:, None], q_safe]
+        do_sel = do64[b[:, None], h[:, None], q_safe]
+        scores = torch.bmm(q_sel, k_sel.transpose(1, 2)) * scale
+        scores = scores.masked_fill(~kv_valid[:, None, :], float("-inf"))
+        all_empty = ~kv_valid.any(dim=1)
+        probs = torch.softmax(scores, dim=-1)
+        if bool(all_empty.any()):
+            probs[all_empty] = 0.0
+        probs = torch.where(q_valid[:, :, None], probs, torch.zeros_like(probs))
+        dp = torch.bmm(do_sel, v_sel.transpose(1, 2))
+        delta = sum_odo[b[:, None], h[:, None], q_safe]
+        ds = probs * (dp - delta[:, :, None])
+        ds = torch.where(all_empty[:, None, None], torch.zeros_like(ds), ds)
+        dq_sel = torch.bmm(ds, k_sel) * scale
+        dk_sel = torch.bmm(ds.transpose(1, 2), q_sel) * scale
+        dv_sel = torch.bmm(probs.transpose(1, 2), do_sel)
+
+        global_q = ((b[:, None] * heads + h[:, None]) * seqlen_q + q_tokens).reshape(-1)
+        q_valid_flat = q_valid.reshape(-1)
+        dq.reshape(-1, head_dim)[global_q[q_valid_flat]] = dq_sel.reshape(-1, head_dim)[
+            q_valid_flat
+        ]
+        global_kv = ((b[:, None, None] * heads + h[:, None, None]) * seqlen_kv + kv_safe).reshape(
+            -1
+        )
+        valid_flat = kv_valid.reshape(-1)
+        dk.reshape(-1, head_dim).index_add_(
+            0, global_kv[valid_flat], dk_sel.reshape(-1, head_dim)[valid_flat]
+        )
+        dv.reshape(-1, head_dim).index_add_(
+            0, global_kv[valid_flat], dv_sel.reshape(-1, head_dim)[valid_flat]
+        )
+
+    q128 = data["source"]["q8"]
+    k128 = data["source"]["k8"]
+    oracle = {
+        "sum_odo": torch.zeros((batch, heads, q128), dtype=torch.float32, device=device),
+        "scaled_lse": torch.zeros((batch, heads, q128), dtype=torch.float32, device=device),
+        "dq_acc": torch.zeros((batch, heads, q128, head_dim), dtype=torch.float32, device=device),
+        "dk_acc": torch.zeros((batch, heads, k128, head_dim), dtype=torch.float32, device=device),
+        "dv_acc": torch.zeros((batch, heads, k128, head_dim), dtype=torch.float32, device=device),
+        "dq": dq.to(torch.bfloat16),
+        "dk": dk.to(torch.bfloat16),
+        "dv": dv.to(torch.bfloat16),
+    }
+    oracle["sum_odo"][:, :, :seqlen_q] = sum_odo.to(torch.float32)
+    oracle["scaled_lse"][:, :, :seqlen_q] = scaled_lse.to(torch.float32)
+    oracle["dq_acc"][:, :, :seqlen_q] = (dq / scale).to(torch.float32)
+    oracle["dk_acc"][:, :, :seqlen_kv] = (dk / scale).to(torch.float32)
+    oracle["dv_acc"][:, :, :seqlen_kv] = dv.to(torch.float32)
+    data["oracle"] = oracle
+    return oracle
+
+
+def _assert_same_classification(actual, expected, name):
+    if not torch.equal(torch.isnan(actual), torch.isnan(expected)):
+        raise AssertionError(f"{name}: NaN classification mismatch")
+    if not torch.equal(torch.isposinf(actual), torch.isposinf(expected)):
+        raise AssertionError(f"{name}: +Inf classification mismatch")
+    if not torch.equal(torch.isneginf(actual), torch.isneginf(expected)):
+        raise AssertionError(f"{name}: -Inf classification mismatch")
+
+
+def _assert_close(actual, expected, name, tolerance=None):
+    _assert_same_classification(actual, expected, name)
+    finite = torch.isfinite(expected)
+    if not bool(finite.any()):
+        return
+    atol, rtol = _TOLERANCES[name] if tolerance is None else tolerance
+    torch.testing.assert_close(
+        actual[finite].float(), expected[finite].float(), atol=atol, rtol=rtol, equal_nan=False
+    )
+
+
+def _validate_redzones(state, source_name):
+    for storage_name, value in (
+        ("workspace_storage", _REDZONE_F32),
+        ("dq_storage", _REDZONE_BF16),
+        ("dk_storage", _REDZONE_BF16),
+        ("dv_storage", _REDZONE_BF16),
+    ):
+        storage = state[storage_name]
+        expected = torch.tensor(value, dtype=storage.dtype, device=storage.device)
+        if not torch.all(storage[:_REDZONE_ELEMENTS] == expected):
+            raise AssertionError(f"{source_name}.{storage_name}: leading redzone modified")
+        if not torch.all(storage[-_REDZONE_ELEMENTS:] == expected):
+            raise AssertionError(f"{source_name}.{storage_name}: trailing redzone modified")
+
+
+def validate_outputs(data, *, sources, with_oracle=True, tolerance_overrides=None):
+    oracle = _analytic_oracle(data) if with_oracle else None
+    config = data["config"]
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    multi_group = spec.q_group_count(config) > 1
+    for source_name in sources:
+        state = data[source_name]
+        _validate_redzones(state, source_name)
+        if source_name == "tirx":
+            fields = _workspace_fields(state, config)
+            if not torch.all(fields["sum_odo"][:, :, seqlen_q:] == 0):
+                raise AssertionError("tirx.sum_odo padding is not exactly zero")
+            if not torch.all(fields["scaled_lse"][:, :, seqlen_q:] == 0):
+                raise AssertionError("tirx.scaled_lse padding is not exactly zero")
+            if multi_group:
+                if not torch.all(fields["dk_acc"][:, :, seqlen_kv:] == 0):
+                    raise AssertionError("tirx.dk_acc padding is not exactly zero")
+                if not torch.all(fields["dv_acc"][:, :, seqlen_kv:] == 0):
+                    raise AssertionError("tirx.dv_acc padding is not exactly zero")
+            if oracle is not None:
+                names = ["sum_odo", "scaled_lse", "dq_acc"]
+                if multi_group:
+                    names.extend(("dk_acc", "dv_acc"))
+                for name in names:
+                    tolerance = (
+                        _oracle_tolerance(config, name)
+                        if tolerance_overrides is None
+                        else tolerance_overrides.get(name, _oracle_tolerance(config, name))
+                    )
+                    actual = fields[name]
+                    expected = oracle[name]
+                    if name == "dq_acc":
+                        # Source bulk-reduces complete 128-row tiles; only the
+                        # valid SQ rows are semantic, and postprocess predicates
+                        # its final BF16 stores for the q tail.
+                        actual = actual[:, :, :seqlen_q]
+                        expected = expected[:, :, :seqlen_q]
+                    _assert_close(actual, expected, name, tolerance)
+        for name in ("dq", "dk", "dv"):
+            actual = _as_bhsd(state[name], config)
+            if oracle is None:
+                if not bool(torch.isfinite(actual).all()):
+                    raise AssertionError(f"{source_name}.{name} contains non-finite values")
+                continue
+            tolerance = (
+                _oracle_tolerance(config, name)
+                if tolerance_overrides is None
+                else tolerance_overrides.get(name, _oracle_tolerance(config, name))
+            )
+            _assert_close(actual, oracle[name], name, tolerance)
+    if oracle is not None and "tirx" in sources and "source" in sources:
+        for name in ("dq", "dk", "dv"):
+            _assert_close(
+                _as_bhsd(data["tirx"][name], config),
+                _as_bhsd(data["source"][name], config),
+                name,
+                _SOURCE_PAIR_TOLERANCES[name],
+            )
+
+
+def workspace_fields(data, source_name):
+    return _workspace_fields(data[source_name], data["config"])
+
+
+def tolerance_grid():
+    return (
+        (0.0, 0.0),
+        *((value, value) for value in (2**-15, 2**-13, 2**-11, 2**-9, 2**-7, 1e-2, 2e-2, 3e-2)),
+    )
+
+
+CONFIGS = spec.correctness_configs()

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/kernel.py
@@ -1,0 +1,1194 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Source-shaped SM100 blk128 block-sparse-attention backward kernels."""
+
+import tirx_kernels.kern as K
+
+WARPS = 16
+THREADS = 512
+TMEM_COLUMNS = 512
+BAR_EPILOGUE_0 = (1, 160)
+BAR_EPILOGUE_1 = (2, 160)
+BAR_COMPUTE = (3, 256)
+BAR_REDUCE = (4, 128)
+BAR_TMEM = (5, 416)
+
+TMEM_S = 0
+TMEM_DV = 128
+
+MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+TMEM_LD16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+TMEM_LD32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+TMEM_ST16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
+TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+TMA_G2S = (
+    "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+TMA_S2G = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+TMA_REDUCE = "cp.reduce.async.bulk.tensor.4d.global.shared::cta.add.tile.bulk_group.L2::cache_hint"
+TMA_CACHE = K.uint64(0)
+
+
+def _xor(a, b):
+    if isinstance(a, int) and isinstance(b, int):
+        return a ^ b
+    return K.bitwise_xor(a, b)
+
+
+def _tile_elem(row, dim):
+    return (dim // 64) * 8192 + _xor(row * 64 + dim % 64, (row % 8) * 8)
+
+
+def _tile_byte(base, row, dim):
+    return base + 2 * _tile_elem(row, dim)
+
+
+def _epi_bf16_byte(base, wg, row, dim, columns):
+    """Source make_smem_layout_epi address for one workgroup's BF16 tile."""
+    linear = base + wg * K.int32(128 * columns * 2) + row * K.int32(columns * 2) + K.int32(dim * 2)
+    mask = K.int32(columns * 2 - 16)
+    return _xor(linear, K.bitwise_and(linear // K.int32(8), mask))
+
+
+def _desc_base(ldo, sdo=64, swizzle=3):
+    arrangement = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    # Cute's source layout reports semantic ldo=512. Its line-info PTX
+    # encodes that as low-half field 0x04000000 (the BF16 byte step), while
+    # sdo remains 64 in descriptor units.
+    encoded_ldo = ldo * 2
+    value = ((encoded_ldo & 0x3FFF) << 16) | ((sdo & 0x3FFF) << 32) | (1 << 46)
+    return (value | ((arrangement & 0x7) << 61)) & 0xFFFFFFFFFFFFFFFF
+
+
+def _desc_at(base, shared_address):
+    field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(K.uint64(base), field)
+
+
+def _desc_add16(desc, offset):
+    if offset == 0:
+        return desc
+    lo = K.local_scalar("uint32")
+    hi = K.local_scalar("uint32")
+    out = K.local_scalar("uint64")
+    K.ptx.mov.b64(lo, hi, desc)
+    K.ptx.add.u32(lo, lo, K.uint32(offset))
+    K.ptx.mov.b64(out, lo, hi)
+    return out
+
+
+def _mma(dest, a_desc, b_desc, idesc, accumulate, pred):
+    K.ptx[MMA_F16](
+        K.cast(dest, "uint32"),
+        a_desc,
+        b_desc,
+        K.uint32(idesc),
+        K.uint32(0),
+        K.uint32(0),
+        K.uint32(0),
+        K.uint32(0),
+        K.ptx.pred(accumulate),
+        pred=pred,
+    )
+
+
+def _mma_chain(dest, a_desc, b_desc, idesc, a_offsets, b_offsets, accumulate, pred):
+    flag = K.local_scalar("uint32", init=K.cast(accumulate, "uint32"))
+    for a_offset, b_offset in zip(a_offsets, b_offsets):
+        _mma(dest, _desc_add16(a_desc, a_offset), _desc_add16(b_desc, b_offset), idesc, flag, pred)
+        K.assign(flag, K.uint32(1))
+
+
+def _mma_tmem_chain(dest, tmem_a, b_desc, idesc, accumulate, pred):
+    flag = K.local_scalar("uint32", init=K.cast(accumulate, "uint32"))
+    for phase in range(8):
+        _mma(
+            dest,
+            K.cast(tmem_a + K.uint32(phase * 8), "uint32"),
+            _desc_add16(b_desc, phase * 128),
+            idesc,
+            flag,
+            pred,
+        )
+        K.assign(flag, K.uint32(1))
+
+
+def _tmem_store16(src, base, address):
+    K.ptx[TMEM_ST16](K.cast(address, "uint32"), *(src[base + i] for i in range(16)))
+
+
+def _shfl_bfly_f32(value, lane_xor, membermask):
+    out = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret(K.u32, value), K.uint32(lane_xor), K.uint32(31), membermask
+    )
+    return K.reinterpret(K.f32, out)
+
+
+def _butterfly_sum_f32(value):
+    membermask = K.local_scalar("uint32", init=K.tvm_warp_activemask())
+    for lane_xor in (1, 2, 4):
+        peer = _shfl_bfly_f32(value, lane_xor, membermask)
+        total = K.local_scalar("float32")
+        K.ptx.add.f32(total, value, peer)
+        value = total
+    return value
+
+
+def _packed_binary(op, a0, a1, b0, b1):
+    a = K.local_scalar("uint64")
+    b = K.local_scalar("uint64")
+    out = K.local_scalar("uint64")
+    K.ptx.mov.b64(a, a0, a1)
+    K.ptx.mov.b64(b, b0, b1)
+    K.ptx[op](out, a, b)
+    lo = K.local_scalar("float32")
+    hi = K.local_scalar("float32")
+    K.ptx.mov.b64(lo, hi, out)
+    return lo, hi
+
+
+def _packed_fma(a0, a1, b0, b1, c0, c1):
+    a = K.local_scalar("uint64")
+    b = K.local_scalar("uint64")
+    c = K.local_scalar("uint64")
+    out = K.local_scalar("uint64")
+    K.ptx.mov.b64(a, a0, a1)
+    K.ptx.mov.b64(b, b0, b1)
+    K.ptx.mov.b64(c, c0, c1)
+    K.ptx["fma.rn.f32x2"](out, a, b, c)
+    lo = K.local_scalar("float32")
+    hi = K.local_scalar("float32")
+    K.ptx.mov.b64(lo, hi, out)
+    return lo, hi
+
+
+def _load_i32(buffer, index):
+    out = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(out, buffer.ptr_to([index]))
+    return out
+
+
+def _publish_pipeline_init():
+    K.ptx["fence.mbarrier_init.release.cluster"]()
+    K.ptx.bar.sync(K.uint32(0), K.uint32(THREADS))
+
+
+class _PipelinePair:
+    """Pair public K barrier objects without imposing a constructor epoch."""
+
+    def __init__(self, full, empty):
+        self.full = full
+        self.empty = empty
+
+
+def _issue_tma_tile(desc, arena, dst, seq0, head, batch_idx, barrier, head_dim):
+    for feature_half in range(head_dim // 64):
+        K.ptx[TMA_G2S](
+            arena.ptr_to([dst + feature_half * 16384]),
+            K.address_of(desc),
+            K.int32(feature_half * 64),
+            seq0,
+            head,
+            batch_idx,
+            K.cuda.cvta_generic_to_shared(barrier),
+            TMA_CACHE,
+        )
+
+
+def _bulk_stats(arena, dst, src, barrier, pred):
+    K.ptx.mbarrier.arrive.expect_tx.shared.b64(barrier, K.uint32(512), pred=pred)
+    K.ptx["cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes"](
+        arena.ptr_to([dst]), src, K.uint32(512), K.cuda.cvta_generic_to_shared(barrier), pred=pred
+    )
+
+
+def _tcgen_commit(barrier, pred):
+    K.ptx["tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"](
+        barrier, pred=pred
+    )
+
+
+def _bar_arrive(barrier):
+    K.ptx.mbarrier.arrive.shared.b64(barrier, K.uint32(1))
+
+
+def _tmem_load32(dst, base, address):
+    K.ptx[TMEM_LD32](*(dst[base + i] for i in range(32)), K.cast(address, "uint32"))
+
+
+def get_kernel(**config):
+    batch = int(config["batch"])
+    heads = int(config["num_heads"])
+    seqlen_q = int(config["seqlen_q"])
+    seqlen_kv = int(config["seqlen_kv"])
+    head_dim = int(config["head_dim"])
+    bshd = config["tensor_layout"] == "bshd"
+    assert head_dim in (64, 128)
+    q_blocks = (seqlen_q + 127) // 128
+    bucket = config.get("bucket_size_blocks")
+    if bucket is None:
+        bucket = 256 if q_blocks >= 4096 and heads <= 1 else (512 if q_blocks >= 2048 else 384)
+    groups = (q_blocks + int(bucket) - 1) // int(bucket)
+    tasks = (seqlen_kv + 127) // 128
+    q128 = q_blocks * 128
+    k128 = tasks * 128
+    bh_count = batch * heads
+    sum_plane = bh_count * q128
+    dq_base = 2 * sum_plane
+    dk_base = dq_base + bh_count * q128 * head_dim
+    dv_base = dk_base + bh_count * k128 * head_dim
+
+    direct_dkv = groups == 1
+    off_sq = 1024
+    if head_dim == 64:
+        off_sk, off_sv, off_sdo = 33792, 50176, 66560
+        off_sds = 82944 if direct_dkv else 99328
+        off_slse = 115712 if direct_dkv else 132096
+        off_ssum, off_sdq = off_slse + 1024, off_slse + 2048
+        shared_bytes = 150528 if direct_dkv else 166912
+    else:
+        off_sk, off_sv, off_sdo = 66560, 99328, 132096
+        off_sds, off_slse, off_ssum, off_sdq = 164864, 197632, 198656, 199680
+        shared_bytes = 232448
+    tmem_dp = 128 + head_dim
+    tmem_dq = tmem_dp
+    tmem_ds = tmem_dp
+    tmem_dk = 256 + head_dim
+    id_qk = 0x08200490
+    id_dkdv = 0x08110490 if head_dim == 64 else 0x08210490
+    id_dq = 0x08118490 if head_dim == 64 else 0x08218490
+
+    @K.kernel(
+        warps=8, arch="sm_100a", min_blocks_per_sm=1, grid=((seqlen_q + 127) // 128, heads, batch)
+    )
+    def preprocess(
+        o: K.gptr[K.bf16], do: K.gptr[K.bf16], lse: K.gptr[K.f32], workspace: K.gptr[K.f32]
+    ):
+        required_block_size = K.attr({"tirx.required_block_size": 1})
+        required_block_size.__enter__()
+        K.ptx.griddepcontrol.wait()
+        q_tile, head, batch_idx = K.cta_id()
+        tid = K.thread_id()
+        threads_per_row = head_dim // 8
+        rows_per_wave = 256 // threads_per_row
+        row_lane = tid // K.int32(threads_per_row)
+        dim8 = (tid % K.int32(threads_per_row)) * K.int32(8)
+        membermask = K.local_scalar("uint32", init=K.tvm_warp_activemask())
+        for row_repeat in range(128 // rows_per_wave):
+            q_idx = q_tile * K.int32(128) + row_lane + K.int32(row_repeat * rows_per_wave)
+            acc = K.local_scalar("float32", init=K.float32(0.0))
+            with K.If(q_idx < K.int32(seqlen_q)), K.Then():
+                row = (
+                    (
+                        (K.cast(batch_idx, "int64") * K.int64(seqlen_q) + K.cast(q_idx, "int64"))
+                        * K.int64(heads)
+                        + K.cast(head, "int64")
+                    )
+                    if bshd
+                    else (
+                        (K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64"))
+                        * K.int64(seqlen_q)
+                        + K.cast(q_idx, "int64")
+                    )
+                ) * K.int64(head_dim)
+                o_words = K.alloc_local((4,), "uint32")
+                do_words = K.alloc_local((4,), "uint32")
+                offset = row + K.cast(dim8, "int64")
+                K.ptx.ld.global_.v4.b32(
+                    o_words[0], o_words[1], o_words[2], o_words[3], o.ptr_to([offset])
+                )
+                K.ptx.ld.global_.v4.b32(
+                    do_words[0], do_words[1], do_words[2], do_words[3], do.ptr_to([offset])
+                )
+                for pair in range(4):
+                    o_lo = K.local_scalar("uint16")
+                    o_hi = K.local_scalar("uint16")
+                    d_lo = K.local_scalar("uint16")
+                    d_hi = K.local_scalar("uint16")
+                    K.ptx.mov.b32(o_lo, o_hi, o_words[pair])
+                    K.ptx.mov.b32(d_lo, d_hi, do_words[pair])
+                    o0 = K.local_scalar("float32")
+                    o1 = K.local_scalar("float32")
+                    d0 = K.local_scalar("float32")
+                    d1 = K.local_scalar("float32")
+                    K.ptx["cvt.f32.bf16"](o0, o_lo)
+                    K.ptx["cvt.f32.bf16"](o1, o_hi)
+                    K.ptx["cvt.f32.bf16"](d0, d_lo)
+                    K.ptx["cvt.f32.bf16"](d1, d_hi)
+                    p0, p1 = _packed_binary("mul.f32x2", o0, o1, d0, d1)
+                    fragment = K.local_scalar("float32")
+                    K.ptx.add.f32(fragment, p0, p1)
+                    K.ptx.add.f32(acc, acc, fragment)
+            total = acc
+            for lane_xor in (1, 2, 4):
+                peer = _shfl_bfly_f32(total, lane_xor, membermask)
+                combined = K.local_scalar("float32")
+                K.ptx.add.f32(combined, total, peer)
+                K.assign(total, combined)
+            if threads_per_row == 16:
+                peer = _shfl_bfly_f32(total, 8, membermask)
+                combined = K.local_scalar("float32")
+                K.ptx.add.f32(combined, total, peer)
+                K.assign(total, combined)
+            with K.If((tid % K.int32(threads_per_row)) == K.int32(0)), K.Then():
+                bhq = (
+                    K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
+                ) * K.int64(q128) + K.cast(q_idx, "int64")
+                K.ptx.st.global_.b32(workspace.ptr_to([bhq]), total)
+                scaled = K.local_scalar("float32", init=K.float32(0.0))
+                with K.If(q_idx < K.int32(seqlen_q)), K.Then():
+                    lse_value = K.local_scalar("float32")
+                    lse_index = (
+                        K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
+                    ) * K.int64(seqlen_q) + K.cast(q_idx, "int64")
+                    K.ptx.ld.global_.b32(lse_value, lse.ptr_to([lse_index]))
+                    K.ptx.mul.f32(scaled, lse_value, K.float32(1.4426950408889634))
+                    with K.If(lse_value == K.float32(float("-inf"))), K.Then():
+                        K.assign(scaled, K.float32(0.0))
+                K.ptx.st.global_.b32(workspace.ptr_to([K.int64(sum_plane) + bhq]), scaled)
+        K.ptx.griddepcontrol.launch_dependents()
+        bh = K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
+        for vec in range(head_dim // 8):
+            elem = tid * K.int32(4) + K.int32(vec * 1024)
+            dst = (
+                K.int64(dq_base)
+                + bh * K.int64(q128 * head_dim)
+                + K.cast(q_tile, "int64") * K.int64(128 * head_dim)
+                + K.cast(elem, "int64")
+            )
+            K.ptx.st.global_.v4.b32(
+                workspace.ptr_to([dst]), K.uint32(0), K.uint32(0), K.uint32(0), K.uint32(0)
+            )
+        required_block_size.__exit__(None, None, None)
+
+    @K.kernel(warps=WARPS, arch="sm_100a", min_blocks_per_sm=1, grid=(tasks * groups, heads, batch))
+    def bwd(
+        q_map: K.TensorMap,
+        k_map: K.TensorMap,
+        v_map: K.TensorMap,
+        do_map: K.TensorMap,
+        dv_map: K.TensorMap,
+        dk_map: K.TensorMap,
+        dk_output: K.gptr[K.bf16],
+        dv_output: K.gptr[K.bf16],
+        bucketed_offsets: K.gptr[K.i32],
+        bucketed_indices: K.gptr[K.i32],
+        workspace: K.gptr[K.f32],
+        edge_stride: K.i64,
+        softmax_scale: K.f32,
+    ):
+        required_block_size = K.attr({"tirx.required_block_size": 1})
+        required_block_size.__enter__()
+        block, head, batch_idx = K.cta_id()
+        warp = K.warp_id()
+        with K.If(warp == K.int32(13)), K.Then():
+            with K.If(K.cuda.elect_sync()), K.Then():
+                K.ptx.prefetch.tensormap(K.address_of(q_map))
+                K.ptx.prefetch.tensormap(K.address_of(k_map))
+                K.ptx.prefetch.tensormap(K.address_of(v_map))
+                K.ptx.prefetch.tensormap(K.address_of(do_map))
+                if direct_dkv:
+                    K.ptx.prefetch.tensormap(K.address_of(dv_map))
+                    K.ptx.prefetch.tensormap(K.address_of(dk_map))
+
+        arena = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+        pool = K.smem_pool(base=arena).pool
+        q_pipe = _PipelinePair(K.TMABar(pool, 2), K.TCGen05Bar(pool, 2))
+        do_pipe = _PipelinePair(K.TMABar(pool, 1), K.TCGen05Bar(pool, 1))
+        lse_pipe = _PipelinePair(K.TMABar(pool, 2), K.MBarrier(pool, 2))
+        sum_pipe = _PipelinePair(K.TMABar(pool, 1), K.MBarrier(pool, 1))
+        s_pipe = _PipelinePair(K.TCGen05Bar(pool, 1), K.MBarrier(pool, 1))
+        dp_pipe = _PipelinePair(K.TCGen05Bar(pool, 1), K.MBarrier(pool, 1))
+        ds_pipe = _PipelinePair(K.MBarrier(pool, 1), K.TCGen05Bar(pool, 1))
+        dkdv_pipe = _PipelinePair(K.TCGen05Bar(pool, 2), K.MBarrier(pool, 2))
+        dq_pipe = _PipelinePair(K.TCGen05Bar(pool, 1), K.MBarrier(pool, 1))
+
+        s_pipe.full.init(1)
+        s_pipe.empty.init(8)
+        _publish_pipeline_init()
+        dp_pipe.full.init(1)
+        dp_pipe.empty.init(8)
+        _publish_pipeline_init()
+        dkdv_pipe.full.init(1)
+        dkdv_pipe.empty.init(8)
+        _publish_pipeline_init()
+        dq_pipe.full.init(1)
+        dq_pipe.empty.init(4)
+        _publish_pipeline_init()
+        ds_pipe.full.init(8)
+        ds_pipe.empty.init(1)
+        _publish_pipeline_init()
+        lse_pipe.full.init(1)
+        lse_pipe.empty.init(8)
+        sum_pipe.full.init(1)
+        sum_pipe.empty.init(8)
+        q_pipe.full.init(1)
+        q_pipe.empty.init(1)
+        do_pipe.full.init(1)
+        do_pipe.empty.init(1)
+        _publish_pipeline_init()
+        tmem_mailbox = pool.alloc((1,), "uint32", align=4)
+        assert pool.offset == 196
+
+        q_group = block // K.int32(tasks)
+        task = block - q_group * K.int32(tasks)
+        offsets_base = ((batch_idx * K.int32(heads) + head) * K.int32(groups) + q_group) * K.int32(
+            tasks + 1
+        )
+        begin = _load_i32(bucketed_offsets, offsets_base + task)
+        end = _load_i32(bucketed_offsets, offsets_base + task + K.int32(1))
+        count = end - begin
+        work = (count > K.int32(0)) & (task * K.int32(128) < K.int32(seqlen_kv))
+
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
+        sp = K.specialize(chain_dispatch=True)
+        r_load = sp.role("load", warps=[13])
+        r_mma = sp.role("mma", warps=[12])
+        r_compute = sp.role("compute", warps=list(range(4, 12)))
+        r_reduce = sp.role("reduce", warps=list(range(4)))
+        r_idle = sp.role("idle", warps=[14])
+        r_empty = sp.role("empty", warps=[15])
+
+        with r_load:
+            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(88))
+            leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            q_prod = K.PipelineState(2, phase=0)
+            do_prod = K.PipelineState(1, phase=0)
+            edge = K.local_scalar("int32", init=K.int32(0))
+            bh = K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
+            bh_edge = bh * edge_stride
+            bh_q = bh * K.int64(q128)
+
+            with K.While(edge < count):
+                q_block = _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
+                q_block_safe = K.Select(q_block < K.int32(q_blocks), q_block, K.int32(q_blocks - 1))
+                first = edge == K.int32(0)
+
+                q_pipe.empty.wait(q_prod.stage, q_prod.phase ^ 1)
+                with K.If(leader != K.uint32(0)), K.Then():
+                    q_bar = q_pipe.full.buf.ptr_to([q_prod.stage])
+                    q_tx = K.local_scalar("uint32", init=K.uint32(head_dim * 256))
+                    with K.If(first), K.Then():
+                        K.assign(q_tx, K.uint32(head_dim * 512))
+                    K.ptx.mbarrier.arrive.expect_tx.shared.b64(q_bar, q_tx)
+                    with K.If(first), K.Then():
+                        _issue_tma_tile(
+                            k_map,
+                            arena,
+                            off_sk,
+                            task * K.int32(128),
+                            head,
+                            batch_idx,
+                            q_bar,
+                            head_dim,
+                        )
+                    _issue_tma_tile(
+                        q_map,
+                        arena,
+                        off_sq + q_prod.stage * K.int32(128 * head_dim * 2),
+                        q_block_safe * K.int32(128),
+                        head,
+                        batch_idx,
+                        q_bar,
+                        head_dim,
+                    )
+                lse_pipe.empty.wait(q_prod.stage, q_prod.phase ^ 1)
+                with K.If(leader != K.uint32(0)), K.Then():
+                    lse_bar = lse_pipe.full.buf.ptr_to([q_prod.stage])
+                    _bulk_stats(
+                        arena,
+                        off_slse + q_prod.stage * K.int32(512),
+                        workspace.ptr_to(
+                            [
+                                K.int64(sum_plane)
+                                + bh_q
+                                + K.cast(q_block_safe, "int64") * K.int64(128)
+                            ]
+                        ),
+                        lse_bar,
+                        K.bool(True),
+                    )
+                q_prod.advance()
+
+                do_pipe.empty.wait(do_prod.stage, do_prod.phase ^ 1)
+                with K.If(leader != K.uint32(0)), K.Then():
+                    do_bar = do_pipe.full.buf.ptr_to([do_prod.stage])
+                    do_tx = K.local_scalar("uint32", init=K.uint32(head_dim * 256))
+                    with K.If(first), K.Then():
+                        K.assign(do_tx, K.uint32(head_dim * 512))
+                    K.ptx.mbarrier.arrive.expect_tx.shared.b64(do_bar, do_tx)
+                    with K.If(first), K.Then():
+                        _issue_tma_tile(
+                            v_map,
+                            arena,
+                            off_sv,
+                            task * K.int32(128),
+                            head,
+                            batch_idx,
+                            do_bar,
+                            head_dim,
+                        )
+                    _issue_tma_tile(
+                        do_map,
+                        arena,
+                        off_sdo,
+                        q_block_safe * K.int32(128),
+                        head,
+                        batch_idx,
+                        do_bar,
+                        head_dim,
+                    )
+                sum_pipe.empty.wait(do_prod.stage, do_prod.phase ^ 1)
+                with K.If(leader != K.uint32(0)), K.Then():
+                    sum_bar = sum_pipe.full.buf.ptr_to([do_prod.stage])
+                    _bulk_stats(
+                        arena,
+                        off_ssum,
+                        workspace.ptr_to([bh_q + K.cast(q_block_safe, "int64") * K.int64(128)]),
+                        sum_bar,
+                        K.bool(True),
+                    )
+                do_prod.advance()
+                K.assign(edge, edge + K.int32(1))
+
+            with K.If(work), K.Then():
+                # Source producer_tail drains both Q/LSE ring stages and the
+                # single dO/dPsum stage only for a processed tile.
+                q_pipe.empty.wait(q_prod.stage, q_prod.phase ^ 1)
+                lse_pipe.empty.wait(q_prod.stage, q_prod.phase ^ 1)
+                q_prod.advance()
+                q_pipe.empty.wait(q_prod.stage, q_prod.phase ^ 1)
+                lse_pipe.empty.wait(q_prod.stage, q_prod.phase ^ 1)
+                do_pipe.empty.wait(do_prod.stage, do_prod.phase ^ 1)
+                sum_pipe.empty.wait(do_prod.stage, do_prod.phase ^ 1)
+
+        with r_mma:
+            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(88))
+            K.ptx[TMEM_ALLOC](
+                K.cuda.cvta_generic_to_shared(tmem_mailbox.ptr_to([0])), K.uint32(TMEM_COLUMNS)
+            )
+            K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+            tcol = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
+            t_s = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_S))
+            t_dv = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(TMEM_DV))
+            t_dp = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(tmem_dp))
+            t_dq = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(tmem_dq))
+            t_ds = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(tmem_ds))
+            t_dk = K.cuda.get_tmem_addr(tcol, K.uint32(0), K.uint32(tmem_dk))
+            elected = K.local_scalar("uint32", init=K.cuda.elect_sync())
+
+            desc = _desc_base(512)
+            d_k = _desc_at(desc, smem_base + K.uint32(off_sk))
+            d_v = _desc_at(desc, smem_base + K.uint32(off_sv))
+            d_do = _desc_at(desc, smem_base + K.uint32(off_sdo))
+            d_ds = _desc_at(desc, smem_base + K.uint32(off_sds))
+            k_offsets = (0, 2, 4, 6)
+            if head_dim == 128:
+                k_offsets = (0, 2, 4, 6, 1024, 1026, 1028, 1030)
+            reduce_offsets = (0, 128, 256, 384, 512, 640, 768, 896)
+
+            q_cons = K.PipelineState(2, phase=0)
+            q_release = K.PipelineState(2, phase=0)
+            do_cons = K.PipelineState(1, phase=0)
+            s_prod = K.PipelineState(1, phase=0)
+            dp_prod = K.PipelineState(1, phase=0)
+            dq_prod = K.PipelineState(1, phase=0)
+            ds_cons = K.PipelineState(1, phase=0)
+            dkdv_prod = K.PipelineState(2, phase=0)
+
+            def q_desc(state):
+                return _desc_at(
+                    desc, smem_base + K.uint32(off_sq) + state.stage * K.uint32(128 * head_dim * 2)
+                )
+
+            def issue_qk(state):
+                _mma_chain(
+                    t_s, d_k, q_desc(state), id_qk, k_offsets, k_offsets, K.uint32(0), elected
+                )
+
+            def issue_dp():
+                _mma_chain(t_dp, d_v, d_do, id_qk, k_offsets, k_offsets, K.uint32(0), elected)
+
+            def issue_dq():
+                _mma_chain(
+                    t_dq, d_ds, d_k, id_dq, reduce_offsets, reduce_offsets, K.uint32(0), elected
+                )
+
+            with K.If(work), K.Then():
+                q_pipe.full.wait(q_cons.stage, q_cons.phase)
+                s_pipe.empty.wait(s_prod.stage, s_prod.phase ^ 1)
+                issue_qk(q_cons)
+                q_cons.advance()
+                s_pipe.full.arrive(s_prod.stage, pred=elected)
+                s_prod.advance()
+
+                do_pipe.full.wait(do_cons.stage, do_cons.phase)
+                dp_pipe.empty.wait(dp_prod.stage, dp_prod.phase ^ 1)
+                dq_pipe.empty.wait(dq_prod.stage, dq_prod.phase ^ 1)
+                issue_dp()
+                dp_pipe.full.arrive(dp_prod.stage, pred=elected)
+                dp_prod.advance()
+
+                s_pipe.empty.wait(s_prod.stage, s_prod.phase ^ 1)
+                _mma_tmem_chain(t_dv, t_s, d_do, id_dkdv, K.uint32(0), elected)
+                do_pipe.empty.arrive(do_cons.stage, pred=elected)
+                do_cons.advance()
+
+                edge = K.local_scalar("int32", init=K.int32(1))
+                dk_accumulate = K.local_scalar("uint32", init=K.uint32(0))
+                with K.While(edge < count):
+                    q_pipe.full.wait(q_cons.stage, q_cons.phase)
+                    issue_qk(q_cons)
+                    q_cons.advance()
+                    s_pipe.full.arrive(s_prod.stage, pred=elected)
+                    s_prod.advance()
+
+                    ds_pipe.full.wait(ds_cons.stage, ds_cons.phase)
+                    _mma_tmem_chain(t_dk, t_ds, q_desc(q_release), id_dkdv, dk_accumulate, elected)
+                    K.assign(dk_accumulate, K.uint32(1))
+                    q_pipe.empty.arrive(q_release.stage, pred=elected)
+                    q_release.advance()
+
+                    issue_dq()
+                    dq_pipe.full.arrive(dq_prod.stage, pred=elected)
+                    dq_prod.advance()
+                    ds_pipe.empty.arrive(ds_cons.stage, pred=elected)
+                    ds_cons.advance()
+
+                    do_pipe.full.wait(do_cons.stage, do_cons.phase)
+                    dq_pipe.empty.wait(dq_prod.stage, dq_prod.phase ^ 1)
+                    dp_pipe.empty.wait(dp_prod.stage, dp_prod.phase ^ 1)
+                    issue_dp()
+                    dp_pipe.full.arrive(dp_prod.stage, pred=elected)
+                    dp_prod.advance()
+
+                    s_pipe.empty.wait(s_prod.stage, s_prod.phase ^ 1)
+                    _mma_tmem_chain(t_dv, t_s, d_do, id_dkdv, K.uint32(1), elected)
+                    do_pipe.empty.arrive(do_cons.stage, pred=elected)
+                    do_cons.advance()
+                    K.assign(edge, edge + K.int32(1))
+
+                s_pipe.full.arrive(s_prod.stage, pred=elected)
+                dkdv_pipe.empty.wait(dkdv_prod.stage, dkdv_prod.phase ^ 1)
+                dkdv_pipe.full.arrive(dkdv_prod.stage, pred=elected)
+                dkdv_prod.advance()
+                dkdv_pipe.empty.wait(dkdv_prod.stage, dkdv_prod.phase ^ 1)
+
+                ds_pipe.full.wait(ds_cons.stage, ds_cons.phase)
+                _mma_tmem_chain(t_dk, t_ds, q_desc(q_release), id_dkdv, dk_accumulate, elected)
+                dkdv_pipe.full.arrive(dkdv_prod.stage, pred=elected)
+                dkdv_prod.advance()
+
+                issue_dq()
+                dq_pipe.full.arrive(dq_prod.stage, pred=elected)
+                dq_prod.advance()
+                q_pipe.empty.arrive(q_release.stage, pred=elected)
+                q_release.advance()
+                ds_pipe.empty.arrive(ds_cons.stage, pred=elected)
+                ds_cons.advance()
+
+            K.ptx[TMEM_RELINQUISH]()
+            K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+            K.ptx[TMEM_DEALLOC](tcol, K.uint32(TMEM_COLUMNS))
+        with r_compute:
+            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(136))
+            K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+            tcol = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
+            ctid = K.tid_in_role()
+            crow = ctid % K.int32(128)
+            # tid_in_role retains the physical CTA thread id.  Source maps
+            # physical compute warpgroups 1 and 2 through bit 7, yielding
+            # the required logical half order 1, 0.
+            wg = K.bitwise_and(ctid, K.int32(128)) // K.int32(128)
+            row_group = (crow // K.int32(32)) * K.int32(32)
+            scale_log2 = K.local_scalar("float32")
+            K.ptx.mul.f32(scale_log2, softmax_scale, K.float32(1.4426950408889634))
+
+            s_cons = K.PipelineState(1, phase=0)
+            lse_cons = K.PipelineState(2, phase=0)
+            sum_cons = K.PipelineState(1, phase=0)
+            dp_cons = K.PipelineState(1, phase=0)
+            ds_prod = K.PipelineState(1, phase=0)
+            dkdv_cons = K.PipelineState(2, phase=0)
+            edge = K.local_scalar("int32", init=K.int32(0))
+            with K.While(edge < count):
+                lse_pipe.full.wait(lse_cons.stage, lse_cons.phase)
+                s_pipe.full.wait(s_cons.stage, s_cons.phase)
+                scores = K.alloc_local((64,), "float32")
+                for rep in range(2):
+                    address = K.cuda.get_tmem_addr(
+                        tcol, row_group, K.int32(TMEM_S + wg * 32 + rep * 64)
+                    )
+                    _tmem_load32(scores, rep * 32, address)
+                kv_live = task * K.int32(128) + crow < K.int32(seqlen_kv)
+                for j in range(64):
+                    with K.If(kv_live == K.bool(False)), K.Then():
+                        K.assign(scores[j], K.reinterpret(K.f32, K.uint32(0xFF800000)))
+                for rep in range(2):
+                    for pair in range(16):
+                        j = rep * 32 + pair * 2
+                        qcol = wg * K.int32(32) + K.int32(rep * 64 + pair * 2)
+                        lse0 = K.local_scalar("float32")
+                        lse1 = K.local_scalar("float32")
+                        K.ptx.ld.shared_.b32(
+                            lse0,
+                            arena.ptr_to(
+                                [off_slse + lse_cons.stage * K.int32(512) + qcol * K.int32(4)]
+                            ),
+                        )
+                        K.ptx.ld.shared_.b32(
+                            lse1,
+                            arena.ptr_to(
+                                [
+                                    off_slse
+                                    + lse_cons.stage * K.int32(512)
+                                    + (qcol + K.int32(1)) * K.int32(4)
+                                ]
+                            ),
+                        )
+                        neg0 = K.local_scalar("float32")
+                        neg1 = K.local_scalar("float32")
+                        K.ptx.neg.f32(neg0, lse0)
+                        K.ptx.neg.f32(neg1, lse1)
+                        lo, hi = _packed_fma(
+                            scores[j], scores[j + 1], scale_log2, scale_log2, neg0, neg1
+                        )
+                        K.ptx.ex2.approx.ftz.f32(scores[j], lo)
+                        K.ptx.ex2.approx.ftz.f32(scores[j + 1], hi)
+                packed_p = K.alloc_local((32,), "uint32")
+                for j in range(32):
+                    K.ptx["cvt.rn.bf16x2.f32"](packed_p[j], scores[2 * j + 1], scores[2 * j])
+                K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                K.ptx.bar.sync(K.uint32(BAR_COMPUTE[0]), K.uint32(BAR_COMPUTE[1]))
+                for rep in range(2):
+                    _tmem_store16(
+                        packed_p,
+                        rep * 16,
+                        K.cuda.get_tmem_addr(tcol, row_group, K.int32(TMEM_S + wg * 16 + rep * 32)),
+                    )
+                K.ptx["tcgen05.wait::st.sync.aligned"]()
+                K.ptx.bar.sync(K.uint32(BAR_COMPUTE[0]), K.uint32(BAR_COMPUTE[1]))
+                with K.If(K.lane_id() == K.int32(0)), K.Then():
+                    s_pipe.empty.arrive(s_cons.stage)
+                s_cons.advance()
+                with K.If(K.lane_id() == K.int32(0)), K.Then():
+                    lse_pipe.empty.arrive(lse_cons.stage)
+                lse_cons.advance()
+
+                sum_pipe.full.wait(sum_cons.stage, sum_cons.phase)
+                dp_pipe.full.wait(dp_cons.stage, dp_cons.phase)
+                for rep in range(2):
+                    dp_values = K.alloc_local((32,), "float32")
+                    address = K.cuda.get_tmem_addr(
+                        tcol, row_group, K.int32(tmem_dp + wg * 32 + rep * 64)
+                    )
+                    _tmem_load32(dp_values, 0, address)
+                    K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                    K.ptx.bar.sync(K.uint32(BAR_COMPUTE[0]), K.uint32(BAR_COMPUTE[1]))
+                    for pair in range(16):
+                        j = pair * 2
+                        qcol = wg * K.int32(32) + K.int32(rep * 64 + pair * 2)
+                        sum0 = K.local_scalar("float32")
+                        sum1 = K.local_scalar("float32")
+                        K.ptx.ld.shared_.b32(sum0, arena.ptr_to([off_ssum + qcol * K.int32(4)]))
+                        K.ptx.ld.shared_.b32(
+                            sum1, arena.ptr_to([off_ssum + (qcol + K.int32(1)) * K.int32(4)])
+                        )
+                        lo, hi = _packed_binary(
+                            "sub.rn.f32x2", dp_values[j], dp_values[j + 1], sum0, sum1
+                        )
+                        lo, hi = _packed_binary(
+                            "mul.rn.f32x2", lo, hi, scores[rep * 32 + j], scores[rep * 32 + j + 1]
+                        )
+                        K.assign(dp_values[j], lo)
+                        K.assign(dp_values[j + 1], hi)
+                    packed_ds = K.alloc_local((16,), "uint32")
+                    for j in range(16):
+                        K.ptx["cvt.rn.bf16x2.f32"](
+                            packed_ds[j], dp_values[2 * j + 1], dp_values[2 * j]
+                        )
+                    if rep == 0:
+                        ds_pipe.empty.wait(ds_prod.stage, ds_prod.phase ^ 1)
+                    _tmem_store16(
+                        packed_ds,
+                        0,
+                        K.cuda.get_tmem_addr(
+                            tcol, row_group, K.int32(tmem_ds + wg * 16 + rep * 32)
+                        ),
+                    )
+                    for group in range(4):
+                        qcol = wg * K.int32(32) + K.int32(rep * 64 + group * 8)
+                        base = group * 4
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to([_tile_byte(off_sds, crow, qcol)]),
+                            packed_ds[base],
+                            packed_ds[base + 1],
+                            packed_ds[base + 2],
+                            packed_ds[base + 3],
+                        )
+                K.ptx["tcgen05.wait::st.sync.aligned"]()
+                with K.If(K.lane_id() == K.int32(0)), K.Then():
+                    dp_pipe.empty.arrive(dp_cons.stage)
+                dp_cons.advance()
+                K.ptx.fence.proxy.async_.shared__cta()
+                K.ptx.bar.sync(K.uint32(BAR_COMPUTE[0]), K.uint32(BAR_COMPUTE[1]))
+                with K.If(K.lane_id() == K.int32(0)), K.Then():
+                    sum_pipe.empty.arrive(sum_cons.stage)
+                sum_cons.advance()
+                with K.If(K.lane_id() == K.int32(0)), K.Then():
+                    ds_pipe.full.arrive(ds_prod.stage)
+                ds_prod.advance()
+                K.assign(edge, edge + K.int32(1))
+
+            with K.If(work), K.Then():
+                bh = K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
+                for is_dk in (False, True):
+                    dkdv_pipe.full.wait(dkdv_cons.stage, dkdv_cons.phase)
+                    tmem_offset = tmem_dk if is_dk else TMEM_DV
+                    epi_base = off_sq if is_dk else off_sdo
+                    if direct_dkv:
+                        values = K.alloc_local((head_dim // 2,), "float32")
+                        for stage in range(head_dim // 64):
+                            address = K.cuda.get_tmem_addr(
+                                tcol,
+                                row_group,
+                                K.int32(tmem_offset + wg * (head_dim // 2) + stage * 32),
+                            )
+                            _tmem_load32(values, stage * 32, address)
+                        K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                        if is_dk:
+                            for pair in range(head_dim // 4):
+                                j = pair * 2
+                                lo, hi = _packed_binary(
+                                    "mul.rn.f32x2",
+                                    values[j],
+                                    values[j + 1],
+                                    softmax_scale,
+                                    softmax_scale,
+                                )
+                                K.assign(values[j], lo)
+                                K.assign(values[j + 1], hi)
+                        packed = K.alloc_local((head_dim // 4,), "uint32")
+                        for pair in range(head_dim // 4):
+                            K.ptx["cvt.rn.bf16x2.f32"](
+                                packed[pair], values[pair * 2 + 1], values[pair * 2]
+                            )
+                        for group in range(head_dim // 16):
+                            base = group * 4
+                            K.ptx.st.shared.v4.b32(
+                                arena.ptr_to(
+                                    [_epi_bf16_byte(epi_base, wg, crow, group * 8, head_dim // 2)]
+                                ),
+                                packed[base],
+                                packed[base + 1],
+                                packed[base + 2],
+                                packed[base + 3],
+                            )
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        K.ptx.bar.sync(K.cast(K.int32(1) + wg, "uint32"), K.uint32(128))
+                        with K.If(crow < K.int32(32)), K.Then():
+                            with K.If(K.cuda.elect_sync()), K.Then():
+                                target_map = dk_map if is_dk else dv_map
+                                K.ptx[TMA_S2G](
+                                    K.address_of(target_map),
+                                    wg * K.int32(head_dim // 2),
+                                    task * K.int32(128),
+                                    head,
+                                    batch_idx,
+                                    arena.ptr_to(
+                                        [epi_base + wg * K.int32(128 * (head_dim // 2) * 2)]
+                                    ),
+                                    TMA_CACHE,
+                                )
+                            K.ptx.bar.arrive(K.cast(K.int32(1) + wg, "uint32"), K.uint32(160))
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        K.ptx.bar.sync(K.cast(K.int32(1) + wg, "uint32"), K.uint32(160))
+                    else:
+                        for stage in range(head_dim // 64):
+                            values = K.alloc_local((32,), "float32")
+                            address = K.cuda.get_tmem_addr(
+                                tcol,
+                                row_group,
+                                K.int32(tmem_offset + wg * (head_dim // 2) + stage * 32),
+                            )
+                            _tmem_load32(values, 0, address)
+                            K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                            for vec in range(8):
+                                base = vec * 4
+                                K.ptx.st.shared.v4.b32(
+                                    arena.ptr_to(
+                                        [
+                                            epi_base
+                                            + wg * K.int32(16384)
+                                            + K.int32(vec * 2048)
+                                            + crow * K.int32(16)
+                                        ]
+                                    ),
+                                    values[base],
+                                    values[base + 1],
+                                    values[base + 2],
+                                    values[base + 3],
+                                )
+                            K.ptx.fence.proxy.async_.shared__cta()
+                            K.ptx.bar.sync(K.cast(K.int32(1) + wg, "uint32"), K.uint32(128))
+                            with K.If(crow < K.int32(32)), K.Then():
+                                with K.If(K.cuda.elect_sync()), K.Then():
+                                    base = dk_base if is_dk else dv_base
+                                    dst = (
+                                        K.int64(base)
+                                        + bh * K.int64(k128 * head_dim)
+                                        + K.cast(task, "int64") * K.int64(128 * head_dim)
+                                        + K.cast(wg, "int64") * K.int64(128 * head_dim // 2)
+                                        + K.int64(stage * 4096)
+                                    )
+                                    K.ptx[
+                                        "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f32"
+                                    ](
+                                        workspace.ptr_to([dst]),
+                                        arena.ptr_to([epi_base + wg * K.int32(16384)]),
+                                        K.uint32(16384),
+                                    )
+                                if stage < head_dim // 64 - 1:
+                                    K.ptx.cp.async_.bulk.commit_group()
+                                    K.ptx.cp.async_.bulk.wait_group.read(0)
+                                K.ptx.bar.arrive(K.cast(K.int32(1) + wg, "uint32"), K.uint32(160))
+                            K.ptx.fence.proxy.async_.shared__cta()
+                            K.ptx.bar.sync(K.cast(K.int32(1) + wg, "uint32"), K.uint32(160))
+                    with K.If(K.lane_id() == K.int32(0)), K.Then():
+                        dkdv_pipe.empty.arrive(dkdv_cons.stage)
+                    dkdv_cons.advance()
+            if direct_dkv:
+                tile_live = task * K.int32(128) < K.int32(seqlen_kv)
+                with K.If((work == K.bool(False)) & tile_live), K.Then():
+                    row = ctid % K.int32(128)
+                    seq = task * K.int32(128) + row
+                    compute_half = ctid // K.int32(128) - K.int32(1)
+                    destination = (
+                        (
+                            (K.cast(batch_idx, "int64") * K.int64(seqlen_kv) + K.cast(seq, "int64"))
+                            * K.int64(heads)
+                            + K.cast(head, "int64")
+                        )
+                        if bshd
+                        else (
+                            (K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64"))
+                            * K.int64(seqlen_kv)
+                            + K.cast(seq, "int64")
+                        )
+                    ) * K.int64(head_dim)
+                    with K.If(seq < K.int32(seqlen_kv)), K.Then():
+                        with K.If(compute_half == K.int32(0)), K.Then():
+                            for vec in range(head_dim // 8):
+                                K.ptx.st.global_.v4.b32(
+                                    dk_output.ptr_to([destination + K.int64(vec * 8)]),
+                                    K.uint32(0),
+                                    K.uint32(0),
+                                    K.uint32(0),
+                                    K.uint32(0),
+                                )
+                        with K.If(compute_half == K.int32(1)), K.Then():
+                            for vec in range(head_dim // 8):
+                                K.ptx.st.global_.v4.b32(
+                                    dv_output.ptr_to([destination + K.int64(vec * 8)]),
+                                    K.uint32(0),
+                                    K.uint32(0),
+                                    K.uint32(0),
+                                    K.uint32(0),
+                                )
+            K.ptx.bar.arrive(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+        with r_reduce:
+            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(152))
+            K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+            tcol = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
+            rtid = K.tid_in_role()
+            row_group = (rtid // K.int32(32)) * K.int32(32)
+            dq_cons = K.PipelineState(1, phase=0)
+            store_stage = K.local_scalar("int32", init=K.int32(0))
+            edge = K.local_scalar("int32", init=K.int32(0))
+            bh = K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
+            bh_edge = bh * edge_stride
+            with K.While(edge < count):
+                dq_pipe.full.wait(dq_cons.stage, dq_cons.phase)
+                q_block = _load_i32(bucketed_indices, bh_edge + K.cast(begin + edge, "int64"))
+                q_block_safe = K.Select(q_block < K.int32(q_blocks), q_block, K.int32(q_blocks - 1))
+                values = K.alloc_local((head_dim,), "float32")
+                for chunk in range(head_dim // 32):
+                    address = K.cuda.get_tmem_addr(tcol, row_group, K.int32(tmem_dq + chunk * 32))
+                    _tmem_load32(values, chunk * 32, address)
+                K.ptx["tcgen05.wait::ld.sync.aligned"]()
+                K.ptx.bar.warp.sync(K.uint32(0xFFFFFFFF))
+                with K.If(K.lane_id() == K.int32(0)), K.Then():
+                    dq_pipe.empty.arrive(dq_cons.stage)
+                dq_cons.advance()
+
+                for chunk in range(head_dim // 32):
+                    for vec in range(8):
+                        base = chunk * 32 + vec * 4
+                        address = (
+                            off_sdq
+                            + store_stage * K.int32(16384)
+                            + K.int32(vec * 2048)
+                            + rtid * K.int32(16)
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to([address]),
+                            values[base],
+                            values[base + 1],
+                            values[base + 2],
+                            values[base + 3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    K.ptx.bar.sync(K.uint32(BAR_REDUCE[0]), K.uint32(BAR_REDUCE[1]))
+                    with K.If(K.warp_id() == K.int32(0)), K.Then():
+                        with K.If(K.cuda.elect_sync()), K.Then():
+                            dst = (
+                                K.int64(dq_base)
+                                + bh * K.int64(q128 * head_dim)
+                                + K.cast(q_block_safe, "int64") * K.int64(128 * head_dim)
+                                + K.int64(chunk * 4096)
+                            )
+                            K.ptx["cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f32"](
+                                workspace.ptr_to([dst]),
+                                arena.ptr_to([off_sdq + store_stage * K.int32(16384)]),
+                                K.uint32(16384),
+                            )
+                        K.ptx.cp.async_.bulk.commit_group()
+                        K.ptx.cp.async_.bulk.wait_group.read(1)
+                    K.ptx.bar.sync(K.uint32(BAR_REDUCE[0]), K.uint32(BAR_REDUCE[1]))
+                    K.assign(store_stage, K.Select(store_stage == K.int32(1), 0, 1))
+                K.assign(edge, edge + K.int32(1))
+            with K.If(work), K.Then():
+                with K.If(K.warp_id() == K.int32(0)), K.Then():
+                    K.ptx.cp.async_.bulk.wait_group.read(0)
+                K.ptx.bar.sync(K.uint32(BAR_REDUCE[0]), K.uint32(BAR_REDUCE[1]))
+            K.ptx.cp.async_.bulk.wait_group.read(0)
+            K.ptx.bar.arrive(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
+
+        with r_idle:
+            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(24))
+            pass
+        with r_empty:
+            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(24))
+            pass
+
+        required_block_size.__exit__(None, None, None)
+
+    def make_postprocess(seq_len, padded_len, source_base):
+        @K.kernel(
+            warps=4,
+            arch="sm_100a",
+            min_blocks_per_sm=1,
+            grid=((seq_len + 127) // 128, heads, batch),
+        )
+        def postprocess(workspace: K.gptr[K.f32], output: K.gptr[K.bf16], output_scale: K.f32):
+            required_block_size = K.attr({"tirx.required_block_size": 1})
+            required_block_size.__enter__()
+            seq_tile, head, batch_idx = K.cta_id()
+            tid = K.thread_id()
+            seq = seq_tile * K.int32(128) + tid
+            bh = K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
+            arena = K.alloc_buffer((128 * head_dim * 4,), K.u8, scope="shared.dyn", align=1024)
+            source = (
+                K.int64(source_base)
+                + bh * K.int64(padded_len * head_dim)
+                + K.cast(seq_tile, "int64") * K.int64(128 * head_dim)
+            )
+            for vec in range(head_dim // 4):
+                element = tid * K.int32(4) + K.int32(vec * 512)
+                K.ptx["cp.async.cg.shared.global"](
+                    arena.ptr_to([element * K.int32(4)]),
+                    workspace.ptr_to([source + K.cast(element, "int64")]),
+                    16,
+                    16,
+                )
+            K.ptx.cp.async_.commit_group()
+            K.ptx.cp.async_.wait_group(0)
+            K.ptx.bar.sync(K.uint32(0), K.uint32(128))
+
+            values = K.alloc_local((head_dim,), "float32")
+            for vec in range(head_dim // 4):
+                element = tid * K.int32(4) + K.int32(vec * 512)
+                K.ptx.ld.shared_.v4.b32(
+                    values[vec * 4],
+                    values[vec * 4 + 1],
+                    values[vec * 4 + 2],
+                    values[vec * 4 + 3],
+                    arena.ptr_to([element * K.int32(4)]),
+                )
+            scaled = K.alloc_local((head_dim,), "float32")
+            for pair in range(head_dim // 2):
+                lo, hi = _packed_binary(
+                    "mul.f32x2", values[pair * 2], values[pair * 2 + 1], output_scale, output_scale
+                )
+                K.assign(scaled[pair * 2], lo)
+                K.assign(scaled[pair * 2 + 1], hi)
+            packed = K.alloc_local((head_dim // 2,), "uint32")
+            for pair in range(head_dim // 2):
+                K.ptx["cvt.rn.bf16x2.f32"](packed[pair], scaled[pair * 2 + 1], scaled[pair * 2])
+            K.ptx.bar.sync(K.uint32(0), K.uint32(128))
+            for group in range(head_dim // 8):
+                base = group * 4
+                byte = _tile_byte(0, tid, K.int32(group * 8))
+                K.ptx.st.shared.v4.b32(
+                    arena.ptr_to([byte]),
+                    packed[base],
+                    packed[base + 1],
+                    packed[base + 2],
+                    packed[base + 3],
+                )
+            K.ptx.bar.sync(K.uint32(0), K.uint32(128))
+            threads_per_row = K.int32(head_dim // 8)
+            row_step = K.int32(128 // (head_dim // 8))
+            row_base = tid // threads_per_row
+            feature = (tid % threads_per_row) * K.int32(8)
+            for rep in range(head_dim // 8):
+                row = row_base + K.int32(rep) * row_step
+                seq = seq_tile * K.int32(128) + row
+                with K.If(seq < K.int32(seq_len)), K.Then():
+                    words = K.alloc_local((4,), "uint32")
+                    byte = _tile_byte(0, row, feature)
+                    K.ptx.ld.shared_.v4.b32(
+                        words[0], words[1], words[2], words[3], arena.ptr_to([byte])
+                    )
+                    destination = (
+                        (
+                            (K.cast(batch_idx, "int64") * K.int64(seq_len) + K.cast(seq, "int64"))
+                            * K.int64(heads)
+                            + K.cast(head, "int64")
+                        )
+                        if bshd
+                        else (
+                            (K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64"))
+                            * K.int64(seq_len)
+                            + K.cast(seq, "int64")
+                        )
+                    ) * K.int64(head_dim)
+                    K.ptx.st.global_.v4.b32(
+                        output.ptr_to([destination + K.cast(feature, "int64")]),
+                        words[0],
+                        words[1],
+                        words[2],
+                        words[3],
+                    )
+            required_block_size.__exit__(None, None, None)
+
+        return postprocess.func
+
+    kernels = [preprocess.func, bwd.func]
+    kernels.append(make_postprocess(seqlen_q, q128, dq_base))
+    if not direct_dkv:
+        kernels.append(make_postprocess(seqlen_kv, k128, dk_base))
+        kernels.append(make_postprocess(seqlen_kv, k128, dv_base))
+    return tuple(kernels)

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/reference.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/reference.py
@@ -1,0 +1,38 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2025, Ted Zadouri, Markus Hoehnerbach, Jay Shah, Tri Dao.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Lazy loader for the pinned cuDNN Frontend blk128 BSA backward program."""
+
+from tirx_kernels.cudnn._reference import load_reference_module
+
+
+def compile_reference(data):
+    """Compile/cache the pinned source path and return a preallocated launch closure."""
+    interface = load_reference_module("cudnn.block_sparse_attention._interface")
+    inputs = data["inputs"]
+    output = data["source"]
+
+    def launch():
+        interface.bsa_attn_bwd(
+            inputs["do"],
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["o"],
+            inputs["lse"],
+            inputs["block_index"],
+            int(inputs["block_sparse_num"]),
+            block_sizes=None,
+            q2k_block_nums=inputs["block_nums"],
+            softmax_scale=float(inputs["softmax_scale"]),
+            dq=output["dq"],
+            dk=output["dk"],
+            dv=output["dv"],
+            bucket_size_blocks=int(data["derived"]["bucket_size_blocks"]),
+            sparse_block_size=128,
+            layout=data["config"]["tensor_layout"],
+        )
+
+    return launch

--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/spec.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/spec.py
@@ -1,0 +1,238 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2025, Ted Zadouri, Markus Hoehnerbach, Jay Shah, Tri Dao.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Configuration domain for the SM100 blk128 BSA backward program."""
+
+
+def _config(label, **overrides):
+    config = {
+        "label": label,
+        "batch": 1,
+        "num_heads": 1,
+        "seqlen_q": 128,
+        "seqlen_kv": 512,
+        "head_dim": 128,
+        "dtype": "bfloat16",
+        "kv_blocks": 2,
+        "tensor_layout": "bhsd",
+        "block_count_mode": "fixed",
+        "block_count_pattern": None,
+        "softmax_scale": None,
+        "use_int64_kv_strides": False,
+        "bucket_size_blocks": None,
+        "preallocate_outputs": False,
+        "data_mode": "random",
+        "seed": 128000,
+    }
+    config.update(overrides)
+    return config
+
+
+def q_block_count(config):
+    return (int(config["seqlen_q"]) + 127) // 128
+
+
+def kv_block_count(config):
+    return (int(config["seqlen_kv"]) + 127) // 128
+
+
+def bucket_size_blocks(config):
+    explicit = config.get("bucket_size_blocks")
+    if explicit is not None and int(explicit) > 0:
+        return int(explicit)
+    q_blocks = q_block_count(config)
+    if q_blocks >= 4096 and int(config["num_heads"]) <= 1:
+        return 256
+    if q_blocks >= 2048:
+        return 512
+    return 384
+
+
+def q_group_count(config):
+    q_blocks = q_block_count(config)
+    bucket = bucket_size_blocks(config)
+    return (q_blocks + bucket - 1) // bucket
+
+
+def validate_config(config):
+    if config["dtype"] != "bfloat16":
+        raise ValueError("SM100 blk128 backward supports bfloat16 only")
+    if int(config["head_dim"]) not in (64, 128):
+        raise ValueError("SM100 blk128 backward supports head_dim 64 or 128")
+    if config["tensor_layout"] not in ("bhsd", "bshd"):
+        raise ValueError("tensor_layout must be 'bhsd' or 'bshd'")
+    if config["block_count_mode"] not in ("fixed", "variable", "variable_empty"):
+        raise ValueError("unsupported block_count_mode")
+    if int(config["kv_blocks"]) < 1 or int(config["kv_blocks"]) > kv_block_count(config):
+        raise ValueError("kv_blocks must fit the physical KV block count")
+    if any(int(config[name]) < 1 for name in ("batch", "num_heads", "seqlen_q", "seqlen_kv")):
+        raise ValueError("batch, heads, and sequence lengths must be positive")
+    if config["data_mode"] not in ("random", "cancellation", "sharp_softmax"):
+        raise ValueError("unsupported data_mode")
+    return config
+
+
+def correctness_configs():
+    rows = (
+        ("c00_b1_h1_d64_sq128_skv512_kv2", dict(head_dim=64)),
+        ("c01_b1_h1_d128_sq512_skv512_kv2_shared", dict(seqlen_q=512)),
+        (
+            "c02_b1_h2_d128_sq256_skv512_kv2_bshd_prealloc",
+            dict(num_heads=2, seqlen_q=256, tensor_layout="bshd", preallocate_outputs=True),
+        ),
+        (
+            "c03_b2_h3_d64_sq257_skv641_kv4_tails",
+            dict(batch=2, num_heads=3, seqlen_q=257, seqlen_kv=641, head_dim=64, kv_blocks=4),
+        ),
+        ("c04_b1_h1_d64_sq1_skv129_kv2", dict(head_dim=64, seqlen_q=1, seqlen_kv=129)),
+        ("c05_b1_h1_d128_sq127_skv255_kv2", dict(seqlen_q=127, seqlen_kv=255)),
+        ("c06_b1_h1_d128_sq129_skv257_kv2", dict(seqlen_q=129, seqlen_kv=257)),
+        (
+            "c07_b1_h1_d64_sq513_skv1024_maxkv4_var_1_2_3",
+            dict(
+                head_dim=64,
+                seqlen_q=513,
+                seqlen_kv=1024,
+                kv_blocks=4,
+                block_count_mode="variable",
+                block_count_pattern="1,2,3",
+            ),
+        ),
+        (
+            "c08_b1_h1_d128_sq513_skv1024_maxkv4_var_0_1_max",
+            dict(
+                seqlen_q=513,
+                seqlen_kv=1024,
+                kv_blocks=4,
+                block_count_mode="variable_empty",
+                block_count_pattern="0,1,max",
+            ),
+        ),
+        (
+            "c09_b1_h1_d128_sq513_skv1024_maxkv4_all_empty",
+            dict(
+                seqlen_q=513,
+                seqlen_kv=1024,
+                kv_blocks=4,
+                block_count_mode="variable_empty",
+                block_count_pattern="0",
+            ),
+        ),
+        (
+            "c10_b1_h1_d64_sq256_skv512_kv2_scale0125",
+            dict(head_dim=64, seqlen_q=256, softmax_scale=0.125),
+        ),
+        ("c11_b1_h1_d128_sq256_skv512_kv2_i64kv", dict(seqlen_q=256, use_int64_kv_strides=True)),
+        ("c12_b1_h1_d64_sq512_skv512_kv2_bucket1", dict(head_dim=64, seqlen_q=512)),
+        ("c13_b1_h1_d128_sq513_skv512_kv2_bucket2", dict(seqlen_q=513)),
+        ("c14_b1_h1_d128_sq49152_skv512_kv2_qb384_g1", dict(seqlen_q=49152)),
+        ("c15_b1_h1_d128_sq49153_skv512_kv2_qb385_g2", dict(seqlen_q=49153)),
+        (
+            "c16_b1_h1_d64_sq256_skv512_kv2_cancellation",
+            dict(head_dim=64, seqlen_q=256, data_mode="cancellation"),
+        ),
+        (
+            "c17_b1_h1_d128_sq256_skv512_kv2_sharp_softmax",
+            dict(seqlen_q=256, data_mode="sharp_softmax"),
+        ),
+    )
+    configs = []
+    for index, (label, overrides) in enumerate(rows):
+        configs.append(_config(label, seed=128001 + index, **overrides))
+    assert len(configs) == 18
+    return configs
+
+
+def benchmark_configs():
+    rows = (
+        ("p00_b1_h1_d64_sq128_skv4096_kv16", dict(head_dim=64, seqlen_kv=4096, kv_blocks=16)),
+        ("p01_b1_h1_d128_sq512_skv4096_kv16", dict(seqlen_q=512, seqlen_kv=4096, kv_blocks=16)),
+        (
+            "p02_b2_h8_d128_sq4096_skv8191_kv32",
+            dict(batch=2, num_heads=8, seqlen_q=4096, seqlen_kv=8191, kv_blocks=32),
+        ),
+        (
+            "p03_b1_h8_d64_sq4097_skv8191_maxkv32_var",
+            dict(
+                num_heads=8,
+                head_dim=64,
+                seqlen_q=4097,
+                seqlen_kv=8191,
+                kv_blocks=32,
+                block_count_mode="variable",
+                block_count_pattern="1,mid,max",
+            ),
+        ),
+        (
+            "p04_b2_h4_d128_sq4097_skv8191_maxkv32_empty",
+            dict(
+                batch=2,
+                num_heads=4,
+                seqlen_q=4097,
+                seqlen_kv=8191,
+                kv_blocks=32,
+                block_count_mode="variable_empty",
+                block_count_pattern="0,1,max",
+            ),
+        ),
+        (
+            "p05_b1_h4_d64_sq1024_skv32768_kv128",
+            dict(num_heads=4, head_dim=64, seqlen_q=1024, seqlen_kv=32768, kv_blocks=128),
+        ),
+        (
+            "p06_b1_h8_d128_sq2048_skv65536_kv256",
+            dict(num_heads=8, seqlen_q=2048, seqlen_kv=65536, kv_blocks=256),
+        ),
+        (
+            "p07_b1_h4_d128_sq49152_skv8192_kv32_qb384_g1",
+            dict(num_heads=4, seqlen_q=49152, seqlen_kv=8192, kv_blocks=32),
+        ),
+        (
+            "p08_b1_h4_d128_sq49153_skv8191_maxkv32_var_qb385_g2",
+            dict(
+                num_heads=4,
+                seqlen_q=49153,
+                seqlen_kv=8191,
+                kv_blocks=32,
+                block_count_mode="variable",
+                block_count_pattern="1,mid,max",
+            ),
+        ),
+        (
+            "p09_b1_h2_d64_sq262144_skv8192_kv32_qb2048_g4",
+            dict(num_heads=2, head_dim=64, seqlen_q=262144, seqlen_kv=8192, kv_blocks=32),
+        ),
+        (
+            "p10_b1_h1_d128_sq524288_skv8192_maxkv32_var_qb4096_g16_i64kv",
+            dict(
+                seqlen_q=524288,
+                seqlen_kv=8192,
+                kv_blocks=32,
+                block_count_mode="variable",
+                block_count_pattern="1,mid,max",
+                use_int64_kv_strides=True,
+            ),
+        ),
+        (
+            "p11_b1_h2_d128_sq524288_skv8192_kv32_qb4096_g8",
+            dict(num_heads=2, seqlen_q=524288, seqlen_kv=8192, kv_blocks=32),
+        ),
+        (
+            "p12_b1_h4_d128_sq8192_skv4096_kv16_bshd_scale0125",
+            dict(
+                num_heads=4,
+                seqlen_q=8192,
+                seqlen_kv=4096,
+                kv_blocks=16,
+                tensor_layout="bshd",
+                softmax_scale=0.125,
+            ),
+        ),
+    )
+    configs = []
+    for index, (label, overrides) in enumerate(rows):
+        configs.append(_config(label, seed=128101 + index, **overrides))
+    assert len(configs) == 13
+    return configs

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py
@@ -1,0 +1,122 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""SM100 blk128 block-sparse attention backward three-kernel program."""
+
+from ._block_sparse_attention_backward_sm100_blk128 import data as _data
+from ._block_sparse_attention_backward_sm100_blk128 import kernel as _kernel
+from ._block_sparse_attention_backward_sm100_blk128 import reference as _reference
+from ._block_sparse_attention_backward_sm100_blk128 import spec as _spec
+
+KERNEL_META = {
+    "name": "cudnn_sm100_bsa_backward_blk128",
+    "category": "cudnn",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
+
+CONFIGS = _spec.correctness_configs()
+BENCH_CONFIGS = _spec.benchmark_configs()
+
+
+def _without_label(config):
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def get_kernel(**config):
+    """Return sum_OdO, main backward, and convert in source launch order."""
+    return _kernel.get_kernel(**config)
+
+
+def prepare_data(**config):
+    return _data.prepare_data(**config)
+
+
+def run_test(**config):
+    """Validate TIRx against the analytic oracle and usable upstream specializations."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    kernel_config = _without_label(config)
+    data = prepare_data(**kernel_config)
+    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    tirx_launch = _data.tirx_launch(executables, data)
+    tirx_launch()
+    source_launch = _reference.compile_reference(data)
+    source_launch()
+    torch.cuda.synchronize()
+    _data.validate_outputs(data, sources=("tirx", "source"))
+
+
+def prepare_bench(**config):
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    state = {
+        "config": kernel_config,
+        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    data = prepare_data(**_without_label(config))
+    tirx_launch = _data.tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    with_source = external_references_enabled()
+    if with_source:
+        source_launch = _reference.compile_reference(data)
+        source_launch()
+        torch.cuda.synchronize()
+        references = {"cudnn_frontend": lambda: source_launch}
+    _data.validate_outputs(
+        data, sources=("tirx", "source") if with_source else ("tirx",), with_oracle=False
+    )
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py
@@ -13,7 +13,18 @@ from ._block_sparse_attention_backward_sm100_blk64 import spec as _spec
 KERNEL_META = {
     "name": "cudnn_sm100_bsa_backward_blk64",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _spec.correctness_configs()

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py
@@ -49,7 +49,18 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "cudnn_sm100_bsa_forward_combine_blk64",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _HEAD_DIM = 128

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py
@@ -16,7 +16,18 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "cudnn_sm100_bsa_forward_blk128",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py
+++ b/tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py
@@ -20,7 +20,18 @@ from ._block_sparse_attention_forward_sm100_blk64 import spec as _spec
 KERNEL_META = {
     "name": "cudnn_sm100_bsa_forward_blk64",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _spec.correctness_configs()

--- a/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
+++ b/tirx_kernels/cudnn/csa/compressor_fwd_sm100.py
@@ -16,7 +16,18 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "cudnn_sm100_csa_compressor_fwd",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _RATIO = 4

--- a/tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
+++ b/tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
@@ -23,7 +23,18 @@ from ._moe_blockscaled_grouped_gemm_dglu_dbias import spec as _spec
 KERNEL_META = {
     "name": "cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _spec.correctness_configs()

--- a/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py
@@ -22,7 +22,18 @@ from ._moe_grouped_gemm_dglu_dbias import spec as _spec
 KERNEL_META = {
     "name": "cudnn_sm100_moe_grouped_gemm_dglu_dbias",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _spec.correctness_configs()

--- a/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
+++ b/tirx_kernels/cudnn/dsa/_sparse_attention_backward/data.py
@@ -351,14 +351,16 @@ def compile_reference(data):
     return launch
 
 
-def tirx_launch(executables, data):
+def tirx_launch(executables, data, *, synchronize_stages=False):
     """Return a no-argument closure that runs the four TIRx kernels on ``data``.
 
     The zeroing is part of the closure, not of setup: ``dkv``, ``d_sink`` and both
     workspaces are accumulated into, so every repetition needs them clean. The
     upstream wrapper does the same zeroing inside its own timed call
     (``_interface_sm100.py:105-162``), which is what keeps the two timing scopes
-    comparable.
+    comparable. Correctness callers may synchronize after each device function
+    to attribute an asynchronous CUDA failure to the exact stage; benchmark
+    callers leave this disabled so the launch sequence remains unchanged.
     """
     import math
 
@@ -396,6 +398,16 @@ def tirx_launch(executables, data):
         inputs["topk_length"].reshape(-1) if inputs["topk_length"] is not None else topk_idxs
     )
 
+    def synchronize(stage):
+        if not synchronize_stages:
+            return
+        try:
+            torch.cuda.synchronize()
+        except RuntimeError as error:
+            raise RuntimeError(
+                f"TIRx DSA {stage} stage failed during CUDA synchronization"
+            ) from error
+
     def launch():
         out["dkv"].zero_()
         out["d_sink"].zero_()
@@ -412,6 +424,7 @@ def tirx_launch(executables, data):
             -1.0,
             neg_log2_e,
         )
+        synchronize("sum_odo")
         bwd(
             maps["q"].ptr,
             maps["do"].ptr,
@@ -427,10 +440,13 @@ def tirx_launch(executables, data):
             plane,
             scale,
         )
+        synchronize("bwd")
         convert(ws_dkv, out["dkv"].reshape(-1), seqlen_kv)
+        synchronize("convert")
         sum_dsink(
             ws_lse_odo, inputs["attn_sink"].reshape(-1), out["d_sink"].reshape(-1), seqlen_q, plane
         )
+        synchronize("sum_dsink")
 
     return launch
 

--- a/tirx_kernels/cudnn/dsa/sparse_attention_backward.py
+++ b/tirx_kernels/cudnn/dsa/sparse_attention_backward.py
@@ -24,7 +24,18 @@ from ._sparse_attention_backward import spec as _spec
 KERNEL_META = {
     "name": "cudnn_sm100_dsa_sparse_attention_backward",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _spec.correctness_configs()
@@ -54,7 +65,7 @@ def run_test(**config):
     kernel_config = _without_label(config)
     data = prepare_data(**kernel_config)
     executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
-    tirx_launch = _data.tirx_launch(executables, data)
+    tirx_launch = _data.tirx_launch(executables, data, synchronize_stages=True)
     tirx_launch()
     source_launch = _data.compile_reference(data)
     source_launch()

--- a/tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
+++ b/tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
@@ -483,7 +483,18 @@ def _benchmark_configs():
 KERNEL_META = {
     "name": "cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _correctness_configs()

--- a/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py
@@ -16,8 +16,22 @@ write gate ``w``, so ``K_decay`` folds beta into the operand, ``Y`` uses
 
 import tirx_kernels.kern as K
 
-KERNEL_META = {"name": "cudnn_sm100_gdn2_bprop_f16", "category": "cudnn", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "cudnn_sm100_gdn2_bprop_f16",
+    "category": "cudnn",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 CONFIGS = [
     {"label": "basic", "seq_lens": (64,), "heads": 1},
     {"label": "tail", "seq_lens": (17, 0, 33), "heads": 2},

--- a/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
@@ -15,7 +15,18 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "cudnn_sm100_gdn2_prefill_f16",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 # Deterministic pairwise cover of the frozen legal capability set.  Candidates

--- a/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
@@ -1,0 +1,4424 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Blackwell FP16/BF16 Gated Delta Net backward TIRx port.
+
+Upstream source:
+``python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py``
+(``prologue_kernel``, ``kernel``, and the two-launch ``run_bwd`` entry).
+
+The implementation preserves the upstream two-launch TensorMap prologue and
+persistent backward-main contract using only ``tirx_kernels.kern`` device APIs.
+"""
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cudnn_sm100_gdn_bprop_f16",
+    "category": "cudnn",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
+CONFIGS = [
+    {"label": "basic_bf16_full", "seq_lens": (64,), "heads": 1},
+    {"label": "basic_fp16_full", "seq_lens": (64,), "heads": 1, "dtype": "float16"},
+    {"label": "tail_zero", "seq_lens": (1, 63, 64, 65, 0), "heads": 2},
+    {"label": "gqa", "seq_lens": (128,), "heads": 64, "q_heads": 64, "k_heads": 16, "v_heads": 16},
+    {"label": "gva", "seq_lens": (128,), "heads": 64, "q_heads": 16, "k_heads": 16, "v_heads": 64},
+    {"label": "safe_gate", "seq_lens": (128,), "heads": 2, "safe_gate": True},
+    {"label": "beta_sigmoid", "seq_lens": (128,), "heads": 2, "beta_sigmoid": True},
+    {
+        "label": "state_io",
+        "seq_lens": (32, 0, 96),
+        "heads": 2,
+        "use_initial_state": True,
+        "use_dstate_in": True,
+        "use_dstate0": True,
+    },
+    {"label": "initial_state_only", "seq_lens": (0, 65), "heads": 2, "use_initial_state": True},
+    {"label": "final_state_only", "seq_lens": (65,), "heads": 2, "use_dstate_in": True},
+    {"label": "raw_gate", "seq_lens": (17, 65), "heads": 2, "log_gate": False},
+    {"label": "dynamic_scheduler", "seq_lens": (32, 96), "heads": 2, "dynamic_scheduler": True},
+    {"label": "order_scratch", "seq_lens": (32, 96), "heads": 2, "run_order": True},
+    {
+        "label": "order_generate",
+        "seq_lens": (32, 96),
+        "heads": 2,
+        "run_order": True,
+        "order_generate": True,
+    },
+    {"label": "split_scratch", "seq_lens": (257,), "heads": 2, "run_order": True, "split": True},
+    {"label": "nondefault_scale", "seq_lens": (128,), "heads": 2, "scale": 0.073},
+    {"label": "multi_tile", "seq_lens": (192,) * 8, "heads": 64},
+    {"label": "strong_decay_ragged", "seq_lens": (17, 129, 255), "heads": 4, "strong_decay": True},
+    {"label": "int64_cu", "seq_lens": (63, 65), "heads": 2, "cu_dtype": "int64"},
+]
+
+BENCH_CONFIGS = [
+    {"label": "perf_basic_b1_s2048_h16", "seq_lens": (2048,), "heads": 16},
+    {"label": "perf_basic_b1_s8192_h16", "seq_lens": (8192,), "heads": 16},
+    {"label": "perf_fp16_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "dtype": "float16"},
+    {"label": "perf_ragged_b3_h16", "seq_lens": (2047, 0, 4093), "heads": 16},
+    {
+        "label": "perf_gqa_b1_s8192_hq64_hk16_hv16",
+        "seq_lens": (8192,),
+        "heads": 64,
+        "q_heads": 64,
+        "k_heads": 16,
+        "v_heads": 16,
+    },
+    {
+        "label": "perf_gva_b1_s8192_hq16_hk16_hv64",
+        "seq_lens": (8192,),
+        "heads": 64,
+        "q_heads": 16,
+        "k_heads": 16,
+        "v_heads": 64,
+    },
+    {"label": "perf_safe_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "safe_gate": True},
+    {"label": "perf_beta_b1_s8192_h16", "seq_lens": (8192,), "heads": 16, "beta_sigmoid": True},
+    {
+        "label": "perf_state_b1_s8192_h16",
+        "seq_lens": (8192,),
+        "heads": 16,
+        "use_initial_state": True,
+        "use_dstate_in": True,
+        "use_dstate0": True,
+    },
+    {
+        "label": "perf_dynamic_b4_s2048_h64",
+        "seq_lens": (2048,) * 4,
+        "heads": 64,
+        "dynamic_scheduler": True,
+    },
+    {
+        "label": "perf_order_scratch_b4_s2048_h64",
+        "seq_lens": (2048,) * 4,
+        "heads": 64,
+        "run_order": True,
+    },
+    {
+        "label": "perf_order_generate_b4_s2048_h64",
+        "seq_lens": (2048,) * 4,
+        "heads": 64,
+        "run_order": True,
+        "order_generate": True,
+    },
+    {"label": "perf_b4_s2048_h64", "seq_lens": (2048,) * 4, "heads": 64},
+    {"label": "perf_b4_s4096_h64", "seq_lens": (4096,) * 4, "heads": 64},
+    {"label": "perf_b4_s8192_h64", "seq_lens": (8192,) * 4, "heads": 64},
+    {"label": "perf_b4_s16384_h64", "seq_lens": (16384,) * 4, "heads": 64},
+    {"label": "perf_b4_s32768_h64", "seq_lens": (32768,) * 4, "heads": 64},
+    {"label": "perf_b1_s8192_h64", "seq_lens": (8192,), "heads": 64},
+    {"label": "perf_b2_s8192_h64", "seq_lens": (8192,) * 2, "heads": 64},
+    {"label": "perf_b8_s8192_h64", "seq_lens": (8192,) * 8, "heads": 64},
+    {"label": "perf_b16_s8192_h64", "seq_lens": (8192,) * 16, "heads": 64},
+]
+
+
+_BT = 64
+_DK = 128
+_DV = 128
+_TENSOR_MAP_BYTES = 128
+_TENSOR_MAP_WORDS = 16
+_TENSOR_MAP_ARRAYS = 8
+_TRY_WAIT_TICKS = 0
+_RCP_LN2 = 1.4426950408889634
+_LN2 = 0.6931471805599453
+_TMA_G2S_3D = "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+_TMA_G2S_4D = "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+_TMA_S2G_3D = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+
+# Reviewer-reconciled declaration-order mbarrier header.
+_BAR_Q_READY = 0
+_BAR_Q_MMA_DONE = 16
+_BAR_Q_CG1_DONE = 32
+_BAR_K_READY = 48
+_BAR_K_MMA_DONE = 64
+_BAR_K_CG0_DONE = 80
+_BAR_V_READY = 96
+_BAR_V_MMA_DONE = 112
+_BAR_DO_READY = 128
+_BAR_DO_MMA_DONE = 144
+_BAR_STATE_READY = 160
+_BAR_STATE_MMA_DONE = 176
+_BAR_GATE_READY = 192
+_BAR_GATE_DONE = 208
+_BAR_BETA_READY = 224
+_BAR_BETA_DONE = 240
+_BAR_DSTATE_ACC_READY = 256
+_BAR_DSTATE_SCALE_DONE = 272
+_BAR_DU_SCALE_READY = 288
+_BAR_DU_SCALE_DONE = 304
+_BAR_DU_TOTAL_READY = 320
+_BAR_DK_SCALE_READY = 336
+_BAR_DK_SCALE_DONE = 352
+_BAR_DK_ATTN_READY = 368
+_BAR_DK_ATTN_DONE = 384
+_BAR_DK_TOTAL_READY = 400
+_BAR_DK_TOTAL_DONE = 416
+_BAR_DQ_SCALE_READY = 432
+_BAR_DQ_SCALE_DONE = 448
+_BAR_DQ_TOTAL_READY = 464
+_BAR_DQ_TOTAL_DONE = 480
+_BAR_KK_READY = 496
+_BAR_KK_DONE = 512
+_BAR_A_ACC_READY = 528
+_BAR_K_STATE_READY = 544
+_BAR_U_ACC_READY = 560
+_BAR_DY_ACC_READY = 576
+_BAR_DA_ACC_READY = 592
+_BAR_DM_ACC_READY = 608
+_BAR_DM_ACC_DONE = 624
+_BAR_DK_STATE_READY = 640
+_BAR_DSTATE_INP_READY = 656
+_BAR_DSTATE_INP_DONE = 672
+_BAR_DO_PRIME_READY = 688
+_BAR_DU_INP_READY = 704
+_BAR_DYP_INP_READY = 720
+_BAR_Y_READY = 736
+_BAR_TINV_READY = 752
+_BAR_A_READY = 768
+_BAR_A_DONE = 784
+_BAR_U_READY = 800
+_BAR_DSTATE_SMEM_READY = 816
+_BAR_STATE_DOT_DONE = 832
+_BAR_DA_READY = 848
+_BAR_DBETA_CG1_READY = 864
+_BAR_DGATE_CG1_READY = 880
+_BAR_DQ_STG_READY = 896
+_BAR_DQ_STG_DONE = 912
+_BAR_DK_STG_READY = 928
+_BAR_DK_STG_DONE = 944
+_BAR_DV_STG_READY = 960
+_BAR_DV_STG_DONE = 976
+_BAR_SDV_DONE = 992
+_BAR_TMEM_DONE = 1008
+_BAR_SCHED_READY = 1024
+_BAR_SCHED_DONE = 1040
+
+_SCHED_BASE = 1056
+_TMEM_MAILBOX = 1072
+_CUMSUMLOG_BASE = 1152
+_CUMPROD_BASE = 1664
+_BETA_BASE = 2176
+_Q_BASE = 3072
+_K_BASE = 19456
+_DO_BASE = 52224
+_STATE_BASE = 68608
+_TINV_BASE = 101376
+_KK_BASE = 109568
+_A_DA_BASE = 117760
+_DM_BASE = 125952
+_V_U_BASE = 134144
+_DSTATE_BASE = 150528
+_DQ_BASE = 183296
+_DK_BASE = 199680
+_DV_DY_BASE = 216064
+_ARENA_BYTES = 232448
+
+_TM_DSTATE = 0
+_TM_DVDK = 128
+_TM_DSTATE_INP = 192
+_TM_ACC0 = 256
+_TM_ACC1 = 320
+_TM_INP0 = 384
+_TM_INP1 = 416
+_TM_Y = 448
+_TM_GK = 480
+
+_IDESC_M64_N64_BF16 = 68158608
+_IDESC_M128_N64_BF16 = 135267472
+_IDESC_M128_N64_A_BF16 = 135300240
+_IDESC_M128_N64_B_BF16 = 135333008
+_IDESC_M128_N64_AB_BF16 = 135365776
+_IDESC_M128_N128_B_BF16 = 136381584
+
+
+def _elected():
+    lane = K.local_scalar("uint32")
+    pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(lane, pred, K.uint32(0xFFFFFFFF))
+    return pred == K.uint32(1)
+
+
+def _load_tensormap(payload, src_map):
+    """Load one host-encoded 128-byte TensorMap image into registers.
+
+    The base images use ordinary global pointers because K's PTX instruction
+    surface intentionally has no parameter-space load; issuing the loads
+    before the order pass hides their cold-memory latency, and one load
+    serves every per-sequence slot of the array.
+    """
+    source = K.reinterpret("uint64", src_map.ptr_to([0]))
+    for group in range(4):
+        offset = K.uint64(group * 32)
+        K.ptx.ld.global_.v4.b64(
+            payload[group * 4],
+            payload[group * 4 + 1],
+            payload[group * 4 + 2],
+            payload[group * 4 + 3],
+            K.reinterpret("handle", source + offset),
+        )
+
+
+def _store_tensormap(dst, payload):
+    target = K.reinterpret("uint64", dst)
+    for word in range(16):
+        K.ptx.st.global_.b64(K.reinterpret("handle", target + K.uint64(word * 8)), payload[word])
+
+
+def _replace_tensormap_address(desc, address):
+    K.ptx.tensormap_replace.tile.global_address.global_.b1024.b64(
+        desc, K.reinterpret("uint64", address)
+    )
+
+
+def _replace_tensormap_dim(desc, ordinal, value):
+    K.ptx.tensormap_replace.tile.global_dim.global_.b1024.b32(
+        desc, K.uint32(ordinal), K.cast(value, "uint32")
+    )
+
+
+def _barrier_ptr(arena, byte_offset, stage=0):
+    return arena.ptr_to([byte_offset + K.cast(stage, "int32") * 8])
+
+
+def _wait_barrier(arena, byte_offset, stage, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        barrier_address = K.cuda.cvta_generic_to_shared(arena.ptr_to([0])) + K.cast(
+            byte_offset + stage * 8, "uint32"
+        )
+        K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+            ready, barrier_address, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _arrive_barrier(arena, byte_offset, stage=0):
+    K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage))
+
+
+def _expect_tx(arena, byte_offset, stage, nbytes, *, pred=None):
+    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+        _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes), pred=pred
+    )
+
+
+def _tcgen_commit(arena, byte_offset, stage=0, *, leader):
+    K.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+        _barrier_ptr(arena, byte_offset, stage), pred=leader
+    )
+
+
+def _load_work_item(work_items, tile):
+    values = K.alloc_local((8,), "int32")
+    K.ptx.ld.global_.v4.b32(
+        values[0], values[1], values[2], values[3], work_items.ptr_to([tile * 8])
+    )
+    K.ptx.ld.global_.v4.b32(
+        values[4], values[5], values[6], values[7], work_items.ptr_to([tile * 8 + 4])
+    )
+    return values
+
+
+def _udiv_nonnegative(value, divisor):
+    """Divide a scheduler field known nonnegative without signed fixup math."""
+    return K.cast(K.cast(value, "uint32") // K.uint32(divisor), "int32")
+
+
+def _load_cu(cu_seqlens, index, cu_dtype):
+    if cu_dtype == "int64":
+        wide = K.local_scalar("int64")
+        K.ptx.ld.global_.s64(wide, cu_seqlens.ptr_to([index]))
+        return K.cast(wide, "int32")
+    value = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(value, cu_seqlens.ptr_to([index]))
+    return value
+
+
+def _load_state_value(pointer, index, state_dtype):
+    value = K.local_scalar("float32")
+    if state_dtype == "float32":
+        K.ptx.ld.global_.f32(value, pointer.ptr_to([index]))
+    else:
+        bits = K.local_scalar("uint16")
+        K.ptx.ld.global_.b16(bits, pointer.ptr_to([index]))
+        K.ptx.cvt.f32.bf16(value, bits)
+    return value
+
+
+def _store_state_value(pointer, index, value, state_dtype):
+    if state_dtype == "float32":
+        K.ptx.st.global_.f32(pointer.ptr_to([index]), value)
+    else:
+        K.ptx.st.global_.b16(
+            pointer.ptr_to([index]), K.reinterpret("uint16", K.cast(value, "bfloat16"))
+        )
+
+
+def _descriptor_slot(workspace, n_desc, array, batch):
+    return workspace.ptr_to([(K.cast(array, "int64") * n_desc + batch) * _TENSOR_MAP_WORDS])
+
+
+def _pack_io_pair(lo, hi, io_dtype):
+    packed = K.local_scalar("uint32")
+    if io_dtype == "float16":
+        K.ptx.cvt.rn.f16x2.f32(packed, hi, lo)
+    else:
+        K.ptx.cvt.rn.bf16x2.f32(packed, hi, lo)
+    return packed
+
+
+def _unpack_io_pair(packed, lo, hi, io_dtype):
+    halves = K.alloc_local((2,), "uint16")
+    K.ptx.mov.b32(halves[0], halves[1], packed)
+    if io_dtype == "float16":
+        K.ptx.cvt.f32.f16(lo, halves[0])
+        K.ptx.cvt.f32.f16(hi, halves[1])
+    else:
+        low_bits = K.local_scalar("uint32")
+        high_bits = K.local_scalar("uint32")
+        K.ptx.mov.b32(low_bits, K.uint16(0), halves[0])
+        K.ptx.mov.b32(high_bits, K.uint16(0), halves[1])
+        K.assign(lo, K.reinterpret("float32", low_bits))
+        K.assign(hi, K.reinterpret("float32", high_bits))
+
+
+def _sub_io_pair(dst, lhs, rhs, io_dtype):
+    if io_dtype == "float16":
+        K.ptx.sub.f16x2(dst, lhs, rhs)
+    else:
+        K.ptx["sub.bf16x2"](dst, lhs, rhs)
+
+
+def _fadd2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.add.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _fsub2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.sub.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _fmul2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.mul.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _exp2(value):
+    result = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(result, value)
+    return result
+
+
+def _lg2(value):
+    result = K.local_scalar("float32")
+    K.ptx.lg2.approx.ftz.f32(result, value)
+    return result
+
+
+def _tanh(value):
+    result = K.local_scalar("float32")
+    K.ptx.tanh.approx.f32(result, value)
+    return result
+
+
+def _softplus(value):
+    # log(1 + exp(x)) with the source's linear tail (x > 20 returns x).
+    grown = _exp2(value * K.float32(_RCP_LN2))
+    smooth = _lg2(K.float32(1.0) + grown) * K.float32(_LN2)
+    return K.if_then_else(value < K.float32(20.0), smooth, value)
+
+
+def _opaque_zero():
+    zero = K.local_scalar("float32")
+    K.ptx.mov.b32(zero, K.uint32(0))
+    return zero
+
+
+def _shfl_idx_f32(value, source_lane, clamp):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.idx.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.cast(source_lane, "uint32"),
+        K.uint32(clamp),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _shfl_up_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.up.b32(
+        shuffled, K.reinterpret("uint32", value), K.uint32(delta), K.uint32(0), K.uint32(0xFFFFFFFF)
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _shfl_down_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.down.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.uint32(delta),
+        K.uint32(31),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _shfl_bfly_f32(value, lane_mask):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.uint32(lane_mask),
+        K.uint32(31),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _ffma2(a0, a1, b0, b1, c0, c1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.fma.rn.f32x2(
+        packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1), K.cuda.make_float2(c0, c1)
+    )
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _rcp(value):
+    result = K.local_scalar("float32")
+    K.ptx.rcp.approx.ftz.f32(result, value)
+    return result
+
+
+def _io_byte(base, stage, row, channel):
+    segment = channel // 64
+    within = channel % 64
+    return base + stage * 16_384 + 2 * (segment * 4096 + row * 64 + _swizzle_xor_128b(row, within))
+
+
+def _state_byte(base, key, value):
+    segment = value // 64
+    within = value % 64
+    return base + 2 * (segment * 8192 + key * 64 + _swizzle_xor_128b(key, within))
+
+
+def _tcgen_load_16x256x8(tmem_address):
+    values = K.alloc_local((32,), "float32")
+    K.ptx["tcgen05.ld.sync.aligned.16x256b.x8.b32"](
+        *[values[index] for index in range(32)], K.cast(tmem_address, "uint32")
+    )
+    return values
+
+
+def _tcgen_store_16x256x8(tmem_address, values):
+    K.ptx["tcgen05.st.sync.aligned.16x256b.x8.b32"](
+        K.cast(tmem_address, "uint32"), *[values[index] for index in range(32)]
+    )
+
+
+def _tcgen_load_32x32x32(tmem_address):
+    values = K.alloc_local((32,), "float32")
+    K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+        *[values[index] for index in range(32)], K.cast(tmem_address, "uint32")
+    )
+    return values
+
+
+def _tcgen_store_32x32x32(tmem_address, values):
+    K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+        K.cast(tmem_address, "uint32"), *[values[index] for index in range(32)]
+    )
+
+
+def _tcgen_store_32x32x16(tmem_address, values):
+    K.ptx["tcgen05.st.sync.aligned.32x32b.x16.b32"](
+        K.cast(tmem_address, "uint32"), *[values[index] for index in range(16)]
+    )
+
+
+def _tcgen_store_16x128x8(tmem_address, values):
+    K.ptx["tcgen05.st.sync.aligned.16x128b.x8.b32"](
+        K.cast(tmem_address, "uint32"), *[values[index] for index in range(16)]
+    )
+
+
+def _tcgen_load_16x128x8(tmem_address):
+    values = K.alloc_local((16,), "uint32")
+    K.ptx["tcgen05.ld.sync.aligned.16x128b.x8.b32"](
+        *[values[index] for index in range(16)], K.cast(tmem_address, "uint32")
+    )
+    return values
+
+
+def _tcgen_wait_load():
+    K.ptx.tcgen05.wait__ld.sync.aligned()
+
+
+def _tcgen_wait_store():
+    K.ptx.tcgen05.wait__st.sync.aligned()
+
+
+def _raw_descriptor(arena, byte_offset, leading_bytes, stride_bytes, layout):
+    shared = K.cuda.cvta_generic_to_shared(arena.ptr_to([byte_offset]))
+    address = K.bitwise_and(K.shift_right(shared, K.uint32(4)), K.uint32(0x3FFF))
+    fixed = (
+        (((leading_bytes >> 4) & 0x3FFF) << 16) | (((stride_bytes >> 4) & 0x3FFF) << 32) | (1 << 46)
+    )
+    desc = K.bitwise_or(K.uint64(fixed), K.cast(address, "uint64"))
+    return K.bitwise_or(desc, K.shift_left(K.uint64(layout & 7), K.uint64(61)))
+
+
+def _swizzle_xor_128b(row, column):
+    # physical column element for the 128-byte XOR swizzle of a bf16/f16 row
+    return K.bitwise_xor(column, (row & 7) * 8)
+
+
+def _swizzle_lin_128b(linear):
+    # 128-byte XOR swizzle over a linear 64-element-row bf16/f16 index
+    return K.bitwise_xor(linear, K.bitwise_and(K.shift_right(linear, K.int32(3)), K.int32(0x38)))
+
+
+def _io_tile_byte(base, stage_bytes, stage, row, column):
+    # byte offset of (row, column) in one 64-column swizzled IO tile stage
+    return base + stage * stage_bytes + (row * 64 + _swizzle_xor_128b(row, column)) * 2
+
+
+def _mma_m16n8k16(acc, acc_base, a, b0, b1, io_dtype):
+    opcode = (
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"
+        if io_dtype == "float16"
+        else "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32"
+    )
+    K.ptx[opcode](
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b0,
+        b1,
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+    )
+
+
+def _mma_m16n8k8(acc, acc_base, a0, a1, b0, io_dtype):
+    opcode = (
+        "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"
+        if io_dtype == "float16"
+        else "mma.sync.aligned.m16n8k8.row.col.f32.bf16.bf16.f32"
+    )
+    K.ptx[opcode](
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+        a0,
+        a1,
+        b0,
+        acc[acc_base],
+        acc[acc_base + 1],
+        acc[acc_base + 2],
+        acc[acc_base + 3],
+    )
+
+
+def _ldmatrix_x4(dst, pointer, *, trans):
+    if trans:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+            dst[0], dst[1], dst[2], dst[3], pointer
+        )
+    else:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(dst[0], dst[1], dst[2], dst[3], pointer)
+
+
+def _ldmatrix_x1(pointer, *, trans):
+    frag = K.local_scalar("uint32")
+    if trans:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x1.trans.shared.b16(frag, pointer)
+    else:
+        K.ptx.ldmatrix.sync.aligned.m8n8.x1.shared.b16(frag, pointer)
+    return frag
+
+
+def _stmatrix_x4(pointer, words):
+    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(pointer, words[0], words[1], words[2], words[3])
+
+
+def _tinv_row_ptr(arena, tinv_byte_base, d, tidx_in_group):
+    row_linear = (d * 8 + tidx_in_group) * 64 + d * 8
+    return arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(row_linear) * 2])
+
+
+def _invert_diagonal_8x8(arena, raw_byte_base, tinv_byte_base, d, tidx_in_group, io_dtype):
+    """Gauss-Jordan inversion of one diagonal 8x8 block in place (IO SMEM)."""
+    row_ptr_in = _tinv_row_ptr(arena, raw_byte_base, d, tidx_in_group)
+    row_ptr = _tinv_row_ptr(arena, tinv_byte_base, d, tidx_in_group)
+    words = K.alloc_local((4,), "uint32")
+    K.ptx.ld.shared.v4.b32(words[0], words[1], words[2], words[3], row_ptr_in)
+    row = K.alloc_local((8,), "float32")
+    for pair in range(4):
+        _unpack_io_pair(words[pair], row[pair * 2], row[pair * 2 + 1], io_dtype)
+    for i in range(8):
+        K.assign(row[i], K.if_then_else(tidx_in_group == i, K.float32(1.0), row[i]))
+    for src_row in range(7):
+        row_scale = K.local_scalar("float32", init=-row[src_row])
+        for i in range(src_row):
+            shuffled = _shfl_idx_f32(row[i], src_row, 0b1100000011111)
+            K.assign(
+                row[i],
+                K.if_then_else(tidx_in_group > src_row, row[i] + row_scale * shuffled, row[i]),
+            )
+        K.assign(row[src_row], K.if_then_else(tidx_in_group > src_row, row_scale, row[src_row]))
+    for pair in range(4):
+        K.assign(words[pair], _pack_io_pair(row[pair * 2], row[pair * 2 + 1], io_dtype))
+    K.ptx.st.shared.v4.b32(row_ptr, words[0], words[1], words[2], words[3])
+
+
+def _blockwise_8_to_16(arena, tinv_byte_base, raw_byte_base, d0, lane, io_dtype):
+    """Off-diagonal correction 8x8 -> 16x16: C <- -(D^-1 C) A^-1."""
+    lane_off = (lane % 8) * 64
+    d_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + 8 + lane_off) * 2]),
+        trans=False,
+    )
+    c_frag = _ldmatrix_x1(
+        arena.ptr_to([raw_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    c_regs = K.alloc_local((4,), "float32")
+    for accum in range(4):
+        K.assign(c_regs[accum], K.float32(0.0))
+    _mma_m16n8k8(c_regs, 0, d_frag, d_frag, c_frag, io_dtype)
+    a_pack = K.alloc_local((2,), "uint32")
+    for pair in range(2):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frag = _ldmatrix_x1(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(d0 * 64 + d0 + lane_off) * 2]), trans=True
+    )
+    o_regs = K.alloc_local((4,), "float32")
+    for accum in range(4):
+        K.assign(o_regs[accum], K.float32(0.0))
+    _mma_m16n8k8(o_regs, 0, a_pack[0], a_pack[1], ai_frag, io_dtype)
+    o_pack = _pack_io_pair(o_regs[0], o_regs[1], io_dtype)
+    K.ptx.stmatrix.sync.aligned.m8n8.x1.shared.b16(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 8) * 64 + d0 + lane_off) * 2]),
+        o_pack,
+    )
+
+
+def _blockwise_16_to_32(arena, tinv_byte_base, raw_byte_base, d0, lane, io_dtype):
+    """Off-diagonal correction 16x16 -> 32x32."""
+    lane_off = (lane % 16) * 64 + (lane // 16) * 8
+    d_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        d_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + 16 + lane_off) * 2]),
+        trans=False,
+    )
+    c_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        c_frag,
+        arena.ptr_to([raw_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    c_regs = K.alloc_local((8,), "float32")
+    for accum in range(8):
+        K.assign(c_regs[accum], K.float32(0.0))
+    for n_frag in range(2):
+        _mma_m16n8k16(
+            c_regs, n_frag * 4, d_frag, c_frag[n_frag * 2], c_frag[n_frag * 2 + 1], io_dtype
+        )
+    a_pack = K.alloc_local((4,), "uint32")
+    for pair in range(4):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frag = K.alloc_local((4,), "uint32")
+    _ldmatrix_x4(
+        ai_frag,
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b(d0 * 64 + d0 + lane_off) * 2]),
+        trans=True,
+    )
+    o_regs = K.alloc_local((8,), "float32")
+    for accum in range(8):
+        K.assign(o_regs[accum], K.float32(0.0))
+    for n_frag in range(2):
+        _mma_m16n8k16(
+            o_regs, n_frag * 4, a_pack, ai_frag[n_frag * 2], ai_frag[n_frag * 2 + 1], io_dtype
+        )
+    o_pack = K.alloc_local((4,), "uint32")
+    for pair in range(4):
+        K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
+    _stmatrix_x4(
+        arena.ptr_to([tinv_byte_base + _swizzle_lin_128b((d0 + 16) * 64 + d0 + lane_off) * 2]),
+        o_pack,
+    )
+
+
+def _blockwise_32_to_64(arena, tinv_byte_base, raw_byte_base, band, lane, io_dtype, store_result):
+    """Off-diagonal correction 32x32 -> 64x64 (two warps, one 16-row band each)."""
+    lane_off = (lane % 16) * 64 + (lane // 16) * 8
+    a_frags = K.alloc_local((8,), "uint32")
+    for vs in range(2):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b((32 + band * 16) * 64 + 32 + vs * 16 + lane_off) * 2
+                ]
+            ),
+            trans=False,
+        )
+        for i in range(4):
+            K.assign(a_frags[vs * 4 + i], chunk[i])
+    b_frags = K.alloc_local((16,), "uint32")
+    for vs in range(4):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    raw_byte_base
+                    + _swizzle_lin_128b((32 + (vs // 2) * 16) * 64 + (vs % 2) * 16 + lane_off) * 2
+                ]
+            ),
+            trans=True,
+        )
+        for i in range(4):
+            K.assign(b_frags[vs * 4 + i], chunk[i])
+    c_regs = K.alloc_local((16,), "float32")
+    for accum in range(16):
+        K.assign(c_regs[accum], K.float32(0.0))
+    for k_step in range(2):
+        a_view = [a_frags[k_step * 4 + i] for i in range(4)]
+        for n_frag in range(4):
+            _mma_m16n8k16(
+                c_regs,
+                n_frag * 4,
+                a_view,
+                b_frags[k_step * 8 + n_frag * 2],
+                b_frags[k_step * 8 + n_frag * 2 + 1],
+                io_dtype,
+            )
+    a_pack = K.alloc_local((8,), "uint32")
+    for pair in range(8):
+        K.assign(a_pack[pair], _pack_io_pair(-c_regs[2 * pair], -c_regs[2 * pair + 1], io_dtype))
+    ai_frags = K.alloc_local((16,), "uint32")
+    for vs in range(4):
+        chunk = K.alloc_local((4,), "uint32")
+        _ldmatrix_x4(
+            chunk,
+            arena.ptr_to(
+                [
+                    tinv_byte_base
+                    + _swizzle_lin_128b(((vs // 2) * 16) * 64 + (vs % 2) * 16 + lane_off) * 2
+                ]
+            ),
+            trans=True,
+        )
+        for i in range(4):
+            K.assign(ai_frags[vs * 4 + i], chunk[i])
+    o_regs = K.alloc_local((16,), "float32")
+    for accum in range(16):
+        K.assign(o_regs[accum], K.float32(0.0))
+    for k_step in range(2):
+        a_view = [a_pack[k_step * 4 + i] for i in range(4)]
+        for n_frag in range(4):
+            _mma_m16n8k16(
+                o_regs,
+                n_frag * 4,
+                a_view,
+                ai_frags[k_step * 8 + n_frag * 2],
+                ai_frags[k_step * 8 + n_frag * 2 + 1],
+                io_dtype,
+            )
+    o_pack = K.alloc_local((8,), "uint32")
+    for pair in range(8):
+        K.assign(o_pack[pair], _pack_io_pair(o_regs[2 * pair], o_regs[2 * pair + 1], io_dtype))
+    K.ptx.bar.sync(K.uint32(3), K.uint32(64))
+    with K.If(store_result), K.Then():
+        _stmatrix_x4(
+            arena.ptr_to(
+                [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + lane_off) * 2]
+            ),
+            [o_pack[0], o_pack[1], o_pack[2], o_pack[3]],
+        )
+        _stmatrix_x4(
+            arena.ptr_to(
+                [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2]
+            ),
+            [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
+        )
+
+
+def _acc_operand(accumulate):
+    if isinstance(accumulate, bool | int):
+        return K.uint32(int(accumulate))
+    return K.cast(accumulate, "uint32")
+
+
+def _tcgen_mma_ss(
+    dst,
+    a_desc,
+    b_desc,
+    idesc,
+    *,
+    leader,
+    m,
+    n,
+    k_extent,
+    a_transpose=False,
+    b_transpose=False,
+    accumulate,
+):
+    def swizzle_bytes(inner_bytes):
+        if inner_bytes % 128 == 0:
+            return 128
+        if inner_bytes % 64 == 0:
+            return 64
+        return 32
+
+    swizzle_a = swizzle_bytes((m if a_transpose else k_extent) * 2)
+    swizzle_b = swizzle_bytes((n if b_transpose else k_extent) * 2)
+    intra_a = 16 * swizzle_a if a_transpose else 32
+    intra_b = 16 * swizzle_b if b_transpose else 32
+    subtile_a = k_extent * swizzle_a if a_transpose else swizzle_a * m
+    subtile_b = k_extent * swizzle_b if b_transpose else swizzle_b * n
+    steps_a = k_extent // 16 if a_transpose else (swizzle_a // 2) // 16
+    steps_b = k_extent // 16 if b_transpose else (swizzle_b // 2) // 16
+    for step in range(k_extent // 16):
+        inc_a = (intra_a * (step % steps_a) + subtile_a * (step // steps_a)) >> 4
+        inc_b = (intra_b * (step % steps_b) + subtile_b * (step // steps_b)) >> 4
+        K.ptx[_MMA_F16](
+            K.cast(dst, "uint32"),
+            a_desc + K.uint64(inc_a),
+            b_desc + K.uint64(inc_b),
+            K.uint32(idesc),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.ptx.pred(_acc_operand(accumulate) if step == 0 else K.uint32(1)),
+            pred=leader,
+        )
+
+
+def _tcgen_mma_ts(
+    dst, tmem_a, b_desc, idesc, *, leader, n, k_extent, b_transpose=False, accumulate
+):
+    inner_bytes = (n if b_transpose else k_extent) * 2
+    swizzle_b = 128 if inner_bytes % 128 == 0 else 64 if inner_bytes % 64 == 0 else 32
+    intra_b = 16 * swizzle_b if b_transpose else 32
+    subtile_b = k_extent * swizzle_b if b_transpose else swizzle_b * n
+    steps_b = k_extent // 16 if b_transpose else (swizzle_b // 2) // 16
+    for step in range(k_extent // 16):
+        inc_b = (intra_b * (step % steps_b) + subtile_b * (step // steps_b)) >> 4
+        K.ptx[_MMA_F16](
+            K.cast(dst, "uint32"),
+            K.cast(tmem_a + step * 8, "uint32"),
+            b_desc + K.uint64(inc_b),
+            K.uint32(idesc),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.uint32(0),
+            K.ptx.pred(_acc_operand(accumulate) if step == 0 else K.uint32(1)),
+            pred=leader,
+        )
+
+
+def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out, cu_dtype):
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+
+    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    def prologue(
+        base_q: K.gptr[K.i64],
+        base_k: K.gptr[K.i64],
+        base_v: K.gptr[K.i64],
+        base_do: K.gptr[K.i64],
+        base_checkpoint: K.gptr[K.i64],
+        base_dq: K.gptr[K.i64],
+        base_dk: K.gptr[K.i64],
+        base_dv: K.gptr[K.i64],
+        descriptor_workspace: K.gptr[K.i64],
+        cu_seqlens: K.gptr[cu_t],
+        q: K.gptr[K.u8],
+        k: K.gptr[K.u8],
+        v: K.gptr[K.u8],
+        do: K.gptr[K.u8],
+        checkpoint: K.gptr[K.u8],
+        dq: K.gptr[K.u8],
+        dk: K.gptr[K.u8],
+        dv: K.gptr[K.u8],
+        work_item_staging: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        work_items: K.gptr[K.i32],
+        scheduler_all: K.gptr[K.i32],
+        n_batch: K.i32,
+        q_row_stride_bytes: K.i32,
+        k_row_stride_bytes: K.i32,
+        v_row_stride_bytes: K.i32,
+        do_row_stride_bytes: K.i32,
+        checkpoint_row_stride_bytes: K.i32,
+        dq_row_stride_bytes: K.i32,
+        dk_row_stride_bytes: K.i32,
+        dv_row_stride_bytes: K.i32,
+        checkpoint_every_n: K.i32,
+    ):
+        thread = K.thread_id()
+        warp = K.warp_id()
+        map_payload = K.alloc_local((16,), "uint64")
+        preload_maps = (base_q, base_k, base_v, base_do, base_checkpoint, base_dq, base_dk, base_dv)
+        for array_index, base_map in enumerate(preload_maps):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    _load_tensormap(map_payload, base_map)
+
+        if run_order:
+            order_arena = K.alloc_buffer((32_776,), K.u8, scope="shared.dyn", align=16)
+            with K.If(thread == 0), K.Then():
+                for scheduler_word in range(4):
+                    K.ptx.st.global_.s32(scheduler_all.ptr_to([scheduler_word]), K.int32(0))
+
+            item_count = K.local_scalar("int32")
+            if order_generate:
+                K.assign(item_count, n_batch * n_heads_out)
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.global_.s32(work_count.ptr_to([0]), item_count)
+            else:
+                K.ptx.ld.global_.s32(item_count, work_count.ptr_to([0]))
+
+            def write_work_item(destination, source):
+                if order_generate:
+                    batch = source // n_heads_out
+                    head = source - batch * n_heads_out
+                    begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                    end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                    chunks = (end - begin + _BT - 1) // _BT
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8]), batch, head, K.int32(0), chunks
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8 + 4]), K.int32(0), chunks, begin, end
+                    )
+                else:
+                    for field in range(8):
+                        value = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
+                        K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
+
+            with K.If(item_count > 4096), K.Then():
+                item = K.local_scalar("int32", init=thread)
+                with K.While(item < item_count):
+                    write_work_item(item, item)
+                    K.assign(item, item + 1024)
+            with K.If(item_count <= 4096), K.Then():
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.shared.v2.u32(
+                        order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
+                    )
+                padded_count = K.local_scalar("int32", init=K.int32(1))
+                with K.While(padded_count < item_count):
+                    K.assign(padded_count, padded_count * 2)
+                K.cuda.cta_sync()
+                local_min = K.local_scalar("int32", init=K.int32(2_147_483_647))
+                local_max = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                for element in range(4):
+                    item = thread + element * 1024
+                    with K.If(item < padded_count), K.Then():
+                        key = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                        with K.If(item < item_count), K.Then():
+                            if order_generate:
+                                batch = item // n_heads_out
+                                begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                                end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                                K.assign(key, (end - begin + _BT - 1) // _BT)
+                            else:
+                                cstart = K.local_scalar("int32")
+                                cend = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(
+                                    cstart, work_item_staging.ptr_to([item * 8 + 4])
+                                )
+                                K.ptx.ld.global_.s32(cend, work_item_staging.ptr_to([item * 8 + 5]))
+                                K.assign(key, cend - cstart)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([16_384 + item * 4]), item)
+                        with K.If(item < item_count), K.Then():
+                            K.assign(local_min, K.if_then_else(local_min < key, local_min, key))
+                            K.assign(local_max, K.if_then_else(local_max > key, local_max, key))
+                old = K.local_scalar("int32")
+                K.ptx["atom.shared::cta.min.s32"](old, order_arena.ptr_to([32_768]), local_min)
+                K.ptx["atom.shared::cta.max.s32"](old, order_arena.ptr_to([32_772]), local_max)
+                K.cuda.cta_sync()
+                spread_min = K.local_scalar("int32")
+                spread_max = K.local_scalar("int32")
+                K.ptx.ld.shared.s32(spread_min, order_arena.ptr_to([32_768]))
+                K.ptx.ld.shared.s32(spread_max, order_arena.ptr_to([32_772]))
+                with K.If(spread_min == spread_max), K.Then():
+                    destination = K.local_scalar("int32", init=thread)
+                    with K.While(destination < item_count):
+                        write_work_item(destination, destination)
+                        K.assign(destination, destination + 1024)
+                with K.If(spread_min != spread_max), K.Then():
+                    network = K.local_scalar("int32", init=K.int32(2))
+                    with K.While(network <= padded_count):
+                        distance = K.local_scalar("int32", init=network // 2)
+                        with K.While(distance > 0):
+                            for element in range(4):
+                                item = thread + element * 1024
+                                partner = K.bitwise_xor(item, distance)
+                                with K.If(K.And(item < padded_count, partner > item)), K.Then():
+                                    key_i = K.local_scalar("int32")
+                                    key_j = K.local_scalar("int32")
+                                    K.ptx.ld.shared.s32(key_i, order_arena.ptr_to([item * 4]))
+                                    K.ptx.ld.shared.s32(key_j, order_arena.ptr_to([partner * 4]))
+                                    ascending = ((item // network) % 2) == 0
+                                    swap = K.Or(
+                                        K.And(ascending, key_i < key_j),
+                                        K.And(K.Not(ascending), key_i > key_j),
+                                    )
+                                    with K.If(swap), K.Then():
+                                        index_i = K.local_scalar("int32")
+                                        index_j = K.local_scalar("int32")
+                                        K.ptx.ld.shared.s32(
+                                            index_i, order_arena.ptr_to([16_384 + item * 4])
+                                        )
+                                        K.ptx.ld.shared.s32(
+                                            index_j, order_arena.ptr_to([16_384 + partner * 4])
+                                        )
+                                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key_j)
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([partner * 4]), key_i
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + item * 4]), index_j
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + partner * 4]), index_i
+                                        )
+                            K.cuda.cta_sync()
+                            K.assign(distance, distance // 2)
+                        K.assign(network, network * 2)
+                    for element in range(4):
+                        destination = thread + element * 1024
+                        with K.If(destination < item_count), K.Then():
+                            source = K.local_scalar("int32")
+                            K.ptx.ld.shared.s32(
+                                source, order_arena.ptr_to([16_384 + destination * 4])
+                            )
+                            write_work_item(destination, source)
+
+        bases = (q, k, v, do, checkpoint, dq, dk, dv)
+        strides = (
+            q_row_stride_bytes,
+            k_row_stride_bytes,
+            v_row_stride_bytes,
+            do_row_stride_bytes,
+            checkpoint_row_stride_bytes,
+            dq_row_stride_bytes,
+            dk_row_stride_bytes,
+            dv_row_stride_bytes,
+        )
+        for array_index in range(8):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    checkpoint_prefix = K.local_scalar("int32", init=K.int32(0))
+                    with K.serial(n_batch) as batch:
+                        begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                        end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                        length = end - begin
+                        slot = _descriptor_slot(descriptor_workspace, n_batch, array_index, batch)
+                        _store_tensormap(slot, map_payload)
+                        if array_index == 4:
+                            count = K.local_scalar("int32", init=K.int32(0))
+                            with K.If(length > 0), K.Then():
+                                K.assign(count, (length - 1) // checkpoint_every_n + 1)
+                            _replace_tensormap_address(
+                                slot,
+                                checkpoint.ptr_to(
+                                    [
+                                        K.cast(checkpoint_prefix, "int64")
+                                        * checkpoint_row_stride_bytes
+                                    ]
+                                ),
+                            )
+                            _replace_tensormap_dim(slot, 2, count)
+                            K.assign(checkpoint_prefix, checkpoint_prefix + count)
+                        else:
+                            _replace_tensormap_address(
+                                slot,
+                                bases[array_index].ptr_to(
+                                    [K.cast(begin, "int64") * strides[array_index]]
+                                ),
+                            )
+                            _replace_tensormap_dim(slot, 2, length)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+    return prologue
+
+
+def _make_main(
+    *,
+    num_sms,
+    io_dtype,
+    cu_dtype,
+    use_initial_state,
+    use_dstate_in,
+    use_dstate0,
+    log_gate,
+    safe_gate,
+    beta_sigmoid,
+    dynamic_scheduler,
+    q_ratio,
+    k_ratio,
+    v_ratio,
+    n_heads_out,
+):
+    io_t = K.f16 if io_dtype == "float16" else K.bf16
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+    beta_t = io_t if beta_sigmoid else K.f32
+    first_state_chunk = 0 if use_initial_state else 1
+    idesc_delta = 1152 if io_dtype == "float16" else 0
+    idesc_m64_n64 = _IDESC_M64_N64_BF16 - idesc_delta
+    idesc_m128_n64 = _IDESC_M128_N64_BF16 - idesc_delta
+    idesc_m128_n64_a = _IDESC_M128_N64_A_BF16 - idesc_delta
+    idesc_m128_n64_b = _IDESC_M128_N64_B_BF16 - idesc_delta
+    idesc_m128_n64_ab = _IDESC_M128_N64_AB_BF16 - idesc_delta
+    idesc_m128_n128_b = _IDESC_M128_N128_B_BF16 - idesc_delta
+
+    @K.kernel(warps=12, arch="sm_100a", min_blocks_per_sm=1, grid=num_sms)
+    def main(
+        descriptor_workspace: K.gptr[K.i64],
+        n_desc: K.i32,
+        gate: K.gptr[K.f32],
+        a_log: K.gptr[K.f32],
+        dt_bias: K.gptr[K.f32],
+        beta: K.gptr[beta_t],
+        dgate: K.gptr[K.f32],
+        dbeta: K.gptr[beta_t],
+        cu_seqlens: K.gptr[cu_t],
+        dstate0: K.gptr[K.f32],
+        dstate_in: K.gptr[K.f32],
+        work_items: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        scale: K.f32,
+    ):
+        arena = K.alloc_buffer((_ARENA_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        K.smem_pool(base=arena)
+        thread = K.thread_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+        with K.attr({"tirx.required_block_size": 1}):
+            _cluster_x, _cluster_y, _cluster_z = K.cta_id_in_cluster([1, 1, 1])
+
+        protocol = (
+            (_BAR_Q_READY, 1, 1),
+            (_BAR_Q_MMA_DONE, 1, 1),
+            (_BAR_Q_CG1_DONE, 1, 128),
+            (_BAR_K_READY, 2, 1),
+            (_BAR_K_MMA_DONE, 2, 1),
+            (_BAR_K_CG0_DONE, 2, 128),
+            (_BAR_V_READY, 1, 1),
+            (_BAR_V_MMA_DONE, 1, 1),
+            (_BAR_DO_READY, 1, 1),
+            (_BAR_DO_MMA_DONE, 1, 1),
+            (_BAR_STATE_READY, 1, 1),
+            (_BAR_STATE_MMA_DONE, 1, 1),
+            (_BAR_GATE_READY, 2, 32),
+            (_BAR_GATE_DONE, 2, 256),
+            (_BAR_BETA_READY, 2, 32),
+            (_BAR_BETA_DONE, 2, 256),
+            (_BAR_DSTATE_ACC_READY, 1, 1),
+            (_BAR_DSTATE_SCALE_DONE, 1, 128),
+            (_BAR_DU_SCALE_READY, 1, 1),
+            (_BAR_DU_SCALE_DONE, 1, 128),
+            (_BAR_DU_TOTAL_READY, 1, 1),
+            (_BAR_DK_SCALE_READY, 1, 1),
+            (_BAR_DK_SCALE_DONE, 1, 128),
+            (_BAR_DK_ATTN_READY, 1, 1),
+            (_BAR_DK_ATTN_DONE, 1, 128),
+            (_BAR_DK_TOTAL_READY, 1, 1),
+            (_BAR_DK_TOTAL_DONE, 1, 128),
+            (_BAR_DQ_SCALE_READY, 1, 1),
+            (_BAR_DQ_SCALE_DONE, 1, 128),
+            (_BAR_DQ_TOTAL_READY, 1, 1),
+            (_BAR_DQ_TOTAL_DONE, 1, 128),
+            (_BAR_KK_READY, 1, 1),
+            (_BAR_KK_DONE, 1, 128),
+            (_BAR_A_ACC_READY, 1, 1),
+            (_BAR_K_STATE_READY, 1, 1),
+            (_BAR_U_ACC_READY, 1, 1),
+            (_BAR_DY_ACC_READY, 1, 1),
+            (_BAR_DA_ACC_READY, 1, 1),
+            (_BAR_DM_ACC_READY, 1, 1),
+            (_BAR_DM_ACC_DONE, 1, 128),
+            (_BAR_DK_STATE_READY, 1, 1),
+            (_BAR_DSTATE_INP_READY, 1, 128),
+            (_BAR_DSTATE_INP_DONE, 1, 1),
+            (_BAR_DO_PRIME_READY, 1, 128),
+            (_BAR_DU_INP_READY, 1, 128),
+            (_BAR_DYP_INP_READY, 1, 128),
+            (_BAR_Y_READY, 1, 128),
+            (_BAR_TINV_READY, 1, 128),
+            (_BAR_A_READY, 1, 128),
+            (_BAR_A_DONE, 1, 1),
+            (_BAR_U_READY, 1, 128),
+            (_BAR_DSTATE_SMEM_READY, 1, 128),
+            (_BAR_STATE_DOT_DONE, 1, 128),
+            (_BAR_DA_READY, 1, 128),
+            (_BAR_DBETA_CG1_READY, 1, 128),
+            (_BAR_DGATE_CG1_READY, 1, 128),
+            (_BAR_DQ_STG_READY, 1, 128),
+            (_BAR_DQ_STG_DONE, 1, 32),
+            (_BAR_DK_STG_READY, 1, 128),
+            (_BAR_DK_STG_DONE, 1, 32),
+            (_BAR_DV_STG_READY, 1, 128),
+            (_BAR_DV_STG_DONE, 1, 32),
+            (_BAR_SDV_DONE, 1, 1),
+            (_BAR_TMEM_DONE, 1, 256),
+            (_BAR_SCHED_READY, 2, 1),
+            (_BAR_SCHED_DONE, 2, 11),
+        )
+        with K.If(warp == 9), K.Then():
+            with K.If(_elected()), K.Then():
+                for offset, stages, count in protocol:
+                    for stage in range(stages):
+                        K.ptx.mbarrier.init.shared.b64(
+                            _barrier_ptr(arena, offset, stage), K.uint32(count)
+                        )
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+
+        total_tiles = K.local_scalar("int32")
+        K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
+        roles = K.specialize()
+        cg0 = roles.role("cg0", warps=range(0, 4), regs=192)
+        cg1 = roles.role("cg1", warps=range(4, 8), regs=248)
+        mma = roles.role("mma", warps=[8], regs=64)
+        tma = roles.role("tma", warps=[9], regs=64)
+        gate_beta = roles.role("gate_beta", warps=[10], regs=64)
+        epilogue = roles.role("epilogue", warps=[11], regs=64)
+
+        def sched_consume(state, tile):
+            if dynamic_scheduler:
+                _wait_barrier(arena, _BAR_SCHED_READY, state.stage, state.phase)
+                K.ptx.ld.shared.s32(
+                    tile, arena.ptr_to([_SCHED_BASE + K.cast(state.stage, "int32") * 4])
+                )
+                with K.If(_elected()), K.Then():
+                    _arrive_barrier(arena, _BAR_SCHED_DONE, state.stage)
+                state.advance()
+            else:
+                K.assign(tile, tile + num_sms)
+
+        def sched_produce(state, tile):
+            if dynamic_scheduler:
+                _wait_barrier(arena, _BAR_SCHED_DONE, state.stage, state.phase)
+                with K.If(_elected()), K.Then():
+                    ticket = K.local_scalar("uint32")
+                    K.ptx.atom.global_.add.u32(ticket, scheduler.ptr_to([0]), K.uint32(1))
+                    K.ptx.st.shared.u32(
+                        arena.ptr_to([_SCHED_BASE + K.cast(state.stage, "int32") * 4]),
+                        K.uint32(num_sms) + ticket,
+                    )
+                K.cuda.warp_sync()
+                K.ptx.ld.shared.s32(
+                    tile, arena.ptr_to([_SCHED_BASE + K.cast(state.stage, "int32") * 4])
+                )
+                with K.If(_elected()), K.Then():
+                    _arrive_barrier(arena, _BAR_SCHED_READY, state.stage)
+                state.advance()
+            else:
+                K.assign(tile, tile + num_sms)
+
+        # Compute-group bodies are inserted below after their exact arithmetic
+        # fragments are translated. Keeping their role scopes here makes the
+        # service pipeline independently lowerable while that work proceeds.
+        with cg0:
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            warp_in_group = K.warp_id_in_role()
+            cg0_thread = warp_in_group * 32 + lane
+            tmem_row = K.shift_left(warp_in_group * 32, K.int32(16))
+            store_row = warp_in_group * 16 + lane % 16
+            store_col = (lane // 16) * 8
+            frag_row = cg0_thread % 8 + ((cg0_thread // 16) % 2) * 8
+            frag_col = ((cg0_thread // 8) % 2) * 8 + ((cg0_thread // 32) % 2) * 32
+            frag_segment = cg0_thread // 64
+
+            gate_cursor = K.PipelineState(2, phase=0)
+            beta_cursor = K.PipelineState(2, phase=0)
+            a_cursor = K.PipelineState(1, phase=1)
+            tinv_cursor = K.PipelineState(1, phase=1)
+            da_cursor = K.PipelineState(1, phase=0)
+            dm_cursor = K.PipelineState(1, phase=0)
+            dbeta_cursor = K.PipelineState(1, phase=0)
+            k_cursor = K.PipelineState(2, phase=0)
+            dgate_cursor = K.PipelineState(1, phase=0)
+            kk_cursor = K.PipelineState(1, phase=0)
+            a_ready_cursor = K.PipelineState(1, phase=0)
+            dk_scale_cursor = K.PipelineState(1, phase=0)
+            dq_scale_cursor = K.PipelineState(1, phase=0)
+            dstate_smem_cursor = K.PipelineState(1, phase=0)
+            dk_attn_cursor = K.PipelineState(1, phase=0)
+            sched_state = K.PipelineState(2, phase=0)
+
+            def reduce_scatter_16(values):
+                stage8 = K.alloc_local((8,), "float32")
+                for output, source in enumerate((0, 1, 4, 5, 8, 9, 12, 13)):
+                    high = ((lane // 4) % 2) == 1
+                    sent = K.if_then_else(high, values[source], values[source + 2])
+                    kept = K.if_then_else(high, values[source + 2], values[source])
+                    K.assign(stage8[output], kept + _shfl_bfly_f32(sent, 4))
+                stage4 = K.alloc_local((4,), "float32")
+                for output, source in enumerate((0, 1, 4, 5)):
+                    high = ((lane // 8) % 2) == 1
+                    sent = K.if_then_else(high, stage8[source], stage8[source + 2])
+                    kept = K.if_then_else(high, stage8[source + 2], stage8[source])
+                    K.assign(stage4[output], kept + _shfl_bfly_f32(sent, 8))
+                stage2 = K.alloc_local((2,), "float32")
+                for output in range(2):
+                    high = ((lane // 16) % 2) == 1
+                    sent = K.if_then_else(high, stage4[output], stage4[output + 2])
+                    kept = K.if_then_else(high, stage4[output + 2], stage4[output])
+                    K.assign(stage2[output], kept + _shfl_bfly_f32(sent, 16))
+                return stage2[0], stage2[1]
+
+            for word in range(16):
+                K.ptx.st.shared.b32(
+                    arena.ptr_to([_TINV_BASE + (cg0_thread + word * 128) * 4]), K.uint32(0)
+                )
+
+            tile = K.local_scalar("int32", init=K.cta_id())
+            dstate_in0 = 1 if use_dstate_in else 0
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                wstart = item[2]
+                cend = item[5]
+                num_item_chunks = cend - wstart
+                with K.serial(num_item_chunks, unroll=False) as reverse_index:
+                    chunk = cend - 1 - reverse_index
+                    have_dstate = K.bool(True) if use_dstate_in else reverse_index > 0
+
+                    gate_stage = K.local_scalar("int32", init=gate_cursor.stage)
+                    _wait_barrier(arena, _BAR_GATE_READY, gate_stage, gate_cursor.phase)
+                    gate_cursor.advance()
+
+                    row_cs = K.alloc_local((2,), "float32")
+                    for row_part in range(2):
+                        row = warp_in_group * 16 + lane // 4 + row_part * 8
+                        K.ptx.ld.shared.f32(
+                            row_cs[row_part],
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + row * 4]),
+                        )
+                    col_cs = K.alloc_local((16,), "float32")
+                    for group in range(8):
+                        for pair in range(2):
+                            column = (lane % 4) * 2 + group * 8 + pair
+                            K.ptx.ld.shared.f32(
+                                col_cs[group * 2 + pair],
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + column * 4]),
+                            )
+
+                    decay = K.alloc_local((32,), "float32")
+                    strict_decay = K.alloc_local((32,), "float32")
+                    for value in range(32):
+                        row = warp_in_group * 16 + lane // 4 + ((value // 2) % 2) * 8
+                        column = (lane % 4) * 2 + (value // 4) * 8 + value % 2
+                        candidate = _exp2(
+                            row_cs[(value // 2) % 2] - col_cs[(value // 4) * 2 + value % 2]
+                        )
+                        K.assign(
+                            decay[value], K.if_then_else(row >= column, candidate, _opaque_zero())
+                        )
+                        K.assign(
+                            strict_decay[value],
+                            K.if_then_else(row == column, _opaque_zero(), decay[value]),
+                        )
+
+                    last_cs = K.local_scalar("float32")
+                    K.ptx.ld.shared.f32(
+                        last_cs, arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + 63 * 4])
+                    )
+                    decay_scale = K.alloc_local((32,), "float32")
+                    for value in range(32):
+                        column_part = (value // 4) * 2 + value % 2
+                        K.assign(decay_scale[value], _exp2(last_cs - col_cs[column_part]))
+                    cumprod_total = K.local_scalar("float32")
+                    K.ptx.ld.shared.f32(
+                        cumprod_total, arena.ptr_to([_CUMPROD_BASE + gate_stage * 256 + 63 * 4])
+                    )
+
+                    beta_stage = K.local_scalar("int32", init=beta_cursor.stage)
+                    _wait_barrier(arena, _BAR_BETA_READY, beta_stage, beta_cursor.phase)
+                    beta_cursor.advance()
+                    beta_rows = K.alloc_local((32,), "float32")
+                    for value in range(32):
+                        row = warp_in_group * 16 + lane // 4 + ((value // 2) % 2) * 8
+                        K.ptx.ld.shared.f32(
+                            beta_rows[value],
+                            arena.ptr_to([_BETA_BASE + beta_stage * 256 + row * 4]),
+                        )
+
+                    tinv_stage = K.local_scalar("int32", init=tinv_cursor.stage)
+                    tinv_cursor.advance()
+                    _wait_barrier(arena, _BAR_KK_READY, 0, kk_cursor.phase)
+                    kk_cursor.advance()
+                    kk_values = _tcgen_load_16x256x8(tmem_base + _TM_ACC0 + tmem_row)
+                    kk_pack = K.alloc_local((16,), "uint32")
+                    for pair in range(16):
+                        product0, product1 = _fmul2(
+                            kk_values[pair * 2],
+                            kk_values[pair * 2 + 1],
+                            strict_decay[pair * 2],
+                            strict_decay[pair * 2 + 1],
+                        )
+                        value0, value1 = _fmul2(
+                            product0, product1, beta_rows[pair * 2], beta_rows[pair * 2 + 1]
+                        )
+                        K.assign(kk_pack[pair], _pack_io_pair(value0, value1, io_dtype))
+                    for fragment in range(4):
+                        _stmatrix_x4(
+                            arena.ptr_to(
+                                [
+                                    _KK_BASE
+                                    + (
+                                        store_row * 64
+                                        + _swizzle_xor_128b(store_row, store_col + fragment * 16)
+                                    )
+                                    * 2
+                                ]
+                            ),
+                            [
+                                kk_pack[fragment * 4],
+                                kk_pack[fragment * 4 + 1],
+                                kk_pack[fragment * 4 + 2],
+                                kk_pack[fragment * 4 + 3],
+                            ],
+                        )
+                    with K.If(reverse_index < cend - first_state_chunk), K.Then():
+                        _arrive_barrier(arena, _BAR_KK_DONE)
+
+                    a_stage = K.local_scalar("int32", init=a_cursor.stage)
+                    a_phase = K.local_scalar("int32", init=a_cursor.phase)
+                    a_cursor.advance()
+                    _wait_barrier(arena, _BAR_A_ACC_READY, 0, a_ready_cursor.phase)
+                    a_ready_cursor.advance()
+                    a_values = _tcgen_load_16x256x8(tmem_base + _TM_ACC1 + tmem_row)
+                    a_pack = K.alloc_local((16,), "uint32")
+                    for pair in range(16):
+                        product0, product1 = _fmul2(
+                            a_values[pair * 2],
+                            a_values[pair * 2 + 1],
+                            decay[pair * 2],
+                            decay[pair * 2 + 1],
+                        )
+                        value0, value1 = _fmul2(product0, product1, scale, scale)
+                        K.assign(a_pack[pair], _pack_io_pair(value0, value1, io_dtype))
+                    _wait_barrier(arena, _BAR_A_DONE, a_stage, a_phase)
+                    for fragment in range(4):
+                        _stmatrix_x4(
+                            arena.ptr_to(
+                                [
+                                    _A_DA_BASE
+                                    + (
+                                        store_row * 64
+                                        + _swizzle_xor_128b(store_row, store_col + fragment * 16)
+                                    )
+                                    * 2
+                                ]
+                            ),
+                            [
+                                a_pack[fragment * 4],
+                                a_pack[fragment * 4 + 1],
+                                a_pack[fragment * 4 + 2],
+                                a_pack[fragment * 4 + 3],
+                            ],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_A_READY, a_stage)
+
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(warp_in_group < 2), K.Then():
+                        _invert_diagonal_8x8(
+                            arena, _KK_BASE, _TINV_BASE, cg0_thread // 8, cg0_thread % 8, io_dtype
+                        )
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    _blockwise_8_to_16(
+                        arena, _TINV_BASE, _KK_BASE, warp_in_group * 16, lane, io_dtype
+                    )
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(warp_in_group < 2), K.Then():
+                        _blockwise_16_to_32(
+                            arena, _TINV_BASE, _KK_BASE, warp_in_group * 32, lane, io_dtype
+                        )
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(warp_in_group < 2), K.Then():
+                        _blockwise_32_to_64(
+                            arena, _TINV_BASE, _KK_BASE, warp_in_group, lane, io_dtype, True
+                        )
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+
+                    beta_columns = K.alloc_local((32,), "float32")
+                    for value in range(32):
+                        column = (lane % 4) * 2 + (value // 4) * 8 + value % 2
+                        K.ptx.ld.shared.f32(
+                            beta_columns[value],
+                            arena.ptr_to([_BETA_BASE + beta_stage * 256 + column * 4]),
+                        )
+                    tinv_words = K.alloc_local((16,), "uint32")
+                    for fragment in range(4):
+                        words = K.alloc_local((4,), "uint32")
+                        _ldmatrix_x4(
+                            words,
+                            arena.ptr_to(
+                                [
+                                    _TINV_BASE
+                                    + (
+                                        store_row * 64
+                                        + _swizzle_xor_128b(store_row, store_col + fragment * 16)
+                                    )
+                                    * 2
+                                ]
+                            ),
+                            trans=False,
+                        )
+                        for word in range(4):
+                            K.assign(tinv_words[fragment * 4 + word], words[word])
+                    tinv_pack = K.alloc_local((16,), "uint32")
+                    for pair in range(16):
+                        value0 = K.local_scalar("float32")
+                        value1 = K.local_scalar("float32")
+                        _unpack_io_pair(tinv_words[pair], value0, value1, io_dtype)
+                        scaled0, scaled1 = _fmul2(
+                            value0, value1, beta_columns[pair * 2], beta_columns[pair * 2 + 1]
+                        )
+                        K.assign(tinv_pack[pair], _pack_io_pair(scaled0, scaled1, io_dtype))
+                    for fragment in range(4):
+                        _stmatrix_x4(
+                            arena.ptr_to(
+                                [
+                                    _TINV_BASE
+                                    + (
+                                        store_row * 64
+                                        + _swizzle_xor_128b(store_row, store_col + fragment * 16)
+                                    )
+                                    * 2
+                                ]
+                            ),
+                            [
+                                tinv_pack[fragment * 4],
+                                tinv_pack[fragment * 4 + 1],
+                                tinv_pack[fragment * 4 + 2],
+                                tinv_pack[fragment * 4 + 3],
+                            ],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_TINV_READY, tinv_stage)
+
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        cumprod_values = K.alloc_local((32,), "float32")
+                        for value in range(32):
+                            column = (lane % 4) * 2 + (value // 4) * 8 + value % 2
+                            K.ptx.ld.shared.f32(
+                                cumprod_values[value],
+                                arena.ptr_to([_CUMPROD_BASE + gate_stage * 256 + column * 4]),
+                            )
+                        _wait_barrier(arena, _BAR_DQ_SCALE_READY, 0, dq_scale_cursor.phase)
+                        dq_scale_cursor.advance()
+                        for sub in range(2):
+                            address = (
+                                tmem_base
+                                + _TM_DSTATE_INP
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                            values = _tcgen_load_16x256x8(address)
+                            scaled = K.alloc_local((32,), "float32")
+                            for pair in range(16):
+                                product0, product1 = _fmul2(
+                                    values[pair * 2],
+                                    values[pair * 2 + 1],
+                                    cumprod_values[pair * 2],
+                                    cumprod_values[pair * 2 + 1],
+                                )
+                                value0, value1 = _fmul2(product0, product1, scale, scale)
+                                K.assign(scaled[pair * 2], value0)
+                                K.assign(scaled[pair * 2 + 1], value1)
+                            _tcgen_store_16x256x8(address, scaled)
+                        _tcgen_wait_store()
+                        _arrive_barrier(arena, _BAR_DQ_SCALE_DONE)
+
+                    with K.If(have_dstate), K.Then():
+                        _wait_barrier(arena, _BAR_DSTATE_SMEM_READY, 0, dstate_smem_cursor.phase)
+                        dstate_smem_cursor.advance()
+                    state_dot_lo = K.alloc_local((4,), "float32")
+                    state_dot_hi = K.alloc_local((4,), "float32")
+                    for word in range(4):
+                        K.assign(state_dot_lo[word], _opaque_zero())
+                        K.assign(state_dot_hi[word], _opaque_zero())
+                    for octet in range(16):
+                        dstate_words = K.alloc_local((4,), "uint32")
+                        state_words = K.alloc_local((4,), "uint32")
+                        K.ptx.ld.shared.v4.b32(
+                            dstate_words[0],
+                            dstate_words[1],
+                            dstate_words[2],
+                            dstate_words[3],
+                            arena.ptr_to([_state_byte(_DSTATE_BASE, cg0_thread, octet * 8)]),
+                        )
+                        K.ptx.ld.shared.v4.b32(
+                            state_words[0],
+                            state_words[1],
+                            state_words[2],
+                            state_words[3],
+                            arena.ptr_to([_state_byte(_STATE_BASE, cg0_thread, octet * 8)]),
+                        )
+                        for word in range(4):
+                            dstate_value0 = K.local_scalar("float32")
+                            dstate_value1 = K.local_scalar("float32")
+                            state0 = K.local_scalar("float32")
+                            state1 = K.local_scalar("float32")
+                            _unpack_io_pair(
+                                dstate_words[word], dstate_value0, dstate_value1, io_dtype
+                            )
+                            _unpack_io_pair(state_words[word], state0, state1, io_dtype)
+                            next0, next1 = _ffma2(
+                                dstate_value0,
+                                dstate_value1,
+                                state0,
+                                state1,
+                                state_dot_lo[word],
+                                state_dot_hi[word],
+                            )
+                            K.assign(state_dot_lo[word], next0)
+                            K.assign(state_dot_hi[word], next1)
+                    state_dot = K.local_scalar(
+                        "float32",
+                        init=(
+                            (state_dot_lo[0] + state_dot_lo[1])
+                            + (state_dot_lo[2] + state_dot_lo[3])
+                            + (state_dot_hi[0] + state_dot_hi[1])
+                            + (state_dot_hi[2] + state_dot_hi[3])
+                        ),
+                    )
+                    for distance in (1, 2, 4, 8, 16):
+                        K.assign(state_dot, state_dot + _shfl_bfly_f32(state_dot, distance))
+                    _arrive_barrier(arena, _BAR_STATE_DOT_DONE)
+
+                    k_stage = K.local_scalar("int32", init=k_cursor.stage)
+                    k_cursor.advance()
+                    k_dot = K.local_scalar("float32", init=K.float32(0.0))
+                    with K.If(have_dstate), K.Then():
+                        _wait_barrier(arena, _BAR_DK_SCALE_READY, 0, dk_scale_cursor.phase)
+                        dk_scale_cursor.advance()
+                        k_dot_lo = K.alloc_local((4,), "float32")
+                        k_dot_hi = K.alloc_local((4,), "float32")
+                        for word in range(4):
+                            K.assign(k_dot_lo[word], _opaque_zero())
+                            K.assign(k_dot_hi[word], _opaque_zero())
+                        for sub in range(2):
+                            address = (
+                                tmem_base
+                                + _TM_DVDK
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                            values = _tcgen_load_16x256x8(address)
+                            scaled = K.alloc_local((32,), "float32")
+                            for pair in range(16):
+                                value0, value1 = _fmul2(
+                                    values[pair * 2],
+                                    values[pair * 2 + 1],
+                                    decay_scale[pair * 2],
+                                    decay_scale[pair * 2 + 1],
+                                )
+                                K.assign(scaled[pair * 2], value0)
+                                K.assign(scaled[pair * 2 + 1], value1)
+                            _tcgen_store_16x256x8(address, scaled)
+                            for matrix_row in range(4):
+                                k_words = K.alloc_local((4,), "uint32")
+                                row = frag_row + matrix_row * 16
+                                channel = frag_segment * 64 + frag_col + sub * 16
+                                _ldmatrix_x4(
+                                    k_words,
+                                    arena.ptr_to([_io_byte(_K_BASE, k_stage, row, channel)]),
+                                    trans=True,
+                                )
+                                for word in range(4):
+                                    k0 = K.local_scalar("float32")
+                                    k1 = K.local_scalar("float32")
+                                    _unpack_io_pair(k_words[word], k0, k1, io_dtype)
+                                    index = matrix_row * 8 + word * 2
+                                    next0, next1 = _ffma2(
+                                        scaled[index],
+                                        scaled[index + 1],
+                                        k0,
+                                        k1,
+                                        k_dot_lo[word],
+                                        k_dot_hi[word],
+                                    )
+                                    K.assign(k_dot_lo[word], next0)
+                                    K.assign(k_dot_hi[word], next1)
+                        _tcgen_wait_store()
+                        _arrive_barrier(arena, _BAR_DK_SCALE_DONE)
+                        K.assign(
+                            k_dot,
+                            (k_dot_lo[0] + k_dot_lo[1])
+                            + (k_dot_lo[2] + k_dot_lo[3])
+                            + (k_dot_hi[0] + k_dot_hi[1])
+                            + (k_dot_hi[2] + k_dot_hi[3]),
+                        )
+                        for distance in (1, 2, 4, 8, 16):
+                            K.assign(k_dot, k_dot + _shfl_bfly_f32(k_dot, distance))
+
+                    _wait_barrier(arena, _BAR_DA_ACC_READY, 0, da_cursor.phase)
+                    da_cursor.advance()
+                    da_values = _tcgen_load_16x256x8(tmem_base + _TM_ACC1 + tmem_row)
+                    da_pack = K.alloc_local((16,), "uint32")
+                    for pair in range(16):
+                        product0, product1 = _fmul2(
+                            da_values[pair * 2],
+                            da_values[pair * 2 + 1],
+                            decay[pair * 2],
+                            decay[pair * 2 + 1],
+                        )
+                        value0, value1 = _fmul2(product0, product1, scale, scale)
+                        K.assign(da_pack[pair], _pack_io_pair(value0, value1, io_dtype))
+                    for fragment in range(4):
+                        _stmatrix_x4(
+                            arena.ptr_to(
+                                [
+                                    _A_DA_BASE
+                                    + (
+                                        store_row * 64
+                                        + _swizzle_xor_128b(store_row, store_col + fragment * 16)
+                                    )
+                                    * 2
+                                ]
+                            ),
+                            [
+                                da_pack[fragment * 4],
+                                da_pack[fragment * 4 + 1],
+                                da_pack[fragment * 4 + 2],
+                                da_pack[fragment * 4 + 3],
+                            ],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DA_READY)
+
+                    _wait_barrier(arena, _BAR_DM_ACC_READY, 0, dm_cursor.phase)
+                    dm_cursor.advance()
+                    dm_values = _tcgen_load_16x256x8(tmem_base + _TM_ACC0 + tmem_row)
+                    dm_pack = K.alloc_local((16,), "uint32")
+                    for pair in range(16):
+                        product0, product1 = _fmul2(
+                            dm_values[pair * 2],
+                            dm_values[pair * 2 + 1],
+                            strict_decay[pair * 2],
+                            strict_decay[pair * 2 + 1],
+                        )
+                        K.assign(dm_pack[pair], _pack_io_pair(-product0, -product1, io_dtype))
+                    for fragment in range(4):
+                        _stmatrix_x4(
+                            arena.ptr_to(
+                                [
+                                    _DM_BASE
+                                    + (
+                                        store_row * 64
+                                        + _swizzle_xor_128b(store_row, store_col + fragment * 16)
+                                    )
+                                    * 2
+                                ]
+                            ),
+                            [
+                                dm_pack[fragment * 4],
+                                dm_pack[fragment * 4 + 1],
+                                dm_pack[fragment * 4 + 2],
+                                dm_pack[fragment * 4 + 3],
+                            ],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DM_ACC_DONE)
+
+                    _wait_barrier(arena, _BAR_DK_ATTN_READY, 0, dk_attn_cursor.phase)
+                    dk_attn_cursor.advance()
+                    dks = []
+                    for sub in range(2):
+                        dks.append(
+                            _tcgen_load_16x256x8(
+                                tmem_base
+                                + _TM_DVDK
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                        )
+                    _tcgen_wait_load()
+                    _arrive_barrier(arena, _BAR_DK_ATTN_DONE)
+
+                    kk_words = K.alloc_local((16,), "uint32")
+                    for fragment in range(4):
+                        words = K.alloc_local((4,), "uint32")
+                        _ldmatrix_x4(
+                            words,
+                            arena.ptr_to(
+                                [
+                                    _KK_BASE
+                                    + (
+                                        store_row * 64
+                                        + _swizzle_xor_128b(store_row, store_col + fragment * 16)
+                                    )
+                                    * 2
+                                ]
+                            ),
+                            trans=False,
+                        )
+                        for word in range(4):
+                            K.assign(kk_words[fragment * 4 + word], words[word])
+                    beta_inverse = K.alloc_local((2,), "float32")
+                    K.assign(beta_inverse[0], _rcp(beta_rows[0] + K.float32(1.0e-10)))
+                    K.assign(beta_inverse[1], _rcp(beta_rows[2] + K.float32(1.0e-10)))
+                    row_acc = K.alloc_local((8,), "float32")
+                    col_part = K.alloc_local((16,), "float32")
+                    for value in range(8):
+                        K.assign(row_acc[value], K.float32(0.0))
+                    for value in range(16):
+                        K.assign(col_part[value], _opaque_zero())
+                    for pair in range(16):
+                        kk0 = K.local_scalar("float32")
+                        kk1 = K.local_scalar("float32")
+                        _unpack_io_pair(kk_words[pair], kk0, kk1, io_dtype)
+                        product0, product1 = _fmul2(
+                            dm_values[pair * 2], dm_values[pair * 2 + 1], kk0, kk1
+                        )
+                        e0, e1 = _fmul2(
+                            product0, product1, beta_inverse[pair % 2], beta_inverse[pair % 2]
+                        )
+                        bucket = (pair % 2) * 4 + (pair // 2) % 4
+                        K.assign(row_acc[bucket], row_acc[bucket] + e0 + e1)
+                        column = (pair // 2) * 2
+                        next0, next1 = _fadd2(col_part[column], col_part[column + 1], e0, e1)
+                        K.assign(col_part[column], next0)
+                        K.assign(col_part[column + 1], next1)
+                    row_part = K.alloc_local((2,), "float32")
+                    K.assign(row_part[0], (row_acc[0] + row_acc[1]) + (row_acc[2] + row_acc[3]))
+                    K.assign(row_part[1], (row_acc[4] + row_acc[5]) + (row_acc[6] + row_acc[7]))
+                    for distance in (1, 2):
+                        for part in range(2):
+                            K.assign(
+                                row_part[part],
+                                row_part[part] + _shfl_bfly_f32(row_part[part], distance),
+                            )
+
+                    _wait_barrier(arena, _BAR_DBETA_CG1_READY, 0, dbeta_cursor.phase)
+                    dbeta_cursor.advance()
+                    with K.If(lane % 4 == 0), K.Then():
+                        for part in range(2):
+                            row = warp_in_group * 16 + lane // 4 + part * 8
+                            beta_partial = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                beta_partial,
+                                arena.ptr_to([_BETA_BASE + beta_stage * 256 + row * 4]),
+                            )
+                            result = beta_partial - row_part[part] * beta_inverse[part]
+                            if beta_sigmoid:
+                                beta_value = beta_rows[part * 2]
+                                result = result * (beta_value - beta_value * beta_value)
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_BETA_BASE + beta_stage * 256 + row * 4]), result
+                            )
+
+                    part_k = K.alloc_local((16,), "float32")
+                    for value in range(16):
+                        K.assign(part_k[value], K.float32(0.0))
+                    for sub in range(2):
+                        for matrix_row in range(4):
+                            k_words = K.alloc_local((4,), "uint32")
+                            row = frag_row + matrix_row * 16
+                            channel = frag_segment * 64 + frag_col + sub * 16
+                            _ldmatrix_x4(
+                                k_words,
+                                arena.ptr_to([_io_byte(_K_BASE, k_stage, row, channel)]),
+                                trans=True,
+                            )
+                            for word in range(4):
+                                k0 = K.local_scalar("float32")
+                                k1 = K.local_scalar("float32")
+                                _unpack_io_pair(k_words[word], k0, k1, io_dtype)
+                                fragment_value = matrix_row * 8 + word * 2
+                                part_value = (fragment_value // 4) * 2 + fragment_value % 2
+                                if sub == 0 and word % 2 == 0:
+                                    next0, next1 = _fmul2(
+                                        dks[sub][fragment_value],
+                                        dks[sub][fragment_value + 1],
+                                        k0,
+                                        k1,
+                                    )
+                                else:
+                                    next0, next1 = _ffma2(
+                                        dks[sub][fragment_value],
+                                        dks[sub][fragment_value + 1],
+                                        k0,
+                                        k1,
+                                        part_k[part_value],
+                                        part_k[part_value + 1],
+                                    )
+                                K.assign(part_k[part_value], next0)
+                                K.assign(part_k[part_value + 1], next1)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_K_CG0_DONE, k_stage)
+
+                    dgate_parts = K.alloc_local((16,), "float32")
+                    for value in range(16):
+                        K.assign(dgate_parts[value], col_part[value] - part_k[value])
+                    dgate0, dgate1 = reduce_scatter_16(dgate_parts)
+                    dgate_last = K.local_scalar("float32", init=k_dot)
+                    with (
+                        K.If(
+                            K.And(
+                                have_dstate,
+                                K.And(
+                                    reverse_index + dstate_in0 >= 1,
+                                    reverse_index < cend - first_state_chunk,
+                                ),
+                            )
+                        ),
+                        K.Then(),
+                    ):
+                        K.assign(dgate_last, dgate_last + cumprod_total * state_dot)
+                    token0 = (lane // 4) * 8 + (lane % 4) * 2
+                    K.ptx.st.shared.f32(
+                        arena.ptr_to([_KK_BASE + (warp_in_group * 64 + token0) * 4]), dgate0
+                    )
+                    K.ptx.st.shared.f32(
+                        arena.ptr_to([_KK_BASE + (warp_in_group * 64 + token0 + 1) * 4]),
+                        K.if_then_else(lane == 31, dgate1 + dgate_last, dgate1),
+                    )
+
+                    _wait_barrier(arena, _BAR_DGATE_CG1_READY, 0, dgate_cursor.phase)
+                    dgate_cursor.advance()
+                    with K.If(lane % 4 == 0), K.Then():
+                        for part in range(2):
+                            row = warp_in_group * 16 + lane // 4 + part * 8
+                            gate_partial = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                gate_partial,
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + row * 4]),
+                            )
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + row * 4]),
+                                gate_partial - row_part[part],
+                            )
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
+                    with K.If(cg0_thread < 64), K.Then():
+                        dgate_sum = K.local_scalar("float32", init=K.float32(0.0))
+                        for group in range(4):
+                            partial = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                partial, arena.ptr_to([_KK_BASE + (group * 64 + cg0_thread) * 4])
+                            )
+                            K.assign(dgate_sum, dgate_sum + partial)
+                        gate_partial = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            gate_partial,
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + cg0_thread * 4]),
+                        )
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + cg0_thread * 4]),
+                            gate_partial + dgate_sum,
+                        )
+
+                    _arrive_barrier(arena, _BAR_GATE_DONE, gate_stage)
+                    _arrive_barrier(arena, _BAR_BETA_DONE, beta_stage)
+                sched_consume(sched_state, tile)
+
+            _wait_barrier(arena, _BAR_A_DONE, a_cursor.stage, a_cursor.phase)
+            a_cursor.advance()
+            _arrive_barrier(arena, _BAR_TMEM_DONE)
+
+        with cg1:
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+            warp_in_group = K.warp_id_in_role()
+            cg1_thread = warp_in_group * 32 + lane
+            tmem_row = K.shift_left(warp_in_group * 32, K.int32(16))
+            frag_row = cg1_thread % 8 + ((cg1_thread // 16) % 2) * 8
+            frag_col = ((cg1_thread // 8) % 2) * 8 + ((cg1_thread // 32) % 2) * 32
+            frag_segment = cg1_thread // 64
+
+            v_cursor = K.PipelineState(1, phase=0)
+            do_cursor = K.PipelineState(1, phase=0)
+            gate_cursor = K.PipelineState(2, phase=0)
+            k_state_cursor = K.PipelineState(1, phase=0)
+            u_cursor = K.PipelineState(1, phase=0)
+            dy_cursor = K.PipelineState(1, phase=0)
+            du_scale_cursor = K.PipelineState(1, phase=0)
+            du_total_cursor = K.PipelineState(1, phase=0)
+            dk_total_cursor = K.PipelineState(1, phase=0)
+            dstate_acc_cursor = K.PipelineState(1, phase=0)
+            state_dot_cursor = K.PipelineState(1, phase=0)
+            dq_cursor = K.PipelineState(1, phase=1)
+            beta_cursor = K.PipelineState(2, phase=0)
+            sdv_cursor = K.PipelineState(1, phase=1)
+            dk_state_cursor = K.PipelineState(1, phase=0)
+            dq_total_cursor = K.PipelineState(1, phase=0)
+            dstate_inp_cursor = K.PipelineState(1, phase=1)
+            dk_cursor = K.PipelineState(1, phase=1)
+            dv_cursor = K.PipelineState(1, phase=1)
+            sched_state = K.PipelineState(2, phase=0)
+
+            def reduce_scatter_16(values):
+                stage8 = K.alloc_local((8,), "float32")
+                for output, source in enumerate((0, 1, 4, 5, 8, 9, 12, 13)):
+                    high = ((lane // 4) % 2) == 1
+                    sent = K.if_then_else(high, values[source], values[source + 2])
+                    kept = K.if_then_else(high, values[source + 2], values[source])
+                    K.assign(stage8[output], kept + _shfl_bfly_f32(sent, 4))
+                stage4 = K.alloc_local((4,), "float32")
+                for output, source in enumerate((0, 1, 4, 5)):
+                    high = ((lane // 8) % 2) == 1
+                    sent = K.if_then_else(high, stage8[source], stage8[source + 2])
+                    kept = K.if_then_else(high, stage8[source + 2], stage8[source])
+                    K.assign(stage4[output], kept + _shfl_bfly_f32(sent, 8))
+                stage2 = K.alloc_local((2,), "float32")
+                for output in range(2):
+                    high = ((lane // 16) % 2) == 1
+                    sent = K.if_then_else(high, stage4[output], stage4[output + 2])
+                    kept = K.if_then_else(high, stage4[output + 2], stage4[output])
+                    K.assign(stage2[output], kept + _shfl_bfly_f32(sent, 16))
+                return stage2[0], stage2[1]
+
+            def load_col_fragment(base, stage, sub, matrix_row):
+                words = K.alloc_local((4,), "uint32")
+                row = frag_row + matrix_row * 16
+                channel = frag_segment * 64 + frag_col + sub * 16
+                _ldmatrix_x4(words, arena.ptr_to([_io_byte(base, stage, row, channel)]), trans=True)
+                return words
+
+            def store_col_fragment(base, stage, sub, matrix_row, words):
+                row = frag_row + matrix_row * 16
+                channel = frag_segment * 64 + frag_col + sub * 16
+                K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                    arena.ptr_to([_io_byte(base, stage, row, channel)]),
+                    words[0],
+                    words[1],
+                    words[2],
+                    words[3],
+                )
+
+            def stage_dstate_smem():
+                for sub in range(4):
+                    values = _tcgen_load_32x32x32(tmem_base + _TM_DSTATE + sub * 32 + tmem_row)
+                    for group in range(4):
+                        packed = K.alloc_local((4,), "uint32")
+                        for pair in range(4):
+                            K.assign(
+                                packed[pair],
+                                _pack_io_pair(
+                                    values[group * 8 + pair * 2],
+                                    values[group * 8 + pair * 2 + 1],
+                                    io_dtype,
+                                ),
+                            )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_state_byte(_DSTATE_BASE, cg1_thread, sub * 32 + group * 8)]
+                            ),
+                            packed[0],
+                            packed[1],
+                            packed[2],
+                            packed[3],
+                        )
+
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                cend = item[5]
+                bos = item[6]
+                eos = item[7]
+                num_chunks = (eos - bos + _BT - 1) // _BT
+                num_item_chunks = cend - wstart
+                state_base = (K.cast(batch, "int64") * n_heads_out + head) * (_DV * _DK)
+
+                if use_dstate_in:
+                    with K.If(num_item_chunks > 0), K.Then():
+                        inp_stage = K.local_scalar("int32", init=dstate_inp_cursor.stage)
+                        _wait_barrier(
+                            arena, _BAR_DSTATE_INP_DONE, inp_stage, dstate_inp_cursor.phase
+                        )
+                        dstate_inp_cursor.advance()
+                        for sub in range(4):
+                            seed_values = K.alloc_local((32,), "float32")
+                            seed_pack = K.alloc_local((16,), "uint32")
+                            for value in range(32):
+                                loaded = K.local_scalar("float32")
+                                K.ptx.ld.global_.f32(
+                                    loaded,
+                                    dstate_in.ptr_to(
+                                        [
+                                            state_base
+                                            + K.cast(cg1_thread, "int64") * _DK
+                                            + sub * 32
+                                            + value
+                                        ]
+                                    ),
+                                )
+                                K.assign(
+                                    seed_values[value],
+                                    K.if_then_else(cend == num_chunks, loaded, K.float32(0.0)),
+                                )
+                            _tcgen_store_32x32x32(
+                                tmem_base + _TM_DSTATE + sub * 32 + tmem_row, seed_values
+                            )
+                            for pair in range(16):
+                                K.assign(
+                                    seed_pack[pair],
+                                    _pack_io_pair(
+                                        seed_values[pair * 2], seed_values[pair * 2 + 1], io_dtype
+                                    ),
+                                )
+                            _tcgen_store_32x32x16(
+                                tmem_base + _TM_DSTATE_INP + sub * 16 + tmem_row, seed_pack
+                            )
+                        _tcgen_wait_store()
+                        _arrive_barrier(arena, _BAR_DSTATE_INP_READY, inp_stage)
+                        stage_dstate_smem()
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, _BAR_DSTATE_SMEM_READY)
+
+                with K.serial(num_item_chunks, unroll=False) as reverse_index:
+                    chunk = cend - 1 - reverse_index
+                    have_dstate = K.bool(True) if use_dstate_in else reverse_index > 0
+                    gate_stage = K.local_scalar("int32", init=gate_cursor.stage)
+                    _wait_barrier(arena, _BAR_GATE_READY, gate_stage, gate_cursor.phase)
+                    gate_cursor.advance()
+                    beta_stage = K.local_scalar("int32", init=beta_cursor.stage)
+                    _wait_barrier(arena, _BAR_BETA_READY, beta_stage, beta_cursor.phase)
+                    beta_cursor.advance()
+
+                    with K.If(have_dstate), K.Then():
+                        cumprod_top = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            cumprod_top, arena.ptr_to([_CUMPROD_BASE + gate_stage * 256 + 63 * 4])
+                        )
+                        for sub in range(4):
+                            address = tmem_base + _TM_DSTATE + sub * 32 + tmem_row
+                            values = _tcgen_load_32x32x32(address)
+                            scaled = K.alloc_local((32,), "float32")
+                            for pair in range(16):
+                                value0, value1 = _fmul2(
+                                    values[pair * 2], values[pair * 2 + 1], cumprod_top, cumprod_top
+                                )
+                                K.assign(scaled[pair * 2], value0)
+                                K.assign(scaled[pair * 2 + 1], value1)
+                            _tcgen_store_32x32x32(address, scaled)
+                        _tcgen_wait_store()
+                        _arrive_barrier(arena, _BAR_DSTATE_SCALE_DONE)
+
+                    cumprod_values = K.alloc_local((32,), "float32")
+                    for value in range(32):
+                        column = (lane % 4) * 2 + (value // 4) * 8 + value % 2
+                        K.ptx.ld.shared.f32(
+                            cumprod_values[value],
+                            arena.ptr_to([_CUMPROD_BASE + gate_stage * 256 + column * 4]),
+                        )
+                    negative_cumprod = K.alloc_local((32,), "float32")
+                    for value in range(32):
+                        K.assign(negative_cumprod[value], -cumprod_values[value])
+
+                    do_stage = K.local_scalar("int32", init=do_cursor.stage)
+                    _wait_barrier(arena, _BAR_DO_READY, do_stage, do_cursor.phase)
+                    do_cursor.advance()
+                    do_values = [K.alloc_local((32,), "float32"), K.alloc_local((32,), "float32")]
+                    for sub in range(2):
+                        for matrix_row in range(4):
+                            words = load_col_fragment(_DO_BASE, do_stage, sub, matrix_row)
+                            for word in range(4):
+                                do0 = K.local_scalar("float32")
+                                do1 = K.local_scalar("float32")
+                                _unpack_io_pair(words[word], do0, do1, io_dtype)
+                                index = matrix_row * 8 + word * 2
+                                product0, product1 = _fmul2(
+                                    do0, do1, cumprod_values[index], cumprod_values[index + 1]
+                                )
+                                value0, value1 = _fmul2(product0, product1, scale, scale)
+                                K.assign(do_values[sub][index], value0)
+                                K.assign(do_values[sub][index + 1], value1)
+                    for sub in range(2):
+                        packed = K.alloc_local((16,), "uint32")
+                        for pair in range(16):
+                            K.assign(
+                                packed[pair],
+                                _pack_io_pair(
+                                    do_values[sub][pair * 2], do_values[sub][pair * 2 + 1], io_dtype
+                                ),
+                            )
+                        _tcgen_store_16x128x8(
+                            tmem_base
+                            + _TM_INP0
+                            + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
+                            packed,
+                        )
+                    _tcgen_wait_store()
+                    _arrive_barrier(arena, _BAR_DO_PRIME_READY)
+
+                    with K.If(have_dstate), K.Then():
+                        last_cs = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            last_cs, arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + 63 * 4])
+                        )
+                        decay_scale = K.alloc_local((32,), "float32")
+                        for value in range(32):
+                            column = (lane % 4) * 2 + (value // 4) * 8 + value % 2
+                            column_cs = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                column_cs,
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + column * 4]),
+                            )
+                            K.assign(decay_scale[value], _exp2(last_cs - column_cs))
+                        _wait_barrier(arena, _BAR_DU_SCALE_READY, 0, du_scale_cursor.phase)
+                        du_scale_cursor.advance()
+                        for sub in range(2):
+                            address = (
+                                tmem_base
+                                + _TM_DVDK
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                            values = _tcgen_load_16x256x8(address)
+                            scaled = K.alloc_local((32,), "float32")
+                            for pair in range(16):
+                                value0, value1 = _fmul2(
+                                    values[pair * 2],
+                                    values[pair * 2 + 1],
+                                    decay_scale[pair * 2],
+                                    decay_scale[pair * 2 + 1],
+                                )
+                                K.assign(scaled[pair * 2], value0)
+                                K.assign(scaled[pair * 2 + 1], value1)
+                            _tcgen_store_16x256x8(address, scaled)
+                        _tcgen_wait_store()
+                        _arrive_barrier(arena, _BAR_DU_SCALE_DONE)
+
+                    v_stage = K.local_scalar("int32", init=v_cursor.stage)
+                    _wait_barrier(arena, _BAR_V_READY, v_stage, v_cursor.phase)
+                    v_cursor.advance()
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        v_words = [K.alloc_local((16,), "uint32"), K.alloc_local((16,), "uint32")]
+                        for sub in range(2):
+                            for matrix_row in range(4):
+                                words = load_col_fragment(_V_U_BASE, v_stage, sub, matrix_row)
+                                for word in range(4):
+                                    K.assign(v_words[sub][matrix_row * 4 + word], words[word])
+                        _wait_barrier(arena, _BAR_K_STATE_READY, 0, k_state_cursor.phase)
+                        k_state_cursor.advance()
+                        for sub in range(2):
+                            values = _tcgen_load_16x256x8(
+                                tmem_base
+                                + _TM_ACC0
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                            g_pack = K.alloc_local((16,), "uint32")
+                            y_pack = K.alloc_local((16,), "uint32")
+                            for pair in range(16):
+                                g0, g1 = _fmul2(
+                                    values[pair * 2],
+                                    values[pair * 2 + 1],
+                                    cumprod_values[pair * 2],
+                                    cumprod_values[pair * 2 + 1],
+                                )
+                                K.assign(g_pack[pair], _pack_io_pair(g0, g1, io_dtype))
+                                y_word = K.local_scalar("uint32")
+                                _sub_io_pair(y_word, v_words[sub][pair], g_pack[pair], io_dtype)
+                                K.assign(y_pack[pair], y_word)
+                            _tcgen_store_16x128x8(
+                                tmem_base
+                                + _TM_Y
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
+                                y_pack,
+                            )
+                            _tcgen_store_16x128x8(
+                                tmem_base
+                                + _TM_GK
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
+                                g_pack,
+                            )
+                    with K.If(chunk < first_state_chunk), K.Then():
+                        for sub in range(2):
+                            v_pack = K.alloc_local((16,), "uint32")
+                            for matrix_row in range(4):
+                                words = load_col_fragment(_V_U_BASE, v_stage, sub, matrix_row)
+                                for word in range(4):
+                                    K.assign(v_pack[matrix_row * 4 + word], words[word])
+                            _tcgen_store_16x128x8(
+                                tmem_base
+                                + _TM_Y
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
+                                v_pack,
+                            )
+                    _tcgen_wait_store()
+                    _arrive_barrier(arena, _BAR_Y_READY)
+
+                    _wait_barrier(arena, _BAR_DU_TOTAL_READY, 0, du_total_cursor.phase)
+                    du_total_cursor.advance()
+                    for sub in range(2):
+                        values = _tcgen_load_16x256x8(
+                            tmem_base
+                            + _TM_DVDK
+                            + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                        )
+                        packed = K.alloc_local((16,), "uint32")
+                        for pair in range(16):
+                            K.assign(
+                                packed[pair],
+                                _pack_io_pair(values[pair * 2], values[pair * 2 + 1], io_dtype),
+                            )
+                        _tcgen_store_16x128x8(
+                            tmem_base
+                            + _TM_INP1
+                            + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
+                            packed,
+                        )
+                    _tcgen_wait_store()
+                    _arrive_barrier(arena, _BAR_DU_INP_READY)
+
+                    _wait_barrier(arena, _BAR_U_ACC_READY, 0, u_cursor.phase)
+                    u_cursor.advance()
+                    u_values = []
+                    for sub in range(2):
+                        u_values.append(
+                            _tcgen_load_16x256x8(
+                                tmem_base
+                                + _TM_ACC1
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                        )
+                    for sub in range(2):
+                        for matrix_row in range(4):
+                            packed = K.alloc_local((4,), "uint32")
+                            for pair in range(4):
+                                K.assign(
+                                    packed[pair],
+                                    _pack_io_pair(
+                                        u_values[sub][matrix_row * 8 + pair * 2],
+                                        u_values[sub][matrix_row * 8 + pair * 2 + 1],
+                                        io_dtype,
+                                    ),
+                                )
+                            store_col_fragment(_V_U_BASE, v_stage, sub, matrix_row, packed)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_U_READY)
+
+                    _wait_barrier(arena, _BAR_DY_ACC_READY, 0, dy_cursor.phase)
+                    dy_cursor.advance()
+                    dy_values = []
+                    for sub in range(2):
+                        dy_values.append(
+                            _tcgen_load_16x256x8(
+                                tmem_base
+                                + _TM_ACC0
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                        )
+                    for sub in range(2):
+                        dyp_pack = K.alloc_local((16,), "uint32")
+                        for pair in range(16):
+                            value0, value1 = _fmul2(
+                                dy_values[sub][pair * 2],
+                                dy_values[sub][pair * 2 + 1],
+                                negative_cumprod[pair * 2],
+                                negative_cumprod[pair * 2 + 1],
+                            )
+                            K.assign(dyp_pack[pair], _pack_io_pair(value0, value1, io_dtype))
+                        _tcgen_store_16x128x8(
+                            tmem_base
+                            + _TM_INP1
+                            + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
+                            dyp_pack,
+                        )
+                    _tcgen_wait_store()
+                    _arrive_barrier(arena, _BAR_DYP_INP_READY)
+
+                    dv_stage = K.local_scalar("int32", init=dv_cursor.stage)
+                    _wait_barrier(arena, _BAR_DV_STG_DONE, dv_stage, dv_cursor.phase)
+                    dv_cursor.advance()
+                    _wait_barrier(arena, _BAR_SDV_DONE, 0, sdv_cursor.phase)
+                    sdv_cursor.advance()
+                    for sub in range(2):
+                        for matrix_row in range(4):
+                            packed = K.alloc_local((4,), "uint32")
+                            for pair in range(4):
+                                K.assign(
+                                    packed[pair],
+                                    _pack_io_pair(
+                                        dy_values[sub][matrix_row * 8 + pair * 2],
+                                        dy_values[sub][matrix_row * 8 + pair * 2 + 1],
+                                        io_dtype,
+                                    ),
+                                )
+                            store_col_fragment(_DV_DY_BASE, dv_stage, sub, matrix_row, packed)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DV_STG_READY, dv_stage)
+
+                    dq_stage = K.local_scalar("int32", init=dq_cursor.stage)
+                    _wait_barrier(arena, _BAR_DQ_STG_DONE, dq_stage, dq_cursor.phase)
+                    dq_cursor.advance()
+
+                    part_y = K.alloc_local((16,), "float32")
+                    for value in range(16):
+                        K.assign(part_y[value], K.float32(0.0))
+                    for sub in range(2):
+                        y_words = _tcgen_load_16x128x8(
+                            tmem_base
+                            + _TM_Y
+                            + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                        )
+                        for pair in range(16):
+                            y0 = K.local_scalar("float32")
+                            y1 = K.local_scalar("float32")
+                            _unpack_io_pair(y_words[pair], y0, y1, io_dtype)
+                            fragment_value = pair * 2
+                            part_value = (fragment_value // 4) * 2 + fragment_value % 2
+                            if sub == 0 and pair % 2 == 0:
+                                next0, next1 = _fmul2(
+                                    dy_values[sub][fragment_value],
+                                    dy_values[sub][fragment_value + 1],
+                                    y0,
+                                    y1,
+                                )
+                            else:
+                                next0, next1 = _ffma2(
+                                    dy_values[sub][fragment_value],
+                                    dy_values[sub][fragment_value + 1],
+                                    y0,
+                                    y1,
+                                    part_y[part_value],
+                                    part_y[part_value + 1],
+                                )
+                            K.assign(part_y[part_value], next0)
+                            K.assign(part_y[part_value + 1], next1)
+                    part_y0, part_y1 = reduce_scatter_16(part_y)
+                    token0 = (lane // 4) * 8 + (lane % 4) * 2
+                    K.ptx.st.shared.f32(
+                        arena.ptr_to([_DQ_BASE + (warp_in_group * 64 + token0) * 4]), part_y0
+                    )
+                    K.ptx.st.shared.f32(
+                        arena.ptr_to([_DQ_BASE + (warp_in_group * 64 + token0 + 1) * 4]), part_y1
+                    )
+
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        part_g = K.alloc_local((16,), "float32")
+                        for value in range(16):
+                            K.assign(part_g[value], K.float32(0.0))
+                        for sub in range(2):
+                            g_words = _tcgen_load_16x128x8(
+                                tmem_base
+                                + _TM_GK
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                            for pair in range(16):
+                                g0 = K.local_scalar("float32")
+                                g1 = K.local_scalar("float32")
+                                _unpack_io_pair(g_words[pair], g0, g1, io_dtype)
+                                fragment_value = pair * 2
+                                part_value = (fragment_value // 4) * 2 + fragment_value % 2
+                                if sub == 0 and pair % 2 == 0:
+                                    next0, next1 = _fmul2(
+                                        dy_values[sub][fragment_value],
+                                        dy_values[sub][fragment_value + 1],
+                                        g0,
+                                        g1,
+                                    )
+                                else:
+                                    next0, next1 = _ffma2(
+                                        dy_values[sub][fragment_value],
+                                        dy_values[sub][fragment_value + 1],
+                                        g0,
+                                        g1,
+                                        part_g[part_value],
+                                        part_g[part_value + 1],
+                                    )
+                                K.assign(part_g[part_value], next0)
+                                K.assign(part_g[part_value + 1], next1)
+                        part_g0, part_g1 = reduce_scatter_16(part_g)
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_DQ_BASE + (256 + warp_in_group * 64 + token0) * 4]),
+                            part_g0,
+                        )
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_DQ_BASE + (256 + warp_in_group * 64 + token0 + 1) * 4]),
+                            part_g1,
+                        )
+                    K.ptx.bar.sync(K.uint32(5), K.uint32(128))
+                    with K.If(cg1_thread < 64), K.Then():
+                        ysum = K.local_scalar("float32", init=K.float32(0.0))
+                        for group in range(4):
+                            partial = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                partial, arena.ptr_to([_DQ_BASE + (group * 64 + cg1_thread) * 4])
+                            )
+                            K.assign(ysum, ysum + partial)
+                        beta_value = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            beta_value,
+                            arena.ptr_to([_BETA_BASE + beta_stage * 256 + cg1_thread * 4]),
+                        )
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_BETA_BASE + beta_stage * 256 + cg1_thread * 4]),
+                            ysum * _rcp(beta_value + K.float32(1.0e-10)),
+                        )
+                        with K.If(chunk >= first_state_chunk), K.Then():
+                            gsum = K.local_scalar("float32", init=K.float32(0.0))
+                            for group in range(4):
+                                partial = K.local_scalar("float32")
+                                K.ptx.ld.shared.f32(
+                                    partial,
+                                    arena.ptr_to([_DQ_BASE + (256 + group * 64 + cg1_thread) * 4]),
+                                )
+                                K.assign(gsum, gsum + partial)
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + cg1_thread * 4]),
+                                -gsum,
+                            )
+                        with K.If(chunk < first_state_chunk), K.Then():
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + cg1_thread * 4]),
+                                K.float32(0.0),
+                            )
+                    _arrive_barrier(arena, _BAR_BETA_DONE, beta_stage)
+                    _arrive_barrier(arena, _BAR_DBETA_CG1_READY)
+                    K.ptx.bar.sync(K.uint32(5), K.uint32(128))
+
+                    q_words = [K.alloc_local((16,), "uint32"), K.alloc_local((16,), "uint32")]
+                    for sub in range(2):
+                        for matrix_row in range(4):
+                            words = load_col_fragment(_Q_BASE, 0, sub, matrix_row)
+                            for word in range(4):
+                                K.assign(q_words[sub][matrix_row * 4 + word], words[word])
+                        _tcgen_store_16x128x8(
+                            tmem_base
+                            + _TM_Y
+                            + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
+                            q_words[sub],
+                        )
+                    _tcgen_wait_store()
+                    _arrive_barrier(arena, _BAR_Q_CG1_DONE)
+
+                    _wait_barrier(arena, _BAR_DQ_TOTAL_READY, 0, dq_total_cursor.phase)
+                    dq_total_cursor.advance()
+                    dq_values = []
+                    for sub in range(2):
+                        values = _tcgen_load_16x256x8(
+                            tmem_base
+                            + _TM_DSTATE_INP
+                            + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                        )
+                        dq_values.append(values)
+                        for matrix_row in range(4):
+                            packed = K.alloc_local((4,), "uint32")
+                            for pair in range(4):
+                                K.assign(
+                                    packed[pair],
+                                    _pack_io_pair(
+                                        values[matrix_row * 8 + pair * 2],
+                                        values[matrix_row * 8 + pair * 2 + 1],
+                                        io_dtype,
+                                    ),
+                                )
+                            store_col_fragment(_DQ_BASE, dq_stage, sub, matrix_row, packed)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DQ_TOTAL_DONE)
+                    _arrive_barrier(arena, _BAR_DQ_STG_READY, dq_stage)
+
+                    part_q = K.alloc_local((16,), "float32")
+                    for value in range(16):
+                        K.assign(part_q[value], K.float32(0.0))
+                    for sub in range(2):
+                        for matrix_row in range(4):
+                            for word in range(4):
+                                q0 = K.local_scalar("float32")
+                                q1 = K.local_scalar("float32")
+                                _unpack_io_pair(
+                                    q_words[sub][matrix_row * 4 + word], q0, q1, io_dtype
+                                )
+                                fragment_value = matrix_row * 8 + word * 2
+                                part_value = (fragment_value // 4) * 2 + fragment_value % 2
+                                if sub == 0 and word % 2 == 0:
+                                    next0, next1 = _fmul2(
+                                        dq_values[sub][fragment_value],
+                                        dq_values[sub][fragment_value + 1],
+                                        q0,
+                                        q1,
+                                    )
+                                else:
+                                    next0, next1 = _ffma2(
+                                        dq_values[sub][fragment_value],
+                                        dq_values[sub][fragment_value + 1],
+                                        q0,
+                                        q1,
+                                        part_q[part_value],
+                                        part_q[part_value + 1],
+                                    )
+                                K.assign(part_q[part_value], next0)
+                                K.assign(part_q[part_value + 1], next1)
+                    part_q0, part_q1 = reduce_scatter_16(part_q)
+                    token0 = (lane // 4) * 8 + (lane % 4) * 2
+                    K.ptx.st.shared.f32(
+                        arena.ptr_to([_DSTATE_BASE + (warp_in_group * 64 + token0) * 4]), part_q0
+                    )
+                    K.ptx.st.shared.f32(
+                        arena.ptr_to([_DSTATE_BASE + (warp_in_group * 64 + token0 + 1) * 4]),
+                        part_q1,
+                    )
+                    K.ptx.bar.sync(K.uint32(5), K.uint32(128))
+                    with K.If(cg1_thread < 64), K.Then():
+                        qsum = K.local_scalar("float32", init=K.float32(0.0))
+                        for group in range(4):
+                            partial = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                partial,
+                                arena.ptr_to([_DSTATE_BASE + (group * 64 + cg1_thread) * 4]),
+                            )
+                            K.assign(qsum, qsum + partial)
+                        gate_partial = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            gate_partial,
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + cg1_thread * 4]),
+                        )
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + cg1_thread * 4]),
+                            gate_partial + qsum,
+                        )
+                    _arrive_barrier(arena, _BAR_GATE_DONE, gate_stage)
+                    _arrive_barrier(arena, _BAR_DGATE_CG1_READY)
+
+                    with K.If(chunk >= wstart + 1), K.Then():
+                        dstate_stage = K.local_scalar("int32", init=dstate_acc_cursor.stage)
+                        _wait_barrier(
+                            arena, _BAR_DSTATE_ACC_READY, dstate_stage, dstate_acc_cursor.phase
+                        )
+                        dstate_acc_cursor.advance()
+                        inp_stage = K.local_scalar("int32", init=dstate_inp_cursor.stage)
+                        _wait_barrier(
+                            arena, _BAR_DSTATE_INP_DONE, inp_stage, dstate_inp_cursor.phase
+                        )
+                        dstate_inp_cursor.advance()
+                        for sub in range(4):
+                            values = _tcgen_load_32x32x32(
+                                tmem_base + _TM_DSTATE + sub * 32 + tmem_row
+                            )
+                            packed = K.alloc_local((16,), "uint32")
+                            for pair in range(16):
+                                K.assign(
+                                    packed[pair],
+                                    _pack_io_pair(values[pair * 2], values[pair * 2 + 1], io_dtype),
+                                )
+                            _tcgen_store_32x32x16(
+                                tmem_base + _TM_DSTATE_INP + sub * 16 + tmem_row, packed
+                            )
+                        _tcgen_wait_store()
+                        _arrive_barrier(arena, _BAR_DSTATE_INP_READY, inp_stage)
+
+                    dk_stage = K.local_scalar("int32", init=dk_cursor.stage)
+                    _wait_barrier(arena, _BAR_DK_STG_DONE, dk_stage, dk_cursor.phase)
+                    dk_cursor.advance()
+                    state_part = [K.alloc_local((32,), "float32"), K.alloc_local((32,), "float32")]
+                    for sub in range(2):
+                        for value in range(32):
+                            K.assign(state_part[sub][value], K.float32(0.0))
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(arena, _BAR_DK_STATE_READY, 0, dk_state_cursor.phase)
+                        dk_state_cursor.advance()
+                        state_raw = []
+                        for sub in range(2):
+                            state_raw.append(
+                                _tcgen_load_16x256x8(
+                                    tmem_base
+                                    + _TM_INP0
+                                    + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                                )
+                            )
+                        _tcgen_wait_load()
+                        for sub in range(2):
+                            for pair in range(16):
+                                value0, value1 = _fmul2(
+                                    state_raw[sub][pair * 2],
+                                    state_raw[sub][pair * 2 + 1],
+                                    negative_cumprod[pair * 2],
+                                    negative_cumprod[pair * 2 + 1],
+                                )
+                                K.assign(state_part[sub][pair * 2], value0)
+                                K.assign(state_part[sub][pair * 2 + 1], value1)
+
+                    _wait_barrier(arena, _BAR_DK_TOTAL_READY, 0, dk_total_cursor.phase)
+                    dk_total_cursor.advance()
+                    total_dk = []
+                    for sub in range(2):
+                        total_dk.append(
+                            _tcgen_load_16x256x8(
+                                tmem_base
+                                + _TM_DVDK
+                                + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16))
+                            )
+                        )
+                    _tcgen_wait_load()
+                    _arrive_barrier(arena, _BAR_DK_TOTAL_DONE)
+                    for sub in range(2):
+                        for matrix_row in range(4):
+                            packed = K.alloc_local((4,), "uint32")
+                            for pair in range(4):
+                                index = matrix_row * 8 + pair * 2
+                                K.assign(
+                                    packed[pair],
+                                    _pack_io_pair(
+                                        total_dk[sub][index] + state_part[sub][index],
+                                        total_dk[sub][index + 1] + state_part[sub][index + 1],
+                                        io_dtype,
+                                    ),
+                                )
+                            store_col_fragment(_DK_BASE, dk_stage, sub, matrix_row, packed)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, _BAR_DK_STG_READY, dk_stage)
+
+                    with K.If(chunk >= wstart + 1), K.Then():
+                        _wait_barrier(arena, _BAR_STATE_DOT_DONE, 0, state_dot_cursor.phase)
+                    state_dot_cursor.advance()
+                    with K.If(chunk >= wstart + 1), K.Then():
+                        stage_dstate_smem()
+                        K.ptx.fence.proxy.async_.shared__cta()
+                        _arrive_barrier(arena, _BAR_DSTATE_SMEM_READY)
+
+                with K.If(num_item_chunks > 0), K.Then():
+                    dstate_stage = K.local_scalar("int32", init=dstate_acc_cursor.stage)
+                    _wait_barrier(
+                        arena, _BAR_DSTATE_ACC_READY, dstate_stage, dstate_acc_cursor.phase
+                    )
+                    dstate_acc_cursor.advance()
+                    if use_dstate0:
+                        with K.If(wstart == 0), K.Then():
+                            for sub in range(4):
+                                values = _tcgen_load_32x32x32(
+                                    tmem_base + _TM_DSTATE + sub * 32 + tmem_row
+                                )
+                                for value in range(32):
+                                    K.ptx.st.global_.f32(
+                                        dstate0.ptr_to(
+                                            [
+                                                state_base
+                                                + K.cast(cg1_thread, "int64") * _DK
+                                                + sub * 32
+                                                + value
+                                            ]
+                                        ),
+                                        values[value],
+                                    )
+                    if not use_dstate_in:
+                        _arrive_barrier(arena, _BAR_DSTATE_SCALE_DONE, dstate_stage)
+                if use_dstate0:
+                    with K.If(K.And(num_item_chunks <= 0, wstart == 0)), K.Then():
+                        for sub in range(4):
+                            for value in range(32):
+                                output_index = (
+                                    state_base
+                                    + K.cast(cg1_thread, "int64") * _DK
+                                    + sub * 32
+                                    + value
+                                )
+                                if use_dstate_in:
+                                    passthrough = K.local_scalar("float32")
+                                    K.ptx.ld.global_.f32(
+                                        passthrough, dstate_in.ptr_to([output_index])
+                                    )
+                                    K.ptx.st.global_.f32(
+                                        dstate0.ptr_to([output_index]), passthrough
+                                    )
+                                else:
+                                    K.ptx.st.global_.f32(
+                                        dstate0.ptr_to([output_index]), K.float32(0.0)
+                                    )
+                sched_consume(sched_state, tile)
+
+            _arrive_barrier(arena, _BAR_TMEM_DONE)
+            _wait_barrier(
+                arena, _BAR_DSTATE_INP_DONE, dstate_inp_cursor.stage, dstate_inp_cursor.phase
+            )
+            dstate_inp_cursor.advance()
+            _wait_barrier(arena, _BAR_DK_STG_DONE, dk_cursor.stage, dk_cursor.phase)
+            dk_cursor.advance()
+            _wait_barrier(arena, _BAR_DV_STG_DONE, dv_cursor.stage, dv_cursor.phase)
+            dv_cursor.advance()
+
+        with mma:
+            elected_lane = K.local_scalar("uint32")
+            leader = K.local_scalar("uint32")
+            K.ptx.elect_sync(elected_lane, leader, K.uint32(0xFFFFFFFF))
+            K.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                arena.ptr_to([_TMEM_MAILBOX]), K.uint32(512)
+            )
+            K.ptx.bar.sync(K.uint32(1), K.uint32(288))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([_TMEM_MAILBOX]))
+
+            kk_done = K.PipelineState(1, phase=0)
+            dk_total_done = K.PipelineState(1, phase=1)
+            du_scale_done = K.PipelineState(1, phase=0)
+            dk_scale_done = K.PipelineState(1, phase=0)
+            dk_attn_done = K.PipelineState(1, phase=0)
+            dstate_acc = K.PipelineState(1, phase=0 if use_dstate_in else 1)
+            k_ready = K.PipelineState(2, phase=0)
+            q_ready = K.PipelineState(1, phase=0)
+            state_ready = K.PipelineState(1, phase=0)
+            v_release = K.PipelineState(1, phase=0)
+            tinv_ready = K.PipelineState(1, phase=0)
+            do_ready = K.PipelineState(1, phase=0)
+            y_ready = K.PipelineState(1, phase=0)
+            u_ready = K.PipelineState(1, phase=0)
+            da_ready = K.PipelineState(1, phase=0)
+            dv_ready = K.PipelineState(1, phase=0)
+            dm_done = K.PipelineState(1, phase=0)
+            dstate_smem = K.PipelineState(1, phase=0)
+            dq_scale_done = K.PipelineState(1, phase=0)
+            dq_total_done = K.PipelineState(1, phase=1)
+            a_ready = K.PipelineState(1, phase=0)
+            do_prime_ready = K.PipelineState(1, phase=0)
+            du_inp_ready = K.PipelineState(1, phase=0)
+            dyp_inp_ready = K.PipelineState(1, phase=0)
+            dstate_inp_ready = K.PipelineState(1, phase=0)
+            sched_state = K.PipelineState(2, phase=0)
+
+            def mma_ss(
+                destination,
+                desc_a,
+                desc_b,
+                instruction,
+                accumulate,
+                *,
+                m,
+                n,
+                k_extent,
+                a_transpose=False,
+                b_transpose=False,
+            ):
+                _tcgen_mma_ss(
+                    tmem_base + destination,
+                    desc_a,
+                    desc_b,
+                    instruction,
+                    leader=leader,
+                    m=m,
+                    n=n,
+                    k_extent=k_extent,
+                    a_transpose=a_transpose,
+                    b_transpose=b_transpose,
+                    accumulate=accumulate,
+                )
+
+            def mma_ts(
+                destination,
+                source,
+                desc_b,
+                instruction,
+                accumulate,
+                *,
+                n,
+                k_extent,
+                b_transpose=False,
+            ):
+                _tcgen_mma_ts(
+                    tmem_base + destination,
+                    tmem_base + source,
+                    desc_b,
+                    instruction,
+                    leader=leader,
+                    n=n,
+                    k_extent=k_extent,
+                    b_transpose=b_transpose,
+                    accumulate=accumulate,
+                )
+
+            desc_q = _raw_descriptor(arena, _Q_BASE, 16, 1024, 2)
+            desc_q_trans = _raw_descriptor(arena, _Q_BASE, 8192, 1024, 2)
+            desc_do = _raw_descriptor(arena, _DO_BASE, 8192, 1024, 2)
+            desc_do_kmaj = _raw_descriptor(arena, _DO_BASE, 16, 1024, 2)
+            desc_state = _raw_descriptor(arena, _STATE_BASE, 16_384, 1024, 2)
+            desc_state_kmaj = _raw_descriptor(arena, _STATE_BASE, 16, 1024, 2)
+            desc_tinv = _raw_descriptor(arena, _TINV_BASE, 16, 1024, 2)
+            desc_tinv_trans = _raw_descriptor(arena, _TINV_BASE, 8192, 1024, 2)
+            desc_a_trans = _raw_descriptor(arena, _A_DA_BASE, 8192, 1024, 2)
+            desc_da = _raw_descriptor(arena, _A_DA_BASE, 16, 1024, 2)
+            desc_da_trans = _raw_descriptor(arena, _A_DA_BASE, 8192, 1024, 2)
+            desc_v_kmaj = _raw_descriptor(arena, _V_U_BASE, 16, 1024, 2)
+            desc_dv_kmaj = _raw_descriptor(arena, _DV_DY_BASE, 16, 1024, 2)
+            desc_dstate = _raw_descriptor(arena, _DSTATE_BASE, 16_384, 1024, 2)
+            desc_dm = _raw_descriptor(arena, _DM_BASE, 16, 1024, 2)
+            desc_dm_trans = _raw_descriptor(arena, _DM_BASE, 8192, 1024, 2)
+
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                wstart = item[2]
+                cend = item[5]
+                with K.serial(cend - wstart, unroll=False) as reverse_index:
+                    chunk = cend - 1 - reverse_index
+                    have_dstate = K.bool(True) if use_dstate_in else reverse_index > 0
+
+                    k_stage = K.local_scalar("int32", init=k_ready.stage)
+                    _wait_barrier(arena, _BAR_K_READY, k_stage, k_ready.phase)
+                    k_ready.advance()
+                    desc_k = _raw_descriptor(arena, _K_BASE + k_stage * 16_384, 16, 1024, 2)
+                    desc_k_trans = _raw_descriptor(arena, _K_BASE + k_stage * 16_384, 8192, 1024, 2)
+                    mma_ss(_TM_ACC0, desc_k, desc_k, idesc_m64_n64, False, m=64, n=64, k_extent=128)
+                    _tcgen_commit(arena, _BAR_KK_READY, leader=leader)
+
+                    q_stage = K.local_scalar("int32", init=q_ready.stage)
+                    _wait_barrier(arena, _BAR_Q_READY, q_stage, q_ready.phase)
+                    q_ready.advance()
+                    mma_ss(_TM_ACC1, desc_q, desc_k, idesc_m64_n64, False, m=64, n=64, k_extent=128)
+                    _tcgen_commit(arena, _BAR_A_ACC_READY, leader=leader)
+
+                    state_stage = K.local_scalar("int32", init=state_ready.stage)
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(arena, _BAR_STATE_READY, state_stage, state_ready.phase)
+                        state_ready.advance()
+                        _wait_barrier(arena, _BAR_KK_DONE, 0, kk_done.phase)
+                        kk_done.advance()
+                        mma_ss(
+                            _TM_ACC0,
+                            desc_state_kmaj,
+                            desc_k,
+                            idesc_m128_n64,
+                            False,
+                            m=128,
+                            n=64,
+                            k_extent=128,
+                        )
+                        _tcgen_commit(arena, _BAR_K_STATE_READY, leader=leader)
+
+                    dstate_inp_stage = K.local_scalar("int32", init=dstate_inp_ready.stage)
+                    with K.If(have_dstate), K.Then():
+                        _wait_barrier(
+                            arena, _BAR_DSTATE_INP_READY, dstate_inp_stage, dstate_inp_ready.phase
+                        )
+                        dstate_inp_ready.advance()
+                    _wait_barrier(arena, _BAR_DK_TOTAL_DONE, 0, dk_total_done.phase)
+                    dk_total_done.advance()
+                    with K.If(have_dstate), K.Then():
+                        mma_ts(
+                            _TM_DVDK,
+                            _TM_DSTATE_INP,
+                            desc_k,
+                            idesc_m128_n64,
+                            False,
+                            n=64,
+                            k_extent=128,
+                        )
+                        _tcgen_commit(arena, _BAR_DU_SCALE_READY, leader=leader)
+                        _tcgen_commit(arena, _BAR_DSTATE_INP_DONE, dstate_inp_stage, leader=leader)
+
+                    do_stage = K.local_scalar("int32", init=do_ready.stage)
+                    _wait_barrier(arena, _BAR_DO_READY, do_stage, do_ready.phase)
+                    do_ready.advance()
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(arena, _BAR_DQ_TOTAL_DONE, 0, dq_total_done.phase)
+                        dq_total_done.advance()
+                        mma_ss(
+                            _TM_DSTATE_INP,
+                            desc_state,
+                            desc_do_kmaj,
+                            idesc_m128_n64_a,
+                            False,
+                            m=128,
+                            n=64,
+                            k_extent=128,
+                            a_transpose=True,
+                        )
+                        _tcgen_commit(arena, _BAR_DQ_SCALE_READY, leader=leader)
+
+                    a_stage = K.local_scalar("int32", init=a_ready.stage)
+                    _wait_barrier(arena, _BAR_A_READY, a_stage, a_ready.phase)
+                    a_ready.advance()
+                    with K.If(have_dstate), K.Then():
+                        _wait_barrier(arena, _BAR_DU_SCALE_DONE, 0, du_scale_done.phase)
+                        du_scale_done.advance()
+                    mma_ss(
+                        _TM_DVDK,
+                        desc_do,
+                        desc_a_trans,
+                        idesc_m128_n64_ab,
+                        have_dstate,
+                        m=128,
+                        n=64,
+                        k_extent=64,
+                        a_transpose=True,
+                        b_transpose=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DU_TOTAL_READY, leader=leader)
+
+                    _wait_barrier(arena, _BAR_DO_PRIME_READY, 0, do_prime_ready.phase)
+                    do_prime_ready.advance()
+                    dstate_stage = K.local_scalar("int32", init=dstate_acc.stage)
+                    _wait_barrier(arena, _BAR_DSTATE_SCALE_DONE, dstate_stage, dstate_acc.phase)
+                    dstate_acc.advance()
+                    mma_ts(
+                        _TM_DSTATE,
+                        _TM_INP0,
+                        desc_q_trans,
+                        idesc_m128_n128_b,
+                        have_dstate,
+                        n=128,
+                        k_extent=64,
+                        b_transpose=True,
+                    )
+
+                    _wait_barrier(arena, _BAR_TINV_READY, 0, tinv_ready.phase)
+                    tinv_ready.advance()
+                    _wait_barrier(arena, _BAR_Y_READY, 0, y_ready.phase)
+                    y_ready.advance()
+                    v_stage = K.local_scalar("int32", init=v_release.stage)
+                    v_release.advance()
+                    mma_ts(_TM_ACC1, _TM_Y, desc_tinv, idesc_m128_n64, False, n=64, k_extent=64)
+                    _tcgen_commit(arena, _BAR_U_ACC_READY, leader=leader)
+
+                    _wait_barrier(arena, _BAR_DU_INP_READY, 0, du_inp_ready.phase)
+                    du_inp_ready.advance()
+                    mma_ts(
+                        _TM_ACC0,
+                        _TM_INP1,
+                        desc_tinv_trans,
+                        idesc_m128_n64_b,
+                        False,
+                        n=64,
+                        k_extent=64,
+                        b_transpose=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DY_ACC_READY, leader=leader)
+
+                    _wait_barrier(arena, _BAR_U_READY, 0, u_ready.phase)
+                    u_ready.advance()
+                    with K.If(have_dstate), K.Then():
+                        _wait_barrier(arena, _BAR_DSTATE_SMEM_READY, 0, dstate_smem.phase)
+                        dstate_smem.advance()
+                        mma_ss(
+                            _TM_DVDK,
+                            desc_dstate,
+                            desc_v_kmaj,
+                            idesc_m128_n64_a,
+                            False,
+                            m=128,
+                            n=64,
+                            k_extent=128,
+                            a_transpose=True,
+                        )
+                        _tcgen_commit(arena, _BAR_DK_SCALE_READY, leader=leader)
+
+                    mma_ss(
+                        _TM_ACC1,
+                        desc_do_kmaj,
+                        desc_v_kmaj,
+                        idesc_m64_n64,
+                        False,
+                        m=64,
+                        n=64,
+                        k_extent=128,
+                    )
+                    _tcgen_commit(arena, _BAR_DA_ACC_READY, leader=leader)
+                    _tcgen_commit(arena, _BAR_DO_MMA_DONE, do_stage, leader=leader)
+
+                    _wait_barrier(arena, _BAR_DV_STG_READY, 0, dv_ready.phase)
+                    dv_ready.advance()
+                    mma_ss(
+                        _TM_ACC0,
+                        desc_dv_kmaj,
+                        desc_v_kmaj,
+                        idesc_m64_n64,
+                        False,
+                        m=64,
+                        n=64,
+                        k_extent=128,
+                    )
+                    _tcgen_commit(arena, _BAR_DM_ACC_READY, leader=leader)
+                    _tcgen_commit(arena, _BAR_V_MMA_DONE, v_stage, leader=leader)
+
+                    _wait_barrier(arena, _BAR_DYP_INP_READY, 0, dyp_inp_ready.phase)
+                    dyp_inp_ready.advance()
+                    mma_ts(
+                        _TM_DSTATE,
+                        _TM_INP1,
+                        desc_k_trans,
+                        idesc_m128_n128_b,
+                        True,
+                        n=128,
+                        k_extent=64,
+                        b_transpose=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DSTATE_ACC_READY, dstate_stage, leader=leader)
+
+                    with K.If(have_dstate), K.Then():
+                        _wait_barrier(arena, _BAR_DK_SCALE_DONE, 0, dk_scale_done.phase)
+                        dk_scale_done.advance()
+                    _wait_barrier(arena, _BAR_DA_READY, 0, da_ready.phase)
+                    da_ready.advance()
+                    mma_ss(
+                        _TM_DVDK,
+                        desc_q_trans,
+                        desc_da_trans,
+                        idesc_m128_n64_ab,
+                        have_dstate,
+                        m=128,
+                        n=64,
+                        k_extent=64,
+                        a_transpose=True,
+                        b_transpose=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DK_ATTN_READY, leader=leader)
+                    _tcgen_commit(arena, _BAR_Q_MMA_DONE, q_stage, leader=leader)
+
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        _wait_barrier(arena, _BAR_DQ_SCALE_DONE, 0, dq_scale_done.phase)
+                        dq_scale_done.advance()
+                    with K.If(chunk < first_state_chunk), K.Then():
+                        _wait_barrier(arena, _BAR_DQ_TOTAL_DONE, 0, dq_total_done.phase)
+                        dq_total_done.advance()
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        mma_ss(
+                            _TM_DSTATE_INP,
+                            desc_k_trans,
+                            desc_da,
+                            idesc_m128_n64_a,
+                            True,
+                            m=128,
+                            n=64,
+                            k_extent=64,
+                            a_transpose=True,
+                        )
+                    with K.If(chunk < first_state_chunk), K.Then():
+                        mma_ss(
+                            _TM_DSTATE_INP,
+                            desc_k_trans,
+                            desc_da,
+                            idesc_m128_n64_a,
+                            False,
+                            m=128,
+                            n=64,
+                            k_extent=64,
+                            a_transpose=True,
+                        )
+                    _tcgen_commit(arena, _BAR_DQ_TOTAL_READY, leader=leader)
+                    _tcgen_commit(arena, _BAR_A_DONE, a_stage, leader=leader)
+
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        mma_ss(
+                            _TM_INP0,
+                            desc_state,
+                            desc_dv_kmaj,
+                            idesc_m128_n64_a,
+                            False,
+                            m=128,
+                            n=64,
+                            k_extent=128,
+                            a_transpose=True,
+                        )
+                        _tcgen_commit(arena, _BAR_DK_STATE_READY, leader=leader)
+                        _tcgen_commit(arena, _BAR_STATE_MMA_DONE, state_stage, leader=leader)
+                    _tcgen_commit(arena, _BAR_SDV_DONE, leader=leader)
+
+                    _wait_barrier(arena, _BAR_DM_ACC_DONE, 0, dm_done.phase)
+                    dm_done.advance()
+                    _wait_barrier(arena, _BAR_DK_ATTN_DONE, 0, dk_attn_done.phase)
+                    dk_attn_done.advance()
+                    mma_ss(
+                        _TM_DVDK,
+                        desc_k_trans,
+                        desc_dm_trans,
+                        idesc_m128_n64_ab,
+                        True,
+                        m=128,
+                        n=64,
+                        k_extent=64,
+                        a_transpose=True,
+                        b_transpose=True,
+                    )
+                    mma_ss(
+                        _TM_DVDK,
+                        desc_k_trans,
+                        desc_dm,
+                        idesc_m128_n64_a,
+                        True,
+                        m=128,
+                        n=64,
+                        k_extent=64,
+                        a_transpose=True,
+                    )
+                    _tcgen_commit(arena, _BAR_DK_TOTAL_READY, leader=leader)
+                    _tcgen_commit(arena, _BAR_K_MMA_DONE, k_stage, leader=leader)
+                sched_consume(sched_state, tile)
+
+            _wait_barrier(arena, _BAR_DK_TOTAL_DONE, 0, dk_total_done.phase)
+            _wait_barrier(arena, _BAR_TMEM_DONE, 0, 0)
+            K.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            K.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                K.cast(tmem_base, "uint32"), K.uint32(512)
+            )
+
+        # Warp 9: K -> Q -> V -> dO -> checkpoint TensorMap loads.
+        with tma:
+            q_state = K.PipelineState(1, phase=1)
+            k_state = K.PipelineState(2, phase=1)
+            v_state = K.PipelineState(1, phase=1)
+            do_state = K.PipelineState(1, phase=1)
+            checkpoint_state = K.PipelineState(1, phase=1)
+            sched_state = K.PipelineState(2, phase=1)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                cend = item[5]
+                head_q = head if q_ratio == 1 else _udiv_nonnegative(head, q_ratio)
+                head_k = head if k_ratio == 1 else _udiv_nonnegative(head, k_ratio)
+                head_v = head if v_ratio == 1 else _udiv_nonnegative(head, v_ratio)
+                desc_q = _descriptor_slot(descriptor_workspace, n_desc, 0, batch)
+                desc_k = _descriptor_slot(descriptor_workspace, n_desc, 1, batch)
+                desc_v = _descriptor_slot(descriptor_workspace, n_desc, 2, batch)
+                desc_do = _descriptor_slot(descriptor_workspace, n_desc, 3, batch)
+                desc_checkpoint = _descriptor_slot(descriptor_workspace, n_desc, 4, batch)
+                with K.If(_elected()), K.Then():
+                    for descriptor in (desc_q, desc_k, desc_v, desc_do, desc_checkpoint):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(descriptor)
+                with K.serial(cend - wstart, unroll=False) as reverse_index:
+                    chunk = cend - 1 - reverse_index
+                    token = chunk * _BT
+                    leader = K.cuda.elect_sync()
+
+                    k_stage = K.local_scalar("int32", init=k_state.stage)
+                    _wait_barrier(arena, _BAR_K_MMA_DONE, k_stage, k_state.phase)
+                    _wait_barrier(arena, _BAR_K_CG0_DONE, k_stage, k_state.phase)
+                    k_state.advance()
+                    _expect_tx(arena, _BAR_K_READY, k_stage, 16_384, pred=leader)
+                    for channel, byte_offset in ((0, 0), (64, 8192)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([_K_BASE + k_stage * 16_384 + byte_offset]),
+                            desc_k,
+                            K.int32(channel),
+                            K.cast(head_k, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_K_READY, k_stage),
+                            pred=leader,
+                        )
+
+                    q_stage = K.local_scalar("int32", init=q_state.stage)
+                    _wait_barrier(arena, _BAR_Q_MMA_DONE, q_stage, q_state.phase)
+                    _wait_barrier(arena, _BAR_Q_CG1_DONE, q_stage, q_state.phase)
+                    q_state.advance()
+                    _expect_tx(arena, _BAR_Q_READY, q_stage, 16_384, pred=leader)
+                    for channel, byte_offset in ((0, 0), (64, 8192)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([_Q_BASE + byte_offset]),
+                            desc_q,
+                            K.int32(channel),
+                            K.cast(head_q, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_Q_READY, q_stage),
+                            pred=leader,
+                        )
+
+                    v_stage = K.local_scalar("int32", init=v_state.stage)
+                    _wait_barrier(arena, _BAR_V_MMA_DONE, v_stage, v_state.phase)
+                    v_state.advance()
+                    _expect_tx(arena, _BAR_V_READY, v_stage, 16_384, pred=leader)
+                    for channel, byte_offset in ((0, 0), (64, 8192)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([_V_U_BASE + byte_offset]),
+                            desc_v,
+                            K.int32(channel),
+                            K.cast(head_v, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_V_READY, v_stage),
+                            pred=leader,
+                        )
+
+                    do_stage = K.local_scalar("int32", init=do_state.stage)
+                    _wait_barrier(arena, _BAR_DO_MMA_DONE, do_stage, do_state.phase)
+                    do_state.advance()
+                    _expect_tx(arena, _BAR_DO_READY, do_stage, 16_384, pred=leader)
+                    for channel, byte_offset in ((0, 0), (64, 8192)):
+                        K.ptx[_TMA_G2S_3D](
+                            arena.ptr_to([_DO_BASE + byte_offset]),
+                            desc_do,
+                            K.int32(channel),
+                            K.cast(head, "int32"),
+                            K.cast(token, "int32"),
+                            _barrier_ptr(arena, _BAR_DO_READY, do_stage),
+                            pred=leader,
+                        )
+
+                    with K.If(chunk >= first_state_chunk), K.Then():
+                        checkpoint_stage = K.local_scalar("int32", init=checkpoint_state.stage)
+                        _wait_barrier(
+                            arena, _BAR_STATE_MMA_DONE, checkpoint_stage, checkpoint_state.phase
+                        )
+                        checkpoint_state.advance()
+                        _expect_tx(arena, _BAR_STATE_READY, checkpoint_stage, 32_768, pred=leader)
+                        for key_coord, byte_offset in ((0, 0), (64, 16_384)):
+                            K.ptx[_TMA_G2S_4D](
+                                arena.ptr_to([_STATE_BASE + byte_offset]),
+                                desc_checkpoint,
+                                K.int32(key_coord),
+                                K.int32(0),
+                                K.cast(chunk, "int32"),
+                                K.cast(head, "int32"),
+                                _barrier_ptr(arena, _BAR_STATE_READY, checkpoint_stage),
+                                pred=leader,
+                            )
+                sched_produce(sched_state, tile)
+
+            for _ in range(1):
+                _wait_barrier(arena, _BAR_Q_MMA_DONE, q_state.stage, q_state.phase)
+                _wait_barrier(arena, _BAR_Q_CG1_DONE, q_state.stage, q_state.phase)
+                q_state.advance()
+            for _ in range(2):
+                _wait_barrier(arena, _BAR_K_MMA_DONE, k_state.stage, k_state.phase)
+                _wait_barrier(arena, _BAR_K_CG0_DONE, k_state.stage, k_state.phase)
+                k_state.advance()
+            for _ in range(1):
+                _wait_barrier(arena, _BAR_V_MMA_DONE, v_state.stage, v_state.phase)
+                v_state.advance()
+            for _ in range(1):
+                _wait_barrier(arena, _BAR_DO_MMA_DONE, do_state.stage, do_state.phase)
+                do_state.advance()
+
+        # Warp 10: first/next scalar prefetch, suffix fold, and in-place stores.
+        with gate_beta:
+            gate_load = K.PipelineState(2, phase=1)
+            beta_load = K.PipelineState(2, phase=1)
+            gate_store = K.PipelineState(2, phase=0)
+            beta_store = K.PipelineState(2, phase=0)
+            sched_state = K.PipelineState(2, phase=0)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                batch_begin = item[6]
+                batch_end = item[7]
+                count = cend - wstart
+                write_end = K.if_then_else(
+                    batch_begin + wend * _BT < batch_end, batch_begin + wend * _BT, batch_end
+                )
+                a_l2 = K.local_scalar("float32", init=K.float32(0.0))
+                bias = K.local_scalar("float32", init=K.float32(0.0))
+                if safe_gate:
+                    with K.If(count > 0), K.Then():
+                        amplitude = K.local_scalar("float32")
+                        K.ptx.ld.global_.f32(amplitude, a_log.ptr_to([head]))
+                        K.assign(
+                            a_l2, -_exp2(amplitude * K.float32(_RCP_LN2)) * K.float32(_RCP_LN2)
+                        )
+                        K.ptx.ld.global_.f32(bias, dt_bias.ptr_to([head]))
+
+                def prefetch(chunk):
+                    chunk_offset = batch_begin + chunk * _BT
+                    gate_stage = K.local_scalar("int32", init=gate_load.stage)
+                    gate_load.advance()
+                    gate_values = K.alloc_local((2,), "float32")
+                    for column in range(2):
+                        position = lane + column * 32
+                        token = chunk_offset + position
+                        neutral = 0.0 if log_gate else 1.0
+                        K.assign(gate_values[column], K.float32(neutral))
+                        with K.If(token < batch_end), K.Then():
+                            K.ptx.ld.global_.f32(
+                                gate_values[column],
+                                gate.ptr_to([K.cast(token, "int64") * n_heads_out + head]),
+                            )
+                    if safe_gate:
+                        for column in range(2):
+                            position = lane + column * 32
+                            token = chunk_offset + position
+                            transformed = a_l2 * _softplus(gate_values[column] + bias)
+                            K.assign(
+                                gate_values[column],
+                                K.if_then_else(token < batch_end, transformed, K.float32(0.0)),
+                            )
+                    elif log_gate:
+                        for column in range(2):
+                            K.assign(gate_values[column], gate_values[column] * K.float32(_RCP_LN2))
+                    else:
+                        for column in range(2):
+                            K.assign(
+                                gate_values[column], _lg2(gate_values[column] + K.float32(1e-10))
+                            )
+                    for distance in (1, 2, 4, 8, 16):
+                        for column in range(2):
+                            prior = _shfl_up_f32(gate_values[column], distance)
+                            K.assign(
+                                gate_values[column],
+                                K.if_then_else(
+                                    lane >= distance,
+                                    gate_values[column] + prior,
+                                    gate_values[column],
+                                ),
+                            )
+                    K.assign(gate_values[1], gate_values[1] + _shfl_idx_f32(gate_values[0], 31, 31))
+                    for column in range(2):
+                        position = lane + column * 32
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + position * 4]),
+                            gate_values[column],
+                        )
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to([_CUMPROD_BASE + gate_stage * 256 + position * 4]),
+                            _exp2(gate_values[column]),
+                        )
+                    _arrive_barrier(arena, _BAR_GATE_READY, gate_stage)
+
+                    beta_stage = K.local_scalar("int32", init=beta_load.stage)
+                    beta_load.advance()
+                    if beta_sigmoid:
+                        for column in range(2):
+                            position = lane + column * 32
+                            token = chunk_offset + position
+                            beta_value = K.local_scalar("float32", init=K.float32(0.0))
+                            with K.If(token < batch_end), K.Then():
+                                bits = K.local_scalar("uint16")
+                                K.ptx.ld.global_.b16(
+                                    bits, beta.ptr_to([K.cast(token, "int64") * n_heads_out + head])
+                                )
+                                raw = K.local_scalar("float32")
+                                if io_dtype == "float16":
+                                    K.assign(raw, K.cast(K.reinterpret("float16", bits), "float32"))
+                                else:
+                                    K.ptx.cvt.f32.bf16(raw, bits)
+                                rounded = _pack_io_pair(
+                                    _tanh(raw * K.float32(0.5)) * K.float32(0.5) + K.float32(0.5),
+                                    K.float32(0.0),
+                                    io_dtype,
+                                )
+                                ignored = K.local_scalar("float32")
+                                _unpack_io_pair(rounded, beta_value, ignored, io_dtype)
+                            K.ptx.st.shared.f32(
+                                arena.ptr_to([_BETA_BASE + beta_stage * 256 + position * 4]),
+                                beta_value,
+                            )
+                        _arrive_barrier(arena, _BAR_BETA_READY, beta_stage)
+                    else:
+                        for column in range(2):
+                            position = lane + column * 32
+                            token = chunk_offset + position
+                            copy_bytes = K.if_then_else(token < batch_end, K.uint32(4), K.uint32(0))
+                            K.ptx["cp.async.ca.shared.global"](
+                                arena.ptr_to([_BETA_BASE + beta_stage * 256 + position * 4]),
+                                beta.ptr_to([K.cast(token, "int64") * n_heads_out + head]),
+                                K.uint32(4),
+                                copy_bytes,
+                            )
+                        K.ptx["cp.async.mbarrier.arrive.noinc.shared.b64"](
+                            _barrier_ptr(arena, _BAR_BETA_READY, beta_stage)
+                        )
+
+                with K.If(count > 0), K.Then():
+                    prefetch(cend - 1)
+                with K.serial(count, unroll=False) as reverse_index:
+                    with K.If(reverse_index + 1 < count), K.Then():
+                        prefetch(cend - 2 - reverse_index)
+                    chunk = cend - 1 - reverse_index
+                    chunk_offset = batch_begin + chunk * _BT
+
+                    gate_stage = K.local_scalar("int32", init=gate_store.stage)
+                    _wait_barrier(arena, _BAR_GATE_DONE, gate_stage, gate_store.phase)
+                    gate_store.advance()
+                    gradient = K.alloc_local((2,), "float32")
+                    for column in range(2):
+                        position = lane + column * 32
+                        K.ptx.ld.shared.f32(
+                            gradient[column],
+                            arena.ptr_to([_CUMSUMLOG_BASE + gate_stage * 256 + position * 4]),
+                        )
+                    for distance in (1, 2, 4, 8, 16):
+                        for column in range(2):
+                            later = _shfl_down_f32(gradient[column], distance)
+                            K.assign(
+                                gradient[column],
+                                K.if_then_else(
+                                    lane < 32 - distance, gradient[column] + later, gradient[column]
+                                ),
+                            )
+                    K.assign(gradient[0], gradient[0] + _shfl_idx_f32(gradient[1], 0, 0))
+                    for column in range(2):
+                        position = lane + column * 32
+                        token = chunk_offset + position
+                        with K.If(token < write_end), K.Then():
+                            K.ptx.st.global_.f32(
+                                dgate.ptr_to([K.cast(token, "int64") * n_heads_out + head]),
+                                gradient[column],
+                            )
+
+                    beta_stage = K.local_scalar("int32", init=beta_store.stage)
+                    _wait_barrier(arena, _BAR_BETA_DONE, beta_stage, beta_store.phase)
+                    beta_store.advance()
+                    for column in range(2):
+                        position = lane + column * 32
+                        token = chunk_offset + position
+                        with K.If(token < write_end), K.Then():
+                            value = K.local_scalar("float32")
+                            K.ptx.ld.shared.f32(
+                                value, arena.ptr_to([_BETA_BASE + beta_stage * 256 + position * 4])
+                            )
+                            if beta_sigmoid:
+                                K.ptx.st.global_.b16(
+                                    dbeta.ptr_to([K.cast(token, "int64") * n_heads_out + head]),
+                                    K.reinterpret("uint16", K.cast(value, io_dtype)),
+                                )
+                            else:
+                                K.ptx.st.global_.f32(
+                                    dbeta.ptr_to([K.cast(token, "int64") * n_heads_out + head]),
+                                    value,
+                                )
+                sched_consume(sched_state, tile)
+
+        # Warp 11: direct current dV -> dQ -> dK TMA store ladder.
+        with epilogue:
+            dq_state = K.PipelineState(1, phase=0)
+            dk_state = K.PipelineState(1, phase=0)
+            dv_state = K.PipelineState(1, phase=0)
+            sched_state = K.PipelineState(2, phase=0)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cend = item[5]
+                desc_dq = _descriptor_slot(descriptor_workspace, n_desc, 5, batch)
+                desc_dk = _descriptor_slot(descriptor_workspace, n_desc, 6, batch)
+                desc_dv = _descriptor_slot(descriptor_workspace, n_desc, 7, batch)
+                with K.If(_elected()), K.Then():
+                    for descriptor in (desc_dv, desc_dq, desc_dk):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(descriptor)
+                with K.serial(cend - wstart, unroll=False) as reverse_index:
+                    chunk = cend - 1 - reverse_index
+                    token = chunk * _BT
+                    writes = chunk < wend
+
+                    dv_stage = K.local_scalar("int32", init=dv_state.stage)
+                    _wait_barrier(arena, _BAR_DV_STG_READY, dv_stage, dv_state.phase)
+                    dv_state.advance()
+                    with K.If(writes), K.Then():
+                        for channel, byte_offset in ((0, 0), (64, 8192)):
+                            K.ptx[_TMA_S2G_3D](
+                                desc_dv,
+                                K.int32(channel),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                arena.ptr_to([_DV_DY_BASE + byte_offset]),
+                            )
+                        K.ptx.cp.async_.bulk.commit_group()
+
+                    dq_stage = K.local_scalar("int32", init=dq_state.stage)
+                    _wait_barrier(arena, _BAR_DQ_STG_READY, dq_stage, dq_state.phase)
+                    dq_state.advance()
+                    with K.If(writes), K.Then():
+                        for channel, byte_offset in ((0, 0), (64, 8192)):
+                            K.ptx[_TMA_S2G_3D](
+                                desc_dq,
+                                K.int32(channel),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                arena.ptr_to([_DQ_BASE + byte_offset]),
+                            )
+                        K.ptx.cp.async_.bulk.commit_group()
+
+                    dk_stage = K.local_scalar("int32", init=dk_state.stage)
+                    _wait_barrier(arena, _BAR_DK_STG_READY, dk_stage, dk_state.phase)
+                    dk_state.advance()
+                    with K.If(writes), K.Then():
+                        for channel, byte_offset in ((0, 0), (64, 8192)):
+                            K.ptx[_TMA_S2G_3D](
+                                desc_dk,
+                                K.int32(channel),
+                                K.cast(head, "int32"),
+                                K.cast(token, "int32"),
+                                arena.ptr_to([_DK_BASE + byte_offset]),
+                            )
+                        K.ptx.cp.async_.bulk.commit_group()
+
+                    K.ptx.cp.async_.bulk.wait_group.read(2)
+                    _arrive_barrier(arena, _BAR_DV_STG_DONE, dv_stage)
+                    K.ptx.cp.async_.bulk.wait_group.read(1)
+                    _arrive_barrier(arena, _BAR_DQ_STG_DONE, dq_stage)
+                    K.ptx.cp.async_.bulk.wait_group.read(0)
+                    _arrive_barrier(arena, _BAR_DK_STG_DONE, dk_stage)
+                sched_consume(sched_state, tile)
+
+    return main
+
+
+def _normalized_config(config):
+    import math
+
+    config = {key: value for key, value in config.items() if key != "label"}
+    if "dtype" in config:
+        dtype = config.pop("dtype")
+        if "io_dtype" in config and config["io_dtype"] != dtype:
+            raise ValueError("dtype and io_dtype disagree")
+        config["io_dtype"] = dtype
+    config.setdefault("seq_lens", (64,))
+    config["seq_lens"] = tuple(int(value) for value in config["seq_lens"])
+    config.setdefault("heads", 1)
+    config.setdefault("q_heads", config["heads"])
+    config.setdefault("k_heads", config["heads"])
+    config.setdefault("v_heads", config["heads"])
+    config.setdefault("io_dtype", "bfloat16")
+    config.setdefault("cu_dtype", "int32")
+    config.setdefault("num_sms", 152)
+    config.setdefault("scale", 1.0 / (_DK**0.5))
+    config.setdefault("use_initial_state", False)
+    config.setdefault("use_dstate_in", False)
+    config.setdefault("use_dstate0", False)
+    config.setdefault("log_gate", True)
+    config.setdefault("safe_gate", False)
+    config.setdefault("beta_sigmoid", False)
+    config.setdefault("dynamic_scheduler", False)
+    config.setdefault("split", False)
+    config.setdefault("run_order", False)
+    config.setdefault("order_generate", False)
+    config.setdefault("strong_decay", False)
+
+    if config["io_dtype"] not in ("bfloat16", "float16"):
+        raise ValueError("io_dtype must be 'bfloat16' or 'float16'")
+    if config["cu_dtype"] not in ("int32", "int64"):
+        raise ValueError("cu_dtype must be 'int32' or 'int64'")
+    if any(length < 0 for length in config["seq_lens"]):
+        raise ValueError("sequence lengths must be nonnegative")
+    if sum(config["seq_lens"]) == 0:
+        raise ValueError("at least one sequence must be nonempty")
+    heads = int(config["heads"])
+    if heads <= 0:
+        raise ValueError("heads must be positive")
+    for name in ("q_heads", "k_heads", "v_heads"):
+        value = int(config[name])
+        if value <= 0 or heads % value:
+            raise ValueError(f"{name}={value} must be a positive divisor of heads={heads}")
+    if heads != max(int(config["q_heads"]), int(config["v_heads"])):
+        raise ValueError("heads must equal max(q_heads, v_heads)")
+    if int(config["k_heads"]) not in (int(config["q_heads"]), int(config["v_heads"])):
+        raise ValueError("k_heads must equal q_heads or v_heads")
+    if config["safe_gate"] and not config["log_gate"]:
+        # safe_gate directly constructs ln(alpha); the source specializes its
+        # log_gate flag independently, but this pairing is the public mode.
+        config["log_gate"] = True
+    if config["use_dstate0"] and not config["use_initial_state"]:
+        raise ValueError("use_dstate0 requires use_initial_state")
+    if config["order_generate"] and not config["run_order"]:
+        raise ValueError("order_generate requires run_order")
+    if config["split"] and (not config["run_order"] or config["order_generate"]):
+        raise ValueError("split work rows require caller-scratch ordering")
+    if config["dynamic_scheduler"] and not config["run_order"]:
+        # The order prologue owns reset of the dynamic ticket counter.  Keep
+        # replay correct even when the shorthand config names only the
+        # scheduler specialization.
+        config["run_order"] = True
+        config["order_generate"] = True
+    scale = float(config["scale"])
+    if not math.isfinite(scale) or scale == 0.0:
+        raise ValueError("scale must be finite and nonzero")
+    if int(config["num_sms"]) <= 0:
+        raise ValueError("num_sms must be positive")
+    return config
+
+
+def _work_rows(seq_lens, heads, *, split):
+    rows = []
+    token_begin = 0
+    for batch, sequence_length in enumerate(seq_lens):
+        chunks = (sequence_length + _BT - 1) // _BT
+        token_end = token_begin + sequence_length
+        for head in range(heads):
+            if split and chunks >= 4:
+                midpoint = chunks // 2
+                rows.append((batch, head, 0, midpoint, 0, midpoint, token_begin, token_end))
+                rows.append((batch, head, midpoint, chunks, 0, chunks, token_begin, token_end))
+            else:
+                rows.append((batch, head, 0, chunks, 0, chunks, token_begin, token_end))
+        token_begin = token_end
+    return rows
+
+
+def get_kernel(**config):
+    """Return the source-ordered TensorMap prologue and persistent main."""
+    config = _normalized_config(config)
+    prologue = _make_prologue(
+        run_order=bool(config["run_order"]),
+        order_generate=bool(config["order_generate"]),
+        dynamic_scheduler=bool(config["dynamic_scheduler"]),
+        n_heads_out=int(config["heads"]),
+        cu_dtype=config["cu_dtype"],
+    )
+    main = _make_main(
+        num_sms=int(config["num_sms"]),
+        io_dtype=config["io_dtype"],
+        cu_dtype=config["cu_dtype"],
+        use_initial_state=bool(config["use_initial_state"]),
+        use_dstate_in=bool(config["use_dstate_in"]),
+        use_dstate0=bool(config["use_dstate0"]),
+        log_gate=bool(config["log_gate"]),
+        safe_gate=bool(config["safe_gate"]),
+        beta_sigmoid=bool(config["beta_sigmoid"]),
+        dynamic_scheduler=bool(config["dynamic_scheduler"]),
+        q_ratio=int(config["heads"]) // int(config["q_heads"]),
+        k_ratio=int(config["heads"]) // int(config["k_heads"]),
+        v_ratio=int(config["heads"]) // int(config["v_heads"]),
+        n_heads_out=int(config["heads"]),
+    )
+    return [prologue.func, main.func]
+
+
+def _aligned_i64(torch, size, alignment=128):
+    if size % 8:
+        raise ValueError(f"workspace size must be divisible by 8, got {size}")
+    owner = torch.empty(size + alignment - 1, dtype=torch.uint8, device="cuda")
+    offset = (-owner.data_ptr()) % alignment
+    view = owner[offset : offset + size].view(torch.int64)
+    if view.data_ptr() % alignment:
+        raise AssertionError("failed to construct an aligned TensorMap workspace")
+    return owner, view
+
+
+def _checkpoint_count(seq_lens):
+    return sum(0 if length == 0 else (length - 1) // _BT + 1 for length in seq_lens)
+
+
+def _prepare_work_tables(torch, config):
+    base = torch.tensor(
+        _work_rows(config["seq_lens"], config["heads"], split=config["split"]),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    def one_side():
+        work_items = torch.empty_like(base) if config["run_order"] else base.clone()
+        staging = None
+        if config["run_order"] and not config["order_generate"]:
+            staging = base.clone()
+        sched_all = torch.zeros(4, dtype=torch.int32, device="cuda")
+        return {
+            "work_items": work_items,
+            "work_count": torch.tensor([base.shape[0]], dtype=torch.int32, device="cuda"),
+            "staging": staging,
+            "sched_all": sched_all,
+            "scheduler": sched_all[:2] if config["dynamic_scheduler"] else None,
+        }
+
+    return {"tirx": one_side(), "source": one_side()}
+
+
+def _guarded_full(torch, shape, value, *, dtype):
+    elements = 1
+    for extent in shape:
+        elements *= int(extent)
+    guard_elements = 256 // torch.empty((), dtype=dtype).element_size()
+    sentinel = 37.0
+    owner = torch.full((elements + 2 * guard_elements,), sentinel, dtype=dtype, device="cuda")
+    tensor = owner[guard_elements : guard_elements + elements].view(shape)
+    tensor.fill_(value)
+    return tensor, (owner, guard_elements, elements, sentinel)
+
+
+def _new_outputs(torch, config, total_tokens):
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    beta_t = io_t if config["beta_sigmoid"] else torch.float32
+    specifications = {
+        "dq": ((total_tokens, config["heads"], _DK), io_t),
+        "dk": ((total_tokens, config["heads"], _DK), io_t),
+        "dv": ((total_tokens, config["heads"], _DV), io_t),
+        "dgate": ((total_tokens, config["heads"]), torch.float32),
+        "dbeta": ((total_tokens, config["heads"]), beta_t),
+    }
+    if config["use_dstate0"]:
+        specifications["d_initial_state"] = (
+            (len(config["seq_lens"]), config["heads"], _DV, _DK),
+            torch.float32,
+        )
+    outputs = {}
+    guards = {}
+    for name, (shape, dtype) in specifications.items():
+        outputs[name], guards[name] = _guarded_full(torch, shape, float("nan"), dtype=dtype)
+    return outputs, guards
+
+
+def _load_recompute_source():
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module("cudnn.linear_attention.frost.kernel.gdn_recompute_f16")
+
+
+def _prepare_state_checkpoints(data):
+    """Run the pinned state-only forward before either timed backward path."""
+    import torch
+
+    config = data["config"]
+    source = _load_recompute_source()
+    rows = torch.empty(
+        (len(config["seq_lens"]) * config["heads"], 8), dtype=torch.int32, device="cuda"
+    )
+    count = torch.tensor([rows.shape[0]], dtype=torch.int32, device="cuda")
+    sched_all = torch.zeros(4, dtype=torch.int32, device="cuda")
+    stream = int(torch.cuda.current_stream().cuda_stream)
+    source.chunk_gdn_recompute_sm100(
+        data["k"],
+        data["v"],
+        data["gate"],
+        data["beta"],
+        data["cu_seqlens"],
+        data["initial_state"],
+        None,
+        checkpoint_every_n_tokens=_BT,
+        output_state_checkpoints=data["checkpoints"],
+        work_items=rows,
+        work_count=count,
+        sched_ctr=None,
+        sched_all=sched_all,
+        work_item_scratch=None,
+        order_in_prologue=True,
+        log_gate=bool(config["log_gate"]),
+        safe_gate=bool(config["safe_gate"]),
+        a_log=data["a_log"],
+        dt_bias=data["dt_bias"],
+        use_beta_sigmoid=bool(config["beta_sigmoid"]),
+        workspace=data["checkpoint_workspace"],
+        stream=stream,
+    )
+    data["_checkpoint_keep_alive"] = (rows, count, sched_all)
+
+
+def _prepare_data(config):
+    import torch
+
+    config = _normalized_config(config)
+    torch.manual_seed(20260831)
+    total_tokens = sum(config["seq_lens"])
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    q = (0.2 * torch.randn(total_tokens, config["q_heads"], _DK, device="cuda")).to(io_t)
+    k = (0.2 * torch.randn(total_tokens, config["k_heads"], _DK, device="cuda")).to(io_t)
+    v = (0.2 * torch.randn(total_tokens, config["v_heads"], _DV, device="cuda")).to(io_t)
+    gate = torch.empty(total_tokens, config["heads"], dtype=torch.float32, device="cuda")
+    if config["safe_gate"]:
+        gate.normal_(std=0.2)
+    elif config["log_gate"]:
+        if config["strong_decay"]:
+            gate.uniform_(-5.0, -1.5)
+        else:
+            gate.uniform_(-0.9, -0.01)
+    elif config["strong_decay"]:
+        gate.uniform_(0.01, 0.25)
+    else:
+        gate.uniform_(0.4, 0.99)
+    if config["beta_sigmoid"]:
+        beta = (0.3 * torch.randn(total_tokens, config["heads"], device="cuda")).to(io_t)
+    else:
+        beta = torch.sigmoid(0.3 * torch.randn(total_tokens, config["heads"], device="cuda"))
+    do = (0.2 * torch.randn(total_tokens, config["heads"], _DV, device="cuda")).to(io_t)
+    cu_t = torch.int64 if config["cu_dtype"] == "int64" else torch.int32
+    endpoints = [0]
+    for length in config["seq_lens"]:
+        endpoints.append(endpoints[-1] + length)
+    cu_seqlens = torch.tensor(endpoints, dtype=cu_t, device="cuda")
+    a_log = (
+        0.1 * torch.randn(config["heads"], dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    dt_bias = (
+        -4.0 + 0.1 * torch.randn(config["heads"], dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    initial_state = (
+        0.01
+        * torch.randn(
+            len(config["seq_lens"]), config["heads"], _DV, _DK, dtype=torch.float32, device="cuda"
+        )
+        if config["use_initial_state"]
+        else None
+    )
+    d_final_state = (
+        0.02
+        * torch.randn(
+            len(config["seq_lens"]), config["heads"], _DV, _DK, dtype=torch.float32, device="cuda"
+        )
+        if config["use_dstate_in"]
+        else None
+    )
+    checkpoint_rows = max(_checkpoint_count(config["seq_lens"]), 1)
+    checkpoints = torch.full(
+        (checkpoint_rows, config["heads"], _DV, _DK), float("nan"), dtype=io_t, device="cuda"
+    )
+    tirx_outputs, tirx_guards = _new_outputs(torch, config, total_tokens)
+    source_outputs, source_guards = _new_outputs(torch, config, total_tokens)
+    workspace_bytes = _TENSOR_MAP_BYTES * (_TENSOR_MAP_ARRAYS * len(config["seq_lens"]) + 1)
+    tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
+    source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
+    checkpoint_owner, checkpoint_workspace = _aligned_i64(torch, workspace_bytes)
+    data = {
+        "config": config,
+        "q": q,
+        "k": k,
+        "v": v,
+        "gate": gate,
+        "beta": beta,
+        "do": do,
+        "cu_seqlens": cu_seqlens,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "initial_state": initial_state,
+        "d_final_state": d_final_state,
+        "checkpoints": checkpoints,
+        "tirx": tirx_outputs,
+        "source": source_outputs,
+        "guards": {"tirx": tirx_guards, "source": source_guards},
+        "work": _prepare_work_tables(torch, config),
+        "tirx_workspace": tirx_workspace,
+        "source_workspace": source_workspace,
+        "checkpoint_workspace": checkpoint_workspace,
+        "_workspace_owners": (tirx_owner, source_owner, checkpoint_owner),
+    }
+    _prepare_state_checkpoints(data)
+    return data
+
+
+def prepare_data(**config):
+    """Allocate inputs/outputs and construct per-chunk entering states."""
+    return _prepare_data(config)
+
+
+def _encode_tiled_map(tensor, dimensions, strides, box):
+    import torch
+    from cuda.bindings import driver as cuda
+
+    if tensor.dtype == torch.float16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT16
+    elif tensor.dtype == torch.bfloat16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    else:
+        raise TypeError(f"unsupported TensorMap dtype {tensor.dtype}")
+    u64 = cuda.cuuint64_t
+    u32 = cuda.cuuint32_t
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        data_type,
+        len(dimensions),
+        tensor.data_ptr(),
+        [u64(int(value)) for value in dimensions],
+        [u64(int(value)) for value in strides],
+        [u32(int(value)) for value in box],
+        [u32(1) for _ in dimensions],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with {result}")
+    return (
+        torch.tensor([int(word) for word in tensor_map.opaque], dtype=torch.uint64)
+        .view(torch.int64)
+        .to(device=tensor.device)
+    )
+
+
+def _base_tensor_maps(data, side):
+    config = data["config"]
+    total_tokens = data["q"].shape[0]
+
+    def headed(tensor, channels, heads):
+        return _encode_tiled_map(
+            tensor,
+            (channels, heads, total_tokens),
+            (tensor.stride(1) * tensor.element_size(), tensor.stride(0) * tensor.element_size()),
+            (64, 1, _BT),
+        )
+
+    output = data[side]
+    checkpoint = data["checkpoints"]
+    return [
+        headed(data["q"], _DK, config["q_heads"]),
+        headed(data["k"], _DK, config["k_heads"]),
+        headed(data["v"], _DV, config["v_heads"]),
+        headed(data["do"], _DV, config["heads"]),
+        _encode_tiled_map(
+            checkpoint,
+            (_DV, _DK, checkpoint.shape[0], config["heads"]),
+            (
+                checkpoint.stride(2) * checkpoint.element_size(),
+                checkpoint.stride(0) * checkpoint.element_size(),
+                checkpoint.stride(1) * checkpoint.element_size(),
+            ),
+            (64, _DK, 1, 1),
+        ),
+        headed(output["dq"], _DK, config["heads"]),
+        headed(output["dk"], _DK, config["heads"]),
+        headed(output["dv"], _DV, config["heads"]),
+    ]
+
+
+def _tirx_launch(executables, data):
+    import torch
+
+    config = data["config"]
+    prologue, main = executables
+    maps = _base_tensor_maps(data, "tirx")
+    work = data["work"]["tirx"]
+    output = data["tirx"]
+    dummy_i32 = torch.zeros(8, dtype=torch.int32, device="cuda")
+    dummy_f32 = torch.zeros(max(config["heads"], 1), dtype=torch.float32, device="cuda")
+
+    def launch(*, prologue_only=False):
+        prologue(
+            *maps,
+            data["tirx_workspace"],
+            data["cu_seqlens"],
+            data["q"].view(torch.uint8).reshape(-1),
+            data["k"].view(torch.uint8).reshape(-1),
+            data["v"].view(torch.uint8).reshape(-1),
+            data["do"].view(torch.uint8).reshape(-1),
+            data["checkpoints"].view(torch.uint8).reshape(-1),
+            output["dq"].view(torch.uint8).reshape(-1),
+            output["dk"].view(torch.uint8).reshape(-1),
+            output["dv"].view(torch.uint8).reshape(-1),
+            work["staging"].reshape(-1) if work["staging"] is not None else dummy_i32,
+            work["work_count"],
+            work["work_items"].reshape(-1),
+            work["sched_all"],
+            len(config["seq_lens"]),
+            data["q"].stride(0) * data["q"].element_size(),
+            data["k"].stride(0) * data["k"].element_size(),
+            data["v"].stride(0) * data["v"].element_size(),
+            data["do"].stride(0) * data["do"].element_size(),
+            data["checkpoints"].stride(0) * data["checkpoints"].element_size(),
+            output["dq"].stride(0) * output["dq"].element_size(),
+            output["dk"].stride(0) * output["dk"].element_size(),
+            output["dv"].stride(0) * output["dv"].element_size(),
+            _BT,
+        )
+        if prologue_only:
+            return
+        main(
+            data["tirx_workspace"],
+            len(config["seq_lens"]),
+            data["gate"].reshape(-1),
+            data["a_log"] if data["a_log"] is not None else dummy_f32,
+            data["dt_bias"] if data["dt_bias"] is not None else dummy_f32,
+            data["beta"].reshape(-1),
+            output["dgate"].reshape(-1),
+            output["dbeta"].reshape(-1),
+            data["cu_seqlens"],
+            output.get("d_initial_state", dummy_f32).reshape(-1),
+            (data["d_final_state"].reshape(-1) if data["d_final_state"] is not None else dummy_f32),
+            work["work_items"].reshape(-1),
+            work["work_count"],
+            work["scheduler"] if work["scheduler"] is not None else dummy_i32,
+            float(config["scale"]),
+        )
+
+    launch._keep_alive = (maps, dummy_i32, dummy_f32)
+    return launch
+
+
+def _load_reference_source():
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module("cudnn.linear_attention.frost.kernel.gdn_bprop_f16")
+
+
+def _source_launch(data):
+    import torch
+
+    source = _load_reference_source()
+    config = data["config"]
+    output = data["source"]
+    work = data["work"]["source"]
+    stream = int(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        source.chunk_gdn_bwd_sm100(
+            data["q"],
+            data["k"],
+            data["v"],
+            data["gate"],
+            data["beta"],
+            data["do"],
+            data["checkpoints"],
+            output["dq"],
+            output["dk"],
+            output["dv"],
+            output["dgate"],
+            output["dbeta"],
+            data["cu_seqlens"],
+            float(config["scale"]),
+            use_initial_state=bool(config["use_initial_state"]),
+            d_initial_state=output.get("d_initial_state"),
+            d_final_state=data["d_final_state"],
+            work_items=work["work_items"],
+            work_count=work["work_count"],
+            sched_ctr=work["scheduler"],
+            sched_all=work["sched_all"],
+            work_item_scratch=work["staging"],
+            order_in_prologue=bool(config["run_order"]),
+            log_gate=bool(config["log_gate"]),
+            safe_gate=bool(config["safe_gate"]),
+            a_log=data["a_log"],
+            dt_bias=data["dt_bias"],
+            use_beta_sigmoid=bool(config["beta_sigmoid"]),
+            workspace=data["source_workspace"],
+            stream=stream,
+        )
+
+    return launch
+
+
+def _check_redzones(data, side):
+    import torch
+
+    for name, (owner, guard, elements, sentinel) in data["guards"][side].items():
+        prefix = owner[:guard]
+        suffix = owner[guard + elements :]
+        if not bool(torch.all(prefix == sentinel)) or not bool(torch.all(suffix == sentinel)):
+            raise AssertionError(f"{side}.{name} wrote outside its output allocation")
+
+
+def _assert_storage_equal(actual, expected, *, name):
+    import torch
+
+    if (
+        actual.shape != expected.shape
+        or actual.dtype != expected.dtype
+        or actual.device != expected.device
+        or actual.layout != expected.layout
+        or actual.stride() != expected.stride()
+    ):
+        raise AssertionError(f"{name} storage contract changed")
+    if not torch.equal(actual.view(torch.uint8), expected.view(torch.uint8)):
+        raise AssertionError(f"{name} is not bitwise identical")
+
+
+def _assert_logical_inputs_unchanged(actual, pristine):
+    names = (
+        "q",
+        "k",
+        "v",
+        "gate",
+        "beta",
+        "do",
+        "cu_seqlens",
+        "a_log",
+        "dt_bias",
+        "initial_state",
+        "d_final_state",
+        "checkpoints",
+    )
+    for name in names:
+        actual_tensor = actual[name]
+        pristine_tensor = pristine[name]
+        if actual_tensor is None or pristine_tensor is None:
+            if actual_tensor is not pristine_tensor:
+                raise AssertionError(f"logical input {name} optionality changed")
+            continue
+        _assert_storage_equal(actual_tensor, pristine_tensor, name=f"input.{name}")
+
+
+def _validate_outputs(data, *, sources):
+    import torch
+
+    config = data["config"]
+    expected_dtypes = {
+        "dq": torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16,
+        "dk": torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16,
+        "dv": torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16,
+        "dgate": torch.float32,
+        "dbeta": (
+            torch.float16
+            if config["io_dtype"] == "float16" and config["beta_sigmoid"]
+            else torch.bfloat16
+            if config["io_dtype"] == "bfloat16" and config["beta_sigmoid"]
+            else torch.float32
+        ),
+    }
+    if config["use_dstate0"]:
+        expected_dtypes["d_initial_state"] = torch.float32
+    for side in sources:
+        _check_redzones(data, side)
+        if set(data[side]) != set(expected_dtypes):
+            raise AssertionError(f"{side} output names do not match the backward ABI")
+        for name, tensor in data[side].items():
+            if tensor.dtype != expected_dtypes[name]:
+                raise AssertionError(
+                    f"{side}.{name} dtype {tensor.dtype} != {expected_dtypes[name]}"
+                )
+            if not bool(torch.isfinite(tensor).all()):
+                raise AssertionError(f"{side}.{name} contains NaN or Inf")
+    if "tirx" in sources and "source" in sources:
+        for name, actual in data["tirx"].items():
+            expected = data["source"][name]
+            if actual.shape != expected.shape or actual.dtype != expected.dtype:
+                raise AssertionError(f"tirx/source contract mismatch for {name}")
+            if not torch.equal(torch.isnan(actual), torch.isnan(expected)):
+                raise AssertionError(f"tirx/source NaN classification mismatch for {name}")
+            if not torch.equal(torch.isinf(actual), torch.isinf(expected)):
+                raise AssertionError(f"tirx/source Inf classification mismatch for {name}")
+            if actual.dtype == torch.bfloat16:
+                rtol, atol = 2.0**-7, 2.0**-10
+            elif actual.dtype == torch.float16:
+                rtol, atol = 2.0**-10, 2.0**-14
+            else:
+                rtol, atol = 2.0**-16, 2.0**-20
+            torch.testing.assert_close(
+                actual,
+                expected,
+                rtol=rtol,
+                atol=atol,
+                equal_nan=True,
+                check_device=True,
+                check_dtype=True,
+                check_layout=True,
+                check_stride=True,
+            )
+
+
+def run_test(**config):
+    """Compare TIRx with the pinned source and exact replay."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = _normalized_config(config)
+    data = _prepare_data(config)
+    executables = [compile_kernel(func) for func in get_kernel(**config)]
+    tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, sources=("tirx", "source"))
+
+    replay_data = _prepare_data(config)
+    _assert_logical_inputs_unchanged(data, replay_data)
+    replay_launch = _tirx_launch(executables, replay_data)
+    replay_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(replay_data, sources=("tirx",))
+    for name in data["tirx"]:
+        _assert_storage_equal(
+            data["tirx"][name], replay_data["tirx"][name], name=f"tirx replay.{name}"
+        )
+    return {"tokens": sum(config["seq_lens"]), "heads": config["heads"]}
+
+
+def prepare_bench(**config):
+    """Compile the two TIRx launches without importing torch or touching CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config = _normalized_config(config)
+    state = {
+        "config": config,
+        "executables": [compile_kernel(func) for func in get_kernel(**config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Prepare checkpoints, validate once, then time only prologue plus main."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = _normalized_config({**prepared["config"], **kwargs})
+    data = _prepare_data(config)
+    tirx_launch = _tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    if external_references_enabled():
+
+        def source_builder():
+            source_launch = _source_launch(data)
+            source_launch()
+            torch.cuda.synchronize()
+            _validate_outputs(data, sources=("tirx", "source"))
+            return source_launch
+
+        references = {"cudnn_frontend": source_builder}
+    else:
+        _validate_outputs(data, sources=("tirx",))
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
@@ -13,8 +13,22 @@ driven by the ``chunk_gdn_sm100`` THD/varlen host entry).
 
 import tirx_kernels.kern as K
 
-KERNEL_META = {"name": "cudnn_sm100_gdn_prefill_f16", "category": "cudnn", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "cudnn_sm100_gdn_prefill_f16",
+    "category": "cudnn",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 # Deterministic pairwise cover of the frozen legal capability set.  Ragged
 # cases include zero- and one-token sequences while retaining a nonzero
 # TensorMap outer dimension.  ``log_gate`` defaults to True (the engine's
@@ -824,10 +838,7 @@ def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype, store_resul
         )
         _stmatrix_x4(
             arena.ptr_to(
-                [
-                    tinv_byte_base
-                    + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2
-                ]
+                [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2]
             ),
             [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
         )
@@ -1451,9 +1462,7 @@ def _make_main(
                     with K.If(do_inv), K.Then():
                         _blockwise_16_to_32(arena, inv_byte_base, inv_warp * 32, lane, io_dtype)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
-                    _blockwise_32_to_64(
-                        arena, inv_byte_base, inv_warp, lane, io_dtype, do_inv
-                    )
+                    _blockwise_32_to_64(arena, inv_byte_base, inv_warp, lane, io_dtype, do_inv)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
 
                     # ---- post-inverse beta column scaling + publish --------

--- a/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
@@ -20,7 +20,18 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "cudnn_sm100_gdn_recompute_f16",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 # Deterministic pairwise cover of the frozen legal capability set.  Ragged
@@ -874,10 +885,7 @@ def _blockwise_32_to_64(arena, tinv_byte_base, band, lane, io_dtype, store_resul
         )
         _stmatrix_x4(
             arena.ptr_to(
-                [
-                    tinv_byte_base
-                    + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2
-                ]
+                [tinv_byte_base + _swizzle_lin_128b((32 + band * 16) * 64 + 16 + lane_off) * 2]
             ),
             [o_pack[4], o_pack[5], o_pack[6], o_pack[7]],
         )
@@ -1463,9 +1471,7 @@ def _make_main(
                     with K.If(do_inv), K.Then():
                         _blockwise_16_to_32(arena, inv_byte_base, inv_warp * 32, lane, io_dtype)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
-                    _blockwise_32_to_64(
-                        arena, inv_byte_base, inv_warp, lane, io_dtype, do_inv
-                    )
+                    _blockwise_32_to_64(arena, inv_byte_base, inv_warp, lane, io_dtype, do_inv)
                     K.ptx.bar.sync(K.uint32(2), K.uint32(128))
 
                     # ---- post-inverse beta column scaling + publish --------

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -12,8 +12,22 @@ Upstream source:
 
 import tirx_kernels.kern as K
 
-KERNEL_META = {"name": "cudnn_sm100_kda_bprop_f16", "category": "cudnn", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "cudnn_sm100_kda_bprop_f16",
+    "category": "cudnn",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 CONFIGS = [
     {"label": "basic", "seq_lens": (64,), "heads": 1},
     {"label": "tail", "seq_lens": (17, 33), "heads": 2},

--- a/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py
+++ b/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py
@@ -143,7 +143,18 @@ def _config(label, tokens, w_out_in):
 KERNEL_META = {
     "name": "cudnn_sm100_gemm_proj_rope_mxfp8_bf16in",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = [

--- a/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -141,7 +141,18 @@ def _config(label, tokens):
 KERNEL_META = {
     "name": "cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = [

--- a/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
+++ b/tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
@@ -1566,7 +1566,18 @@ def _benchmark_configs():
 KERNEL_META = {
     "name": "cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _correctness_configs()

--- a/tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
+++ b/tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py
@@ -468,7 +468,18 @@ def _benchmark_configs():
 KERNEL_META = {
     "name": "cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _correctness_configs()

--- a/tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py
+++ b/tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py
@@ -339,7 +339,18 @@ def _benchmark_configs():
 KERNEL_META = {
     "name": "cudnn_sm100_dense_gemm_persistent_swiglu",
     "category": "cudnn",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = _correctness_configs()

--- a/tirx_kernels/deepep/combine.py
+++ b/tirx_kernels/deepep/combine.py
@@ -25,8 +25,21 @@ import tirx_kernels.kern as K
 
 from .utils._buffer import get_theoretical_num_sms
 
-KERNEL_META = {"name": "deepep_combine", "category": "deepep", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "deepep_combine",
+    "category": "deepep",
+    "runtime_cuda_archs": ["sm_100a"],
+    "reference_requirements": (
+        {
+            "package": "deep-ep",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepEP.git",
+                "commit": "01dc3aaac82068020353dce2c302e38153c0bfaa",
+            },
+            "import": "deep_ep",
+        },
+    ),
+}
 # Correctness matrix. Every config runs the same source specialization
 # (bf16, non-expanded, allow_multiple_reduction, no bias) on `world_size` ranks.
 CONFIGS = [

--- a/tirx_kernels/deepep/dispatch.py
+++ b/tirx_kernels/deepep/dispatch.py
@@ -24,8 +24,21 @@ import tirx_kernels.kern as K
 
 from .utils._buffer import get_theoretical_num_sms
 
-KERNEL_META = {"name": "deepep_dispatch", "category": "deepep", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "deepep_dispatch",
+    "category": "deepep",
+    "runtime_cuda_archs": ["sm_100a"],
+    "reference_requirements": (
+        {
+            "package": "deep-ep",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepEP.git",
+                "commit": "01dc3aaac82068020353dce2c302e38153c0bfaa",
+            },
+            "import": "deep_ep",
+        },
+    ),
+}
 # Correctness matrix. Every config runs the same source specialization
 # (bf16, non-cached, non-expand, do_cpu_sync=False) on `world_size` ranks.
 CONFIGS = [

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/kernel.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/kernel.py
@@ -1191,10 +1191,7 @@ def build_kernel(spec: GemmSpec):
                                                         ),
                                                     )
                                                     K.ptx[utccp_chain](
-                                                        K.cast(
-                                                            sfa_tmem_col + c * 4,
-                                                            "uint32",
-                                                        ),
+                                                        K.cast(sfa_tmem_col + c * 4, "uint32"),
                                                         desc_sf,
                                                         pred=mma_elected,
                                                     )
@@ -1216,10 +1213,7 @@ def build_kernel(spec: GemmSpec):
                                                         ),
                                                     )
                                                     K.ptx[utccp_chain](
-                                                        K.cast(
-                                                            sfb_tmem_col + c * 4,
-                                                            "uint32",
-                                                        ),
+                                                        K.cast(sfb_tmem_col + c * 4, "uint32"),
                                                         desc_sf,
                                                         pred=mma_elected,
                                                     )

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/spec.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_gemm_1d1d/spec.py
@@ -1102,9 +1102,7 @@ def _compile_spec_cached(spec: GemmSpec):
         tags.append("clusterCtaIdx.x")
     tags += ["threadIdx.x", "tirx.use_dyn_shared_memory"]
     func = build_kernel(spec).with_attr("tirx.kernel_launch_params", tags)
-    return tvm.compile(
-        tvm.IRModule({"main": func}), target=cuda_target(arch="sm_100a"), tir_pipeline="tirx"
-    )
+    return tvm.compile(tvm.IRModule({"main": func}), target=cuda_target(), tir_pipeline="tirx")
 
 
 def compile_spec(spec: GemmSpec):

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_mega_moe/kernel.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_mega_moe/kernel.py
@@ -3366,9 +3366,7 @@ def get_kernel(
                                             ),
                                         ),
                                     )
-                                    utccp_copy(
-                                        sfa_tmem_col + sfa_chunk_idx * 4, desc_sf
-                                    )
+                                    utccp_copy(sfa_tmem_col + sfa_chunk_idx * 4, desc_sf)
                                 with K.unroll(0, num_sfb_utccp_chunks) as sfb_chunk_idx:
                                     K.assign(
                                         desc_sf,
@@ -3383,9 +3381,7 @@ def get_kernel(
                                             ),
                                         ),
                                     )
-                                    utccp_copy(
-                                        sfb_tmem_col + sfb_chunk_idx * 4, desc_sf
-                                    )
+                                    utccp_copy(sfb_tmem_col + sfb_chunk_idx * 4, desc_sf)
                                 with K.unroll(0, umma_block_k // umma_k) as k_idx:
                                     K.assign(
                                         runtime_desc_i,

--- a/tirx_kernels/deepgemm/_sm100_fp8_fp4_mega_moe/spec.py
+++ b/tirx_kernels/deepgemm/_sm100_fp8_fp4_mega_moe/spec.py
@@ -1343,9 +1343,10 @@ def _compile_tirx_mega_moe_for_config(
         emit_nvl_barrier_timeout_printf=emit_nvl_barrier_timeout_printf,
     )
     # The block-scale tcgen05 MMA below uses ``scale_vec::1X``, which ptxas
-    # rejects for the family-only sm_100f target. It requires the
-    # architecture-specific Blackwell target used by the B200 compile profile.
-    target = cuda_target(arch="sm_100a")
+    # rejects for a family-only target. The prepared compile profile therefore
+    # supplies the exact architecture-specific target validated for the runtime
+    # GPU (currently sm_100a, sm_103a, or sm_107a).
+    target = cuda_target()
     mod = tvm.IRModule({"main": kernel})
     with _cuda_compile_mode(cuda_compile_mode):
         return tvm.compile(mod, target=target, tir_pipeline="tirx")

--- a/tirx_kernels/deepgemm/fp8_bmm.py
+++ b/tirx_kernels/deepgemm/fp8_bmm.py
@@ -26,8 +26,21 @@ from __future__ import annotations
 
 from ._sm100_fp8_fp4_gemm_1d1d import GemmDesc, GemmType, Major, get_best_config
 
-KERNEL_META = {"name": "deepgemm_sm100_fp8_bmm", "category": "deepgemm", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "deepgemm_sm100_fp8_bmm",
+    "category": "deepgemm",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
+}
 #: expression -> (major_a, major_b, cd_dtype, with_accumulation)
 _EXPRESSIONS = {
     "bhr,hdr->bhd": ("k", "k", "bf16", False),

--- a/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
+++ b/tirx_kernels/deepgemm/fp8_gemm_1d1d.py
@@ -19,7 +19,17 @@ from ._sm100_fp8_fp4_gemm_1d1d import GemmDesc, GemmType, Major, get_best_config
 KERNEL_META = {
     "name": "deepgemm_sm100_fp8_gemm_1d1d",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 #: `tests/generators.py::enumerate_normal` uses these seven (n, k) pairs for

--- a/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py
@@ -29,7 +29,17 @@ from ._sm100_fp8_fp4_gemm_1d1d import (
 KERNEL_META = {
     "name": "deepgemm_sm100_k_grouped_fp8_gemm_contiguous",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 #: `tests/generators.py::enumerate_k_grouped_contiguous`; the first entry has

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py
@@ -28,7 +28,17 @@ from ._sm100_fp8_fp4_gemm_1d1d import (
 KERNEL_META = {
     "name": "deepgemm_sm100_m_grouped_fp8_gemm_contiguous",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 #: `tests/generators.py::enumerate_m_grouped_contiguous`.  These are also the

--- a/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
+++ b/tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py
@@ -25,7 +25,17 @@ from ._sm100_fp8_fp4_gemm_1d1d import (
 KERNEL_META = {
     "name": "deepgemm_sm100_m_grouped_fp8_gemm_masked",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 MAX_M = 4096

--- a/tirx_kernels/deepgemm/mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp4.py
@@ -215,7 +215,17 @@ def _make_case(
 KERNEL_META = {
     "name": "deepgemm_sm100_fp4_mqa_logits",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 DEEPGEMM_TEST_COVERAGE = [
@@ -1038,8 +1048,9 @@ def _compile_tirx_mqa_for_config(
     logits_stride_override: int | None,
 ) -> Any:
     import tvm
+    from tirx_kernels.runner import cuda_target
 
-    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+    target = cuda_target()
     mod = get_kernel(
         seq_len=seq_len,
         seq_len_kv=seq_len_kv,

--- a/tirx_kernels/deepgemm/mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/mqa_logits_fp8.py
@@ -209,7 +209,17 @@ def _make_case(
 KERNEL_META = {
     "name": "deepgemm_sm100_fp8_mqa_logits",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 DEEPGEMM_TEST_COVERAGE = [

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp4.py
@@ -171,7 +171,17 @@ def _make_case(
 KERNEL_META = {
     "name": "deepgemm_sm100_fp4_paged_mqa_logits",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 DSA_INDEXER_LIKE_COVERAGE = [
@@ -1461,8 +1471,9 @@ def _compile_tirx_paged_mqa_for_config(
     indices_pair_stride: int,
 ) -> Any:
     import tvm
+    from tirx_kernels.runner import cuda_target
 
-    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+    target = cuda_target()
     kernel = get_kernel(
         batch_size=batch_size,
         next_n=next_n,

--- a/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
+++ b/tirx_kernels/deepgemm/paged_mqa_logits_fp8.py
@@ -151,7 +151,17 @@ def _make_case(
 KERNEL_META = {
     "name": "deepgemm_sm100_fp8_paged_mqa_logits",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 DSA_INDEXER_LIKE_COVERAGE = [

--- a/tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py
+++ b/tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py
@@ -38,7 +38,21 @@ from ._sm100_fp8_fp4_mega_moe.spec import (
     prepare_tirx_fp8_fp4_mega_moe as prepare_tirx_fp8_fp4_mega_moe,
 )
 
-KERNEL_META = {"name": "sm100_fp8_fp4_mega_moe", "category": "deepgemm", "compute_capability": 10}
+KERNEL_META = {
+    "name": "sm100_fp8_fp4_mega_moe",
+    "category": "deepgemm",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
+}
 
 
 @dataclass

--- a/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
+++ b/tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py
@@ -170,7 +170,17 @@ def _make_case(*, m: int, n: int, k: int, num_splits: int, seed: int) -> dict[st
 KERNEL_META = {
     "name": "deepgemm_sm100_tf32_hc_prenorm_gemm",
     "category": "deepgemm",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "deep-gemm",
+            "git": {
+                "url": "https://github.com/deepseek-ai/DeepGEMM.git",
+                "commit": "559d79fb6994a58b8a15b4b93bf13ccc16edf247",
+            },
+            "import": "deep_gemm",
+        },
+    ),
 }
 
 DEEPGEMM_TEST_COVERAGE = [
@@ -953,7 +963,9 @@ def get_kernel(**kwargs: Any):
 def _compile_tirx_tf32_hc_for_config(
     *, m: int, n: int, k: int, num_splits: int, seed: int, num_sms: int
 ) -> Any:
-    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+    from tirx_kernels.runner import cuda_target
+
+    target = cuda_target()
     kernel = get_kernel(m=m, n=n, k=k, num_splits=num_splits, seed=seed, num_sms=num_sms)
     with target:
         return tvm.compile(tvm.IRModule({"main": kernel}), target=target, tir_pipeline="tirx")

--- a/tirx_kernels/flashattention/flash_attention4.py
+++ b/tirx_kernels/flashattention/flash_attention4.py
@@ -26,7 +26,7 @@ import torch
 import tirx_kernels.kern as K
 import tvm
 import tvm.testing
-from tirx_kernels.runner import bench
+from tirx_kernels.runner import bench, cuda_target
 from tvm.tirx.cuda import iket
 from tvm.tirx.cuda.iket import IketProfiler
 
@@ -1314,7 +1314,22 @@ def prepare_data(batch_size, seq_len_q, seq_len_kv, num_qo_heads, num_kv_heads, 
     return q, k, v, out
 
 
-KERNEL_META = {"name": "flash_attention4", "category": "flashattention", "compute_capability": 10}
+KERNEL_META = {
+    "name": "flash_attention4",
+    "category": "flashattention",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flash-attn-4",
+            "git": {
+                "url": "https://github.com/Dao-AILab/flash-attention.git",
+                "commit": "0251105a2fb19d2957484b7f023cd8c115286ced",
+            },
+            "import": "flash_attn.cute",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 CONFIGS = [
     {
         "batch_size": 1,
@@ -1648,9 +1663,7 @@ def _profile_iket_workload(args: argparse.Namespace) -> None:
         is_causal=args.causal,
     )
     executable = IketProfiler().compile(
-        tvm.IRModule({"main": func}),
-        target=tvm.target.Target({"kind": "cuda", "arch": "sm_100a"}),
-        tir_pipeline="tirx",
+        tvm.IRModule({"main": func}), target=cuda_target(), tir_pipeline="tirx"
     )
 
     q, k, v, _ = prepare_data(

--- a/tirx_kernels/flashattention/flash_attention_backward.py
+++ b/tirx_kernels/flashattention/flash_attention_backward.py
@@ -1393,7 +1393,18 @@ def setup(data, B, H, S, D, *, executables=None):
 KERNEL_META = {
     "name": "flash_attention_backward_sm100",
     "category": "flashattention",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flash-attn-4",
+            "git": {
+                "url": "https://github.com/Dao-AILab/flash-attention.git",
+                "commit": "0251105a2fb19d2957484b7f023cd8c115286ced",
+            },
+            "import": "flash_attn.cute",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 CONFIGS = [

--- a/tirx_kernels/flashinfer/activation/act_and_mul.py
+++ b/tirx_kernels/flashinfer/activation/act_and_mul.py
@@ -20,8 +20,22 @@ from typing import Any
 import tirx_kernels.kern as K
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "act_and_mul", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "act_and_mul",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 # Source dispatch domain (DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16 + vec_t alignment):
 #   dtype in {float16, bfloat16}; d % 8 == 0 (both row halves 16B-aligned); d >= 8.
 _ACTS = ("silu", "gelu", "gelu_tanh")

--- a/tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py
+++ b/tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py
@@ -24,7 +24,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "silu_and_mul_nvfp4_experts_quantize",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _DTYPES = ("float16", "bfloat16")

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py
@@ -18,8 +18,22 @@ import torch
 import tirx_kernels.kern as TK
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "gdn_decode_bf16_ilp4", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "gdn_decode_bf16_ilp4",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 
 K = 128
 V = 128
@@ -329,9 +343,7 @@ def _make_gdn_decode_bf16_ilp4(
     PER_TOKEN_POOL_SCATTER,
     PER_TOKEN_POOL_SCATTER_FLAT,
 ):
-    @TK.kernel(
-        warps=NUM_WARPS, arch="sm_100a", min_blocks_per_sm=8, grid=False
-    )
+    @TK.kernel(warps=NUM_WARPS, arch="sm_100a", min_blocks_per_sm=8, grid=False)
     def gdn_decode_bf16_ilp4(
         state: TK.gptr[TK.bf16],
         intermediate: TK.gptr[TK.bf16],

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py
@@ -21,7 +21,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "gdn_decode_bf16_wide_vec_mtp",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py
@@ -21,7 +21,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "gdn_decode_bf16_wide_vec_t1",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py
+++ b/tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py
@@ -21,7 +21,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "gdn_decode_fp32_mtp_warp",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 K = 128

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py
@@ -84,8 +84,22 @@ PREFILL_OPT_T_STORE_BARRIER = 2
 PREFILL_OPT_TMEM_DEALLOC_BARRIER = 3
 PREFILL_OPT_INITIAL_STATE_BARRIER = 4
 
-KERNEL_META = {"name": "gdn_cp_prefill_sm100", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "gdn_cp_prefill_sm100",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 
 BENCH_CONFIGS = [
     {
@@ -4119,8 +4133,10 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
     if not torch.cuda.is_available() or torch.device(device).type != "cuda":
         raise SkipTest("CUDA is required for GDN CP prefill SM100")
     capability = torch.cuda.get_device_capability(device)
-    if capability != (10, 0):
-        raise SkipTest(f"GDN CP prefill requires SM100/B200, got {capability}")
+    if capability not in {(10, 0), (10, 3), (10, 7)}:
+        raise SkipTest(
+            f"GDN CP prefill requires compute capability 10.0, 10.3, or 10.7, got {capability}"
+        )
 
     spec = _specialization(cfg, device)
     io_dtype = _TORCH_DTYPES[cfg.dtype]

--- a/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
+++ b/tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py
@@ -1638,7 +1638,22 @@ CONFIGS = [
     for seq_idx, (seq_lens, seq_label) in enumerate(SEQ_CASES)
 ]
 
-KERNEL_META = {"name": "gdn_prefill_sm100", "category": "flashinfer", "compute_capability": 10}
+KERNEL_META = {
+    "name": "gdn_prefill_sm100",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 
 
 def _cfg(**kwargs: Any) -> GDNPrefillSM100Config:

--- a/tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py
+++ b/tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py
@@ -1,0 +1,1110 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ 012cfdb97f217e0d48bc9352c17a74068c9e495b)
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""SM107 FP8 batched GEMM transcribed from FlashInfer's CuTeDSL kernel.
+
+Upstream sources:
+- flashinfer/gemm/kernels/bmm_fp8_rubin.py
+- flashinfer/gemm/kernels/bmm_fp8_blackwell.py
+- flashinfer/gemm/kernels/bmm_fp8_wrapper.py
+- flashinfer/gemm/kernels/epilogue_utils.py
+"""
+
+# K.kernel traces concrete annotation objects; postponed annotations would turn them into strings.
+import hashlib
+import importlib
+import sys
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "bmm_fp8_rubin",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "012cfdb97f217e0d48bc9352c17a74068c9e495b",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
+
+SOURCE_COMMIT = "012cfdb97f217e0d48bc9352c17a74068c9e495b"
+SOURCE_SHA256 = "f10b5ee03096af8394b57cfbe7abb6ee3103baf87c6a58a60f576ead3f4386f3"
+SOURCE_DEPENDENCY_SHA256 = {
+    "bmm_fp8_blackwell.py": "1b24de919897ef7ede911661150d67b044aa917ff50965dc08107b1aa9cacf30",
+    "bmm_fp8_wrapper.py": "f6981c4891403fd204c3bc53e716ef75ad883c904c83828d7c05526854366530",
+    "epilogue_utils.py": "ae48ecfca2220975cd3e0e1d60803f8634aa72827857aaff3b2af24205c01c92",
+}
+
+_AB_DTYPES = ("float8_e4m3fn", "float8_e5m2")
+_C_DTYPES = ("bfloat16", "float16", "float32")
+_DTYPE_LABEL = {
+    "float8_e4m3fn": "e4m3",
+    "float8_e5m2": "e5m2",
+    "bfloat16": "bf16",
+    "float16": "fp16",
+    "float32": "fp32",
+}
+
+_TRY_WAIT_TICKS = 10_000_000
+_SMEM_CAPACITY = 335_872
+_MAX_ACTIVE_CLUSTERS = {2: 74, 4: 33}
+_SOURCE_ROOT = Path("/root-vol/aarch64-ws/kernel-libs/vr200/flashinfer")
+
+# (mma_tiler, mma_instruction, cluster_mn, raster)
+TACTICS = (
+    ((256, 256, 128), (256, 256, 64), (2, 1), "m"),
+    ((256, 128, 128), (256, 128, 64), (2, 1), "m"),
+    ((256, 256, 64), (256, 256, 32), (2, 1), "m"),
+    ((256, 256, 64), (256, 256, 64), (2, 1), "m"),
+    ((256, 256, 128), (256, 256, 64), (2, 2), "m"),
+    ((256, 128, 128), (256, 128, 64), (4, 1), "m"),
+    ((256, 256, 128), (256, 256, 64), (2, 1), "n"),
+    ((256, 128, 128), (256, 128, 64), (2, 1), "n"),
+)
+
+_CORRECTNESS_SHAPES = (
+    (2, 272, 1040, 1008),
+    (2, 272, 1040, 1008),
+    (2, 272, 1040, 1008),
+    (2, 272, 1040, 1008),
+    (2, 272, 528, 1008),
+    (2, 528, 1040, 1008),
+    (2, 272, 1040, 1008),
+    (2, 272, 1040, 1008),
+)
+
+_BENCH_SHAPES = (
+    (1, 256, 10304, 2688),
+    (4, 256, 4096, 2688),
+    (1, 512, 4096, 2720),
+    (2, 512, 4096, 2688),
+    (1, 1024, 4096, 3072),
+    (1, 2048, 4096, 3072),
+    (1, 4096, 1024, 3072),
+    (2, 4096, 1024, 3072),
+)
+
+
+def _config(
+    prefix: str, tactic: int, shape: tuple[int, int, int, int], ab_dtype: str, c_dtype: str
+):
+    B, M, N, K_dim = shape
+    return {
+        "label": (
+            f"{prefix}_t{tactic}_{_DTYPE_LABEL[ab_dtype]}_{_DTYPE_LABEL[c_dtype]}_"
+            f"b{B}_m{M}_n{N}_k{K_dim}"
+        ),
+        "B": B,
+        "M": M,
+        "N": N,
+        "K": K_dim,
+        "ab_dtype": ab_dtype,
+        "c_dtype": c_dtype,
+        "tactic": tactic,
+    }
+
+
+CONFIGS = [
+    _config("guard", tactic, _CORRECTNESS_SHAPES[tactic], ab_dtype, c_dtype)
+    for tactic in range(len(TACTICS))
+    for ab_dtype in _AB_DTYPES
+    for c_dtype in _C_DTYPES
+]
+CONFIGS.append(_config("source_anchor", 0, _BENCH_SHAPES[0], "float8_e4m3fn", "bfloat16"))
+
+BENCH_CONFIGS = [
+    _config("bench", tactic, _BENCH_SHAPES[tactic], ab_dtype, c_dtype)
+    for tactic in range(len(TACTICS))
+    for ab_dtype in _AB_DTYPES
+    for c_dtype in _C_DTYPES
+]
+
+
+def _validate_problem(
+    B: int, M: int, N: int, K: int, ab_dtype: str, c_dtype: str, tactic: int
+) -> None:
+    if not 0 <= tactic < len(TACTICS):
+        raise ValueError(f"tactic must be in [0, {len(TACTICS) - 1}], got {tactic}")
+    if ab_dtype not in _AB_DTYPES:
+        raise ValueError(f"unsupported FP8 input dtype {ab_dtype!r}")
+    if c_dtype not in _C_DTYPES:
+        raise ValueError(f"unsupported output dtype {c_dtype!r}")
+    if B <= 0:
+        raise ValueError(f"B must be positive, got {B}")
+    if M % 16 or N % 16 or K % 16:
+        raise ValueError(f"M, N, and K must be multiples of 16, got {(M, N, K)}")
+    mma_tiler, _mma_instruction, cluster, _raster = TACTICS[tactic]
+    cta_m = mma_tiler[0] // 2
+    if M < cta_m * cluster[0] or N < mma_tiler[1] * cluster[1]:
+        raise ValueError(
+            f"shape {(M, N)} cannot fill tactic {tactic} cluster {cluster} "
+            f"with CTA tile {(cta_m, mma_tiler[1])}"
+        )
+
+
+def _ceil_div(value: int, divisor: int) -> int:
+    return (value + divisor - 1) // divisor
+
+
+def _descriptor_base(ldo: int, sdo: int, swizzle: int) -> int:
+    arrangement_type = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = 0
+    value |= (ldo & 0x3FFF) << 16
+    value |= (sdo & 0x3FFF) << 32
+    value |= 1 << 46
+    value |= (arrangement_type & 0x7) << 61
+    return value & 0xFFFFFFFFFFFFFFFF
+
+
+def _descriptor_with_address(base: int, shared_address):
+    base_value = K.bitwise_or(
+        K.shift_left(K.uint64(base >> 32), K.uint64(32)), K.uint64(base & 0xFFFFFFFF)
+    )
+    address_field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x3FFF)), "uint64"
+    )
+    return K.bitwise_or(base_value, address_field)
+
+
+def _advance(state) -> None:
+    state.advance()
+
+
+def _try_wait_acquire(dst, barrier, phase) -> None:
+    K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+        dst, barrier, K.cast(phase, "uint32")
+    )
+
+
+def _wait_plain(barrier, phase) -> None:
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _wait_plain_if_needed(barrier, phase, speculative_ready) -> None:
+    with K.If(speculative_ready == K.uint32(0)):
+        with K.Then():
+            _wait_plain(barrier, phase)
+
+
+def _elected():
+    elected_lane = K.local_scalar("uint32")
+    elected_pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(elected_lane, elected_pred, K.uint32(0xFFFFFFFF))
+    return elected_pred == K.uint32(1)
+
+
+def _instruction_descriptor(n_tile: int, instruction_k: int, ab_dtype: str) -> int:
+    descriptors = {
+        (256, 64, "float8_e4m3fn"): 0x30410010,
+        (256, 64, "float8_e5m2"): 0x30410490,
+        (128, 64, "float8_e4m3fn"): 0x30210010,
+        (128, 64, "float8_e5m2"): 0x30210490,
+        (256, 32, "float8_e4m3fn"): 0x10410010,
+        (256, 32, "float8_e5m2"): 0x10410490,
+    }
+    return descriptors[(n_tile, instruction_k, ab_dtype)]
+
+
+@cache
+def _make_bmm_kernel(B: int, M: int, N: int, K_dim: int, ab_dtype: str, c_dtype: str, tactic: int):
+    _validate_problem(B, M, N, K_dim, ab_dtype, c_dtype, tactic)
+    mma_tiler, mma_instruction, (cluster_m, cluster_n), raster = TACTICS[tactic]
+    tile_m, n_tile, k_tile = mma_tiler
+    instruction_m, instruction_n, instruction_k = mma_instruction
+    if tile_m != 256 or instruction_m != 256 or instruction_n != n_tile:
+        raise AssertionError("the frozen source surface contains only 256-row two-CTA MMA")
+
+    cta_group = 2
+    cta_m = 128
+    b_rows = n_tile // cta_group
+    cluster_size = cluster_m * cluster_n
+    cluster_m_groups = cluster_m // cta_group
+    k_phases = k_tile // instruction_k
+    k_tiles = _ceil_div(K_dim, k_tile)
+    m_tiles = _ceil_div(M, cta_m)
+    n_tiles = _ceil_div(N, n_tile)
+    cluster_m_tiles = _ceil_div(m_tiles, cluster_m)
+    cluster_n_tiles = _ceil_div(n_tiles, cluster_n)
+    cluster_work = cluster_m_tiles * cluster_n_tiles * B
+    num_clusters = min(cluster_work, _MAX_ACTIVE_CLUSTERS[cluster_size])
+
+    c_bits = {"bfloat16": 16, "float16": 16, "float32": 32}[c_dtype]
+    acc_stages = 2
+    if tactic in (2, 3):
+        c_stages = 2
+        ab_stages = 18 if c_dtype == "float32" else 19
+    else:
+        c_stages = 2 if c_dtype == "float32" else 4
+        ab_stages = 9 if n_tile == 256 else 12
+
+    a_stage_bytes = cta_m * k_tile
+    b_stage_bytes = b_rows * k_tile
+    ab_stage_bytes = a_stage_bytes + b_stage_bytes
+    c_stage_bytes = cta_m * 32 * c_bits // 8
+
+    ab_full_offset = 0
+    ab_empty_offset = ab_full_offset + ab_stages * 8
+    acc_full_offset = ab_empty_offset + ab_stages * 8
+    acc_empty_offset = acc_full_offset + acc_stages * 8
+    tmem_dealloc_offset = acc_empty_offset + acc_stages * 8
+    tmem_ptr_offset = tmem_dealloc_offset + 8
+    a_offset = 384 if ab_stages > 12 else 256
+    b_offset = a_offset + ab_stages * a_stage_bytes
+    c_offset = b_offset + ab_stages * b_stage_bytes
+    shared_bytes = c_offset + c_stages * c_stage_bytes
+    if shared_bytes not in (327_936, 328_064):
+        raise AssertionError(f"source shared-memory layout changed: {shared_bytes}")
+    if shared_bytes > _SMEM_CAPACITY:
+        raise ValueError(f"dynamic shared memory {shared_bytes} exceeds {_SMEM_CAPACITY}")
+
+    ab_empty_arrivals = cluster_n + cluster_m_groups - 1
+    acc_empty_arrivals = 8
+    tmem_columns = acc_stages * n_tile
+    if k_tile == 128:
+        a_swizzle, a_ldo, a_sdo = 3, 1, 64
+    else:
+        a_swizzle, a_ldo, a_sdo = 2, 1, 32
+    if b_rows == 128:
+        b_swizzle, b_chunk, b_ldo, b_sdo = 3, 128, 0, 64
+    else:
+        b_swizzle, b_chunk, b_ldo, b_sdo = 2, 64, 0, 32
+    a_cluster_piece = cta_m // cluster_n
+    b_cluster_piece = k_tile // cluster_m_groups
+    a_piece_bytes = a_stage_bytes // cluster_n
+    b_piece_bytes = b_stage_bytes // cluster_m_groups
+    num_tma_load_bytes = ab_stage_bytes * cta_group
+    a_desc_base = _descriptor_base(ldo=a_ldo, sdo=a_sdo, swizzle=a_swizzle)
+    b_desc_base = _descriptor_base(ldo=b_ldo, sdo=b_sdo, swizzle=b_swizzle)
+    instruction_descriptor = _instruction_descriptor(n_tile, instruction_k, ab_dtype)
+    epilogue_subtiles = n_tile // 32
+    tma_cache_hint = 0
+
+    def host_prelude(params):
+        a = params["a"]
+        b = params["b"]
+        c = params["c"]
+        a_map = K.stack_alloca("tensormap", 1)
+        b_map = K.stack_alloca("tensormap", 1)
+        c_map = K.stack_alloca("tensormap", 1)
+
+        def encode(descriptor, dtype, rank, data, *fields):
+            K.call_packed("runtime.cuTensorMapEncodeTiled", descriptor, dtype, rank, data, *fields)
+
+        a_fields = (K_dim, M, B, K_dim, M * K_dim, k_tile, a_cluster_piece, 1)
+        b_fields = (N, K_dim, B, N, N * K_dim, b_chunk, b_cluster_piece, 1)
+        tensor_tail = (1, 1, 1, 0)
+        encode(a_map, ab_dtype, 3, a.data, *a_fields, *tensor_tail, a_swizzle, 2, 0)
+        encode(b_map, ab_dtype, 3, b.data, *b_fields, *tensor_tail, b_swizzle, 2, 0)
+
+        element_bytes = c_bits // 8
+        row_bytes = 32 * element_bytes
+        c_swizzle = 3 if row_bytes == 128 else 2
+        c_fields = (N, M, B, N * element_bytes, M * N * element_bytes, 32, cta_m, 1)
+        encode(c_map, c_dtype, 3, c.data, *c_fields, 1, 1, 1, 0, c_swizzle, 2, 0)
+        return a_map, b_map, c_map
+
+    def kernel(a, b, c, output_scale, *, host):
+        del a, b, c
+        required_block_size = K.attr({"tirx.required_block_size": 1})
+        required_block_size.__enter__()
+        a_map, b_map, c_map = host
+        scale = K.local_scalar("float32")
+        K.ptx.ld.global_.f32(scale, output_scale.ptr_to([0]))
+
+        _block_x, _block_y, cluster_work_id = K.cta_id()
+        cluster_x_scope, cluster_y_scope = K.cta_id_in_cluster(
+            [cluster_m, cluster_n], preferred=[cluster_m, cluster_n]
+        )
+        del _block_x, _block_y, cluster_x_scope, cluster_y_scope
+        cluster_rank = K.local_scalar("int32", init=K.cuda.mov_sreg(32, "cluster_ctarank"))
+        cluster_x = K.local_scalar("int32", init=cluster_rank & (cluster_m - 1))
+        cluster_y = K.local_scalar("int32", init=cluster_rank >> (cluster_m.bit_length() - 1))
+        cta_v = cluster_x & 1
+        leader_cta = cta_v == 0
+        cluster_m_group = cluster_x >> 1
+        pair_leader_x = cluster_m_group << 1
+        leader_rank = pair_leader_x + cluster_m * cluster_y
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        roles = K.specialize(chain_dispatch=True)
+        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3])
+        mma_role = roles.role("mma", warps=[4])
+        tma_role = roles.role("tma", warps=[5])
+
+        smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+        protocol_pool = K.smem_pool(base=smem)
+        ab_pipe = K.Pipeline(
+            protocol_pool,
+            ab_stages,
+            full="tma",
+            empty="tcgen05",
+            init_empty=ab_empty_arrivals,
+            leader=K.bool(False),
+        )
+        acc_pipe = K.Pipeline(
+            protocol_pool,
+            acc_stages,
+            full="tcgen05",
+            empty="mbar",
+            init_empty=acc_empty_arrivals,
+            leader=K.bool(False),
+        )
+        if protocol_pool.bytes != tmem_dealloc_offset:
+            raise AssertionError("protocol storage offsets changed")
+        tmem_dealloc = protocol_pool.alloc((1,), K.u64, align=8)
+        tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
+        if protocol_pool.bytes != tmem_ptr_offset + 4:
+            raise AssertionError("protocol storage header changed")
+
+        with tma_role:
+            K.ptx.prefetch.tensormap(K.address_of(a_map))
+            K.ptx.prefetch.tensormap(K.address_of(b_map))
+            K.ptx.prefetch.tensormap(K.address_of(c_map))
+
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.empty.ptr_to([stage]), K.uint32(ab_empty_arrivals)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.empty.ptr_to([stage]), K.uint32(acc_empty_arrivals)
+                            )
+        with tma_role:
+            with K.If(_elected()):
+                with K.Then():
+                    K.ptx.mbarrier.init.shared.b64(tmem_dealloc.ptr_to([0]), K.uint32(32))
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.barrier.cluster.arrive.relaxed()
+
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+        cluster_smem_u64 = K.local_scalar("uint64")
+        K.ptx.cvta.to.shared__cluster.u64(cluster_smem_u64, smem.ptr_to([0]))
+        cluster_smem = K.local_scalar("uint32", init=K.cast(cluster_smem_u64, "uint32"))
+        a_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(a_desc_base, smem_base + a_offset)
+        )
+        b_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(b_desc_base, smem_base + b_offset)
+        )
+
+        a_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_n in range(cluster_n):
+            K.assign(
+                a_mcast_mask,
+                K.bitwise_or(
+                    a_mcast_mask, K.uint32(1) << K.cast(cluster_x + cluster_m * peer_n, "uint32")
+                ),
+            )
+        b_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_group in range(cluster_m_groups):
+            peer_x = cta_v + 2 * peer_group
+            K.assign(
+                b_mcast_mask,
+                K.bitwise_or(
+                    b_mcast_mask, K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32")
+                ),
+            )
+        ab_consumer_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for pair_v in range(2):
+            for peer_n in range(cluster_n):
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1)
+                        << K.cast(pair_leader_x + pair_v + cluster_m * peer_n, "uint32"),
+                    ),
+                )
+            for peer_group in range(cluster_m_groups):
+                peer_x = pair_v + 2 * peer_group
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32"),
+                    ),
+                )
+        acc_producer_mask = K.local_scalar(
+            "uint32", init=K.uint32(3) << K.cast(leader_rank, "uint32")
+        )
+        ab_full_leader = ab_pipe.full.remote_view(leader_rank)
+        acc_empty_leader = acc_pipe.empty.remote_view(leader_rank)
+        K.ptx.barrier.cluster.wait()
+
+        def scheduler_coords(work):
+            if raster == "m":
+                cluster_m_idx = work % cluster_m_tiles
+                quotient = work // cluster_m_tiles
+                cluster_n_idx = quotient % cluster_n_tiles
+                batch_idx = quotient // cluster_n_tiles
+            else:
+                cluster_n_idx = work % cluster_n_tiles
+                quotient = work // cluster_n_tiles
+                cluster_m_idx = quotient % cluster_m_tiles
+                batch_idx = quotient // cluster_m_tiles
+            tile_m_idx = cluster_m_idx * cluster_m + cluster_x
+            tile_n_idx = cluster_n_idx * cluster_n + cluster_y
+            return tile_m_idx, tile_n_idx, batch_idx
+
+        def advance_work(work) -> None:
+            K.assign(work, work + num_clusters)
+
+        with tma_role:
+            tma_state = K.PipelineState(ab_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If(count < k_tiles):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase
+                        )
+                with K.While(count < k_tiles):
+                    _wait_plain_if_needed(
+                        ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase, speculative
+                    )
+                    with K.If(leader_cta):
+                        with K.Then():
+                            with K.If(_elected()):
+                                with K.Then():
+                                    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.uint32(num_tma_load_bytes),
+                                    )
+
+                    with K.If(_elected()):
+                        with K.Then():
+                            a_coord_m = tile_m_idx * cta_m + cluster_y * a_cluster_piece
+                            a_coord_k = count * k_tile
+                            a_smem_offset = (
+                                a_offset
+                                + tma_state.stage * a_stage_bytes
+                                + cluster_y * a_piece_bytes
+                            )
+                            if cluster_n == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2"
+                                ](
+                                    cluster_smem + a_smem_offset,
+                                    K.address_of(a_map),
+                                    K.cast(a_coord_k, "int32"),
+                                    K.cast(a_coord_m, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint.cta_group::2"
+                                ](
+                                    cluster_smem + a_smem_offset,
+                                    K.address_of(a_map),
+                                    K.cast(a_coord_k, "int32"),
+                                    K.cast(a_coord_m, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+
+                    with K.If(_elected()):
+                        with K.Then():
+                            b_coord_n = tile_n_idx * n_tile + cta_v * b_rows
+                            b_coord_k = count * k_tile + cluster_m_group * b_cluster_piece
+                            b_smem_offset = (
+                                b_offset
+                                + tma_state.stage * b_stage_bytes
+                                + cluster_m_group * b_piece_bytes
+                            )
+                            if cluster_m_groups == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2"
+                                ](
+                                    cluster_smem + b_smem_offset,
+                                    K.address_of(b_map),
+                                    K.cast(b_coord_n, "int32"),
+                                    K.cast(b_coord_k, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint.cta_group::2"
+                                ](
+                                    cluster_smem + b_smem_offset,
+                                    K.address_of(b_map),
+                                    K.cast(b_coord_n, "int32"),
+                                    K.cast(b_coord_k, "int32"),
+                                    K.cast(batch_idx, "int32"),
+                                    ab_full_leader.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    _advance(tma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If(count < k_tiles):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative,
+                                ab_pipe.empty.ptr_to([tma_state.stage]),
+                                tma_state.phase,
+                            )
+                advance_work(work)
+            with K.unroll(0, ab_stages) as unused_stage:
+                _wait_plain(ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase)
+                _advance(tma_state)
+            del unused_stage
+
+        with mma_role:
+            K.ptx.bar.sync(K.uint32(2), K.uint32(160))
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot.ptr_to([0]))
+            mma_state = K.PipelineState(ab_stages, phase=0)
+            acc_state = K.PipelineState(acc_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            accumulate = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If((count < k_tiles) & leader_cta):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                        )
+                with K.If(leader_cta):
+                    with K.Then():
+                        _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(accumulate, K.uint32(0))
+                with K.While(count < k_tiles):
+                    with K.If(leader_cta):
+                        with K.Then():
+                            _wait_plain_if_needed(
+                                ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase, speculative
+                            )
+                            for kphase in range(k_phases):
+                                a_kphase = kphase * (instruction_k // 16)
+                                b_kphase = kphase * (b_chunk * instruction_k // 16)
+                                with K.If(_elected()):
+                                    with K.Then():
+                                        K.ptx[
+                                            "tcgen05.mma.cta_group::2.kind::f8f6f4"
+                                            ".collector::a::discard"
+                                        ](
+                                            K.cast(tmem_base + acc_state.stage * n_tile, "uint32"),
+                                            a_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (a_stage_bytes // 16) + a_kphase,
+                                                "uint64",
+                                            ),
+                                            b_descriptor
+                                            + K.cast(
+                                                mma_state.stage * (b_stage_bytes // 16) + b_kphase,
+                                                "uint64",
+                                            ),
+                                            K.uint32(instruction_descriptor),
+                                            *[K.uint32(0) for _ in range(8)],
+                                            K.ptx.pred(K.cast(accumulate, "bool")),
+                                        )
+                                K.assign(accumulate, K.uint32(1))
+                            with K.If(_elected()):
+                                with K.Then():
+                                    K.ptx[
+                                        "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
+                                        ".shared::cluster.multicast::cluster.b64"
+                                    ](
+                                        ab_pipe.empty.ptr_to([mma_state.stage]),
+                                        K.cast(ab_consumer_mask, "uint16"),
+                                    )
+                    _advance(mma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If((count < k_tiles) & leader_cta):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                            )
+                with K.If(leader_cta):
+                    with K.Then():
+                        with K.If(_elected()):
+                            with K.Then():
+                                K.ptx[
+                                    "tcgen05.commit.cta_group::2.mbarrier::arrive::one"
+                                    ".shared::cluster.multicast::cluster.b64"
+                                ](
+                                    acc_pipe.full.ptr_to([acc_state.stage]),
+                                    K.cast(acc_producer_mask, "uint16"),
+                                )
+                _advance(acc_state)
+                advance_work(work)
+            with K.If(leader_cta):
+                with K.Then():
+                    _advance(acc_state)
+                    _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+
+        with epilogue_role:
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx["tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32"](
+                        tmem_slot.ptr_to([0]), K.uint32(tmem_columns)
+                    )
+            K.ptx.bar.sync(K.uint32(2), K.uint32(160))
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot.ptr_to([0]))
+            acc_state = K.PipelineState(acc_stages, phase=0)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            executed_tiles = K.local_scalar("int32", init=0)
+            values = K.alloc_local((32,), "float32")
+            if c_bits == 32:
+                words = K.alloc_local((32,), "uint32")
+                offsets = K.alloc_local((8,), "int32")
+            else:
+                words = K.alloc_local((16,), "uint32")
+                offsets = K.alloc_local((4,), "int32")
+
+            def scale_values() -> None:
+                for index in range(0, 32, 2):
+                    packed = K.local_scalar("uint64")
+                    scale_pair = K.local_scalar("uint64")
+                    K.ptx.mov.b64(packed, values[index], values[index + 1])
+                    K.ptx.mov.b64(scale_pair, scale, scale)
+                    K.ptx.mul.f32x2(packed, scale_pair, packed)
+                    K.ptx.mov.b64(values[index], values[index + 1], packed)
+
+            def pack_values() -> None:
+                if c_dtype == "float32":
+                    for index in range(32):
+                        K.assign(words[index], K.reinterpret("uint32", values[index]))
+                elif c_dtype == "float16":
+                    for index in range(16):
+                        K.ptx.cvt.rn.f16x2.f32(
+                            words[index], values[index * 2 + 1], values[index * 2]
+                        )
+                else:
+                    for index in range(16):
+                        K.ptx.cvt.rn.bf16x2.f32(
+                            words[index], values[index * 2 + 1], values[index * 2]
+                        )
+
+            def output_offset(stage, vector):
+                row_bytes = 32 * c_bits // 8
+                unswizzled = (
+                    smem_base
+                    + c_offset
+                    + stage * c_stage_bytes
+                    + warp * (32 * row_bytes)
+                    + lane * row_bytes
+                    + vector * 16
+                )
+                swizzle_mask = 112 if row_bytes == 128 else 48
+                swizzled = K.bitwise_xor(
+                    unswizzled,
+                    K.bitwise_and(K.shift_right(unswizzled, K.uint32(3)), K.uint32(swizzle_mask)),
+                )
+                return K.cast(swizzled - smem_base, "int32")
+
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx, batch_idx = scheduler_coords(work)
+                _wait_plain(acc_pipe.full.ptr_to([acc_state.stage]), acc_state.phase)
+                subtile = K.local_scalar("int32", init=0)
+                with K.While(subtile < epilogue_subtiles):
+                    tmem_address = K.local_scalar(
+                        "uint32",
+                        init=(tmem_base + (warp << 21) + acc_state.stage * n_tile + subtile * 32),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                        *[values[index] for index in range(32)], tmem_address
+                    )
+                    scale_values()
+                    pack_values()
+                    output_stage = (executed_tiles * epilogue_subtiles + subtile) % c_stages
+                    for vector in range((32 * c_bits // 32) // 4):
+                        K.assign(offsets[vector], output_offset(output_stage, vector))
+                    for vector in range((32 * c_bits // 32) // 4):
+                        K.ptx.st.shared.v4.b32(
+                            smem.ptr_to([offsets[vector]]),
+                            words[vector * 4],
+                            words[vector * 4 + 1],
+                            words[vector * 4 + 2],
+                            words[vector * 4 + 3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    with K.If(warp == 0):
+                        with K.Then():
+                            K.ptx[
+                                "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+                                ".L2::cache_hint"
+                            ](
+                                K.address_of(c_map),
+                                K.cast(tile_n_idx * n_tile + subtile * 32, "int32"),
+                                K.cast(tile_m_idx * cta_m, "int32"),
+                                K.cast(batch_idx, "int32"),
+                                smem.ptr_to([c_offset + output_stage * c_stage_bytes]),
+                                K.uint64(tma_cache_hint),
+                            )
+                            K.ptx.cp.async_.bulk.commit_group()
+                            K.ptx.cp.async_.bulk.wait_group.read(c_stages - 1)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    K.assign(subtile, subtile + 1)
+                K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                with K.If(_elected()):
+                    with K.Then():
+                        K.ptx.mbarrier.arrive.shared__cluster.b64(
+                            acc_empty_leader.ptr_to([acc_state.stage]), K.uint32(1)
+                        )
+                _advance(acc_state)
+                K.assign(executed_tiles, executed_tiles + 1)
+                advance_work(work)
+
+            K.ptx.cp.async_.bulk.wait_group.read(0)
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx["tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned"]()
+                    remote_dealloc = K.local_scalar("uint32")
+                    K.ptx.mapa.shared__cluster.u32(
+                        remote_dealloc,
+                        K.cuda.cvta_generic_to_shared(tmem_dealloc.ptr_to([0])),
+                        K.cast(cluster_rank ^ 1, "uint32"),
+                    )
+                    K.ptx.mbarrier.arrive.shared__cluster.b64(remote_dealloc, K.uint32(1))
+                    _wait_plain(tmem_dealloc.ptr_to([0]), K.uint32(0))
+                    K.ptx["tcgen05.dealloc.cta_group::2.sync.aligned.b32"](
+                        tmem_base, K.uint32(tmem_columns)
+                    )
+
+        required_block_size.__exit__(None, None, None)
+
+    kernel.__annotations__ = {
+        "a": K.gptr[K.u8, (B * M * K_dim,)],
+        "b": K.gptr[K.u8, (B * K_dim * N,)],
+        "c": K.gptr[K.u8, (B * M * N * c_bits // 8,)],
+        "output_scale": K.gptr[K.f32, (1,)],
+    }
+    return K.kernel(
+        warps=6,
+        arch="sm_107a",
+        min_blocks_per_sm=1,
+        grid=[cluster_m, cluster_n, num_clusters],
+        host_prelude=host_prelude,
+    )(kernel)
+
+
+def get_kernel(B: int, M: int, N: int, K: int, ab_dtype: str, c_dtype: str, tactic: int):
+    _validate_problem(B, M, N, K, ab_dtype, c_dtype, tactic)
+    return _make_bmm_kernel(B, M, N, K, ab_dtype, c_dtype, tactic).func
+
+
+def _torch_dtype(torch, dtype: str):
+    return {
+        "float8_e4m3fn": torch.float8_e4m3fn,
+        "float8_e5m2": torch.float8_e5m2,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }[dtype]
+
+
+def _pattern(torch, shape: tuple[int, ...], phase: int, device):
+    count = 1
+    for extent in shape:
+        count *= extent
+    values = (torch.arange(count, device=device, dtype=torch.int64) + phase) % 5 - 2
+    return values.reshape(shape).to(torch.float32)
+
+
+def prepare_data(
+    B: int, M: int, N: int, K: int, ab_dtype: str, c_dtype: str, tactic: int
+) -> dict[str, Any]:
+    _validate_problem(B, M, N, K, ab_dtype, c_dtype, tactic)
+    import torch
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 7):
+        raise RuntimeError("bmm_fp8_rubin requires an SM107 CUDA device")
+    device = torch.device("cuda")
+    a = _pattern(torch, (B, M, K), 0, device).to(_torch_dtype(torch, ab_dtype)).contiguous()
+    b = _pattern(torch, (B, K, N), 2, device).to(_torch_dtype(torch, ab_dtype)).contiguous()
+    a_scale = torch.tensor(0.75, dtype=torch.float32, device=device)
+    b_scale = torch.tensor(1.25, dtype=torch.float32, device=device)
+    output_scale = (a_scale * b_scale).reshape(1)
+    output_dtype = _torch_dtype(torch, c_dtype)
+    tirx_c = torch.full((B, M, N), float("nan"), dtype=output_dtype, device=device)
+    source_c = torch.full((B, M, N), float("nan"), dtype=output_dtype, device=device)
+    return {
+        "a": a,
+        "b": b,
+        "a_raw": a.view(torch.uint8).reshape(-1),
+        "b_raw": b.view(torch.uint8).reshape(-1),
+        "tirx_c": tirx_c,
+        "tirx_c_raw": tirx_c.view(torch.uint8).reshape(-1),
+        "source_c": source_c,
+        "a_scale": a_scale,
+        "b_scale": b_scale,
+        "output_scale": output_scale,
+    }
+
+
+@cache
+def _compile_executable(
+    B: int, M: int, N: int, K_dim: int, ab_dtype: str, c_dtype: str, tactic: int
+):
+    from tirx_kernels.runner import compile_kernel
+
+    return compile_kernel(get_kernel(B, M, N, K_dim, ab_dtype, c_dtype, tactic))
+
+
+def _tirx_launch(executable, data):
+    def launch():
+        executable(data["a_raw"], data["b_raw"], data["tirx_c_raw"], data["output_scale"])
+
+    launch._keep_alive = data
+    return launch
+
+
+@cache
+def _source_bmm_op():
+    source_files = {
+        "flashinfer/gemm/kernels/bmm_fp8_rubin.py": SOURCE_SHA256,
+        **{
+            f"flashinfer/gemm/kernels/{name}": digest
+            for name, digest in SOURCE_DEPENDENCY_SHA256.items()
+        },
+    }
+    for relative, expected in source_files.items():
+        source = _SOURCE_ROOT / relative
+        if not source.is_file():
+            raise RuntimeError(f"frozen FlashInfer source is unavailable: {source}")
+        actual = hashlib.sha256(source.read_bytes()).hexdigest()
+        if actual != expected:
+            raise RuntimeError(f"frozen FlashInfer source hash mismatch: {source} sha256={actual}")
+    loaded = sys.modules.get("flashinfer")
+    loaded_file = Path(getattr(loaded, "__file__", "")).resolve() if loaded is not None else None
+    if loaded_file is not None and _SOURCE_ROOT not in loaded_file.parents:
+        for name in tuple(sys.modules):
+            if name == "flashinfer" or name.startswith("flashinfer."):
+                del sys.modules[name]
+    source_root = str(_SOURCE_ROOT)
+    if source_root not in sys.path:
+        sys.path.insert(0, source_root)
+    module = importlib.import_module("flashinfer.gemm.kernels.bmm_fp8_wrapper")
+    return module.bmm_fp8_cute_dsl
+
+
+def _source_launch(data, c_dtype: str, tactic: int):
+    bmm_fp8_cute_dsl = _source_bmm_op()
+    output_dtype = _torch_dtype(__import__("torch"), c_dtype)
+
+    def launch():
+        bmm_fp8_cute_dsl(
+            data["a"],
+            data["b"],
+            data["a_scale"],
+            data["b_scale"],
+            output_dtype,
+            out=data["source_c"],
+            config_index=tactic,
+            arch="sm107",
+        )
+
+    launch._keep_alive = data
+    return launch
+
+
+def _validate_outputs(data, *, with_source: bool) -> dict[str, Any]:
+    import torch
+
+    actual = data["tirx_c"]
+    if not bool(torch.isfinite(actual.float()).all().item()):
+        raise AssertionError("TIRx output contains a non-finite value")
+    if not with_source:
+        return {"bitwise": None, "max_abs_diff": None}
+    expected = data["source_c"]
+    if not bool(torch.isfinite(expected.float()).all().item()):
+        raise AssertionError("source output contains a non-finite value")
+    if torch.equal(actual, expected):
+        return {"bitwise": True, "max_abs_diff": 0.0}
+    actual_f32 = actual.float()
+    expected_f32 = expected.float()
+    difference = (actual_f32 - expected_f32).abs()
+    worst = int(torch.argmax(difference).item())
+    differing = int((actual != expected).sum().item())
+    raise AssertionError(
+        "bmm_fp8_rubin bitwise mismatch against frozen FlashInfer source: "
+        f"differing={differing}, max_abs_diff={float(difference.max().item())}, "
+        f"actual={float(actual_f32.reshape(-1)[worst].item())}, "
+        f"expected={float(expected_f32.reshape(-1)[worst].item())}, flat_index={worst}"
+    )
+
+
+def run_test(
+    B: int, M: int, N: int, K: int, ab_dtype: str, c_dtype: str, tactic: int
+) -> dict[str, Any]:
+    import torch
+
+    data = prepare_data(B, M, N, K, ab_dtype, c_dtype, tactic)
+    executable = _compile_executable(B, M, N, K, ab_dtype, c_dtype, tactic)
+    tirx_launch = _tirx_launch(executable, data)
+    source_launch = _source_launch(data, c_dtype, tactic)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    return _validate_outputs(data, with_source=True)
+
+
+def prepare_bench(B: int, M: int, N: int, K: int, ab_dtype: str, c_dtype: str, tactic: int):
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    _validate_problem(B, M, N, K, ab_dtype, c_dtype, tactic)
+    state = {
+        "config": {
+            "B": B,
+            "M": M,
+            "N": N,
+            "K": K,
+            "ab_dtype": ab_dtype,
+            "c_dtype": c_dtype,
+            "tactic": tactic,
+        },
+        "executable": _compile_executable(B, M, N, K, ab_dtype, c_dtype, tactic),
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    data = prepare_data(**config)
+    tirx_launch = _tirx_launch(prepared["executable"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    with_source = external_references_enabled()
+    references = None
+    if with_source:
+        source_launch = _source_launch(data, config["c_dtype"], config["tactic"])
+        source_launch()
+        torch.cuda.synchronize()
+        references = {"flashinfer": lambda: source_launch}
+    _validate_outputs(data, with_source=with_source)
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(
+    B: int,
+    M: int,
+    N: int,
+    K: int,
+    ab_dtype: str,
+    c_dtype: str,
+    tactic: int,
+    *,
+    warmup=None,
+    repeat=None,
+    timer=None,
+    rounds=1,
+    cooldown_s=1.0,
+):
+    return prepare_bench(B, M, N, K, ab_dtype, c_dtype, tactic).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "TACTICS",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -20,8 +20,22 @@ import torch
 
 import tirx_kernels.kern as K
 
-KERNEL_META = {"name": "tinygemm2_sm100", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "tinygemm2_sm100",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 CONFIGS = [
     {"label": "b1_o128_k720", "B": 1, "O": 128, "K": 720},
     {"label": "b2_o16_k256", "B": 2, "O": 16, "K": 256},
@@ -63,13 +77,14 @@ def _validate_problem(B: int, O: int, K: int) -> None:
         raise ValueError("B, O, and K must fit signed int32")
 
 
-def _require_sm100() -> None:
+def _require_supported_arch() -> None:
     if not torch.cuda.is_available():
         raise SkipTest("TinyGEMM2 SM100 requires CUDA")
     capability = torch.cuda.get_device_capability()
-    if capability != (10, 0):
+    if capability not in {(10, 0), (10, 3), (10, 7)}:
         raise SkipTest(
-            f"TinyGEMM2 SM100 requires SM100/B200, got sm_{capability[0]}{capability[1]}"
+            "TinyGEMM2 requires SM100/B200, SM103/GB300, or SM107, "
+            f"got sm_{capability[0]}{capability[1]}"
         )
 
 
@@ -542,7 +557,7 @@ def _run_flashinfer(case: dict[str, Any], stage: int, use_pdl: bool, output: tor
 
 
 def run_test(B: int, O: int, K: int) -> None:
-    _require_sm100()
+    _require_supported_arch()
     case = prepare_data(B, O, K)
     num_sms = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
     stage = _select_stage(B, O, K, num_sms)
@@ -587,7 +602,7 @@ def run_gpu(
     rounds: int = 5,
     cooldown_s: float = 1.0,
 ) -> dict[str, Any]:
-    _require_sm100()
+    _require_supported_arch()
     from tirx_kernels.runner import bench, external_references_enabled
 
     B, O, K = prepared["B"], prepared["O"], prepared["K"]

--- a/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
+++ b/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
@@ -507,7 +507,18 @@ BENCH_CONFIGS = [
 KERNEL_META = {
     "name": "flashkda_bf16_fused_m128",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -269,7 +269,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "flashkda_decode_t1_precomputed",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -324,7 +324,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "flashkda_decode_t2_precomputed",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py
@@ -226,7 +226,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "flashkda_decode_t3_lower_bound",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py
@@ -186,7 +186,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "flashkda_decode_t4_precomputed",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py
@@ -250,7 +250,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "flashkda_decode_t5_gram",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py
@@ -338,7 +338,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "flashkda_decode_t6_gram",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py
@@ -360,7 +360,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "recurrent_kda_decode_grouped",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
+++ b/tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py
@@ -360,7 +360,18 @@ CONFIGS = [dict(cfg) for cfg in BENCH_CONFIGS] + [
 KERNEL_META = {
     "name": "recurrent_kda_decode_one_warp",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -23,7 +23,18 @@ from .selective_state_update_mtp_simple import _case, _shfl_down_f32
 KERNEL_META = {
     "name": "selective_state_update_mtp_horizontal",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 
@@ -309,12 +320,7 @@ def get_kernel(**kwargs: Any):
     WEIGHT_DTYPE = spec["WEIGHT_DTYPE"]
     INDEX_DTYPE = spec["INDEX_DTYPE"]
 
-    @K.kernel(
-        warps=5,
-        arch="sm_100a",
-        min_blocks_per_sm=7,
-        grid=(spec["BATCH"], spec["NHEADS"]),
-    )
+    @K.kernel(warps=5, arch="sm_100a", min_blocks_per_sm=7, grid=(spec["BATCH"], spec["NHEADS"]))
     def selective_state_update_mtp_horizontal(
         tensor_state: K.TensorMap,
         tensor_b: K.TensorMap,

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
@@ -19,7 +19,18 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "selective_state_update_mtp_simple",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _LOG2_E = 1.4426950408889634
@@ -465,11 +476,7 @@ def get_kernel(**kwargs: Any):
     STATE_STAGES = spec["STATE_STAGES"]
     WEIGHT_DTYPE = spec["WEIGHT_DTYPE"]
 
-    @K.kernel(
-        warps=4,
-        arch="sm_100a",
-        grid=(spec["BATCH"], spec["NHEADS"], spec["CTAS_PER_HEAD"]),
-    )
+    @K.kernel(warps=4, arch="sm_100a", grid=(spec["BATCH"], spec["NHEADS"], spec["CTAS_PER_HEAD"]))
     def selective_state_update_mtp_simple(
         state: K.gptr[spec["STATE_DTYPE"]],
         state_scale: K.gptr[K.f32],

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py
@@ -22,7 +22,18 @@ from .selective_state_update_mtp_simple import _case, _shfl_down_f32
 KERNEL_META = {
     "name": "selective_state_update_mtp_vertical",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py
@@ -20,7 +20,18 @@ from . import selective_state_update_stp_simple as _simple
 KERNEL_META = {
     "name": "selective_state_update_stp_horizontal",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py
@@ -19,7 +19,18 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "selective_state_update_stp_simple",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _LOG2_E = 1.4426950408889634
@@ -366,11 +377,7 @@ def get_kernel(**kwargs: Any):
     STATE_VECTOR = spec["STATE_VECTOR"]
     WEIGHT_DTYPE = spec["WEIGHT_DTYPE"]
 
-    @K.kernel(
-        warps=4,
-        arch="sm_100a",
-        grid=(spec["BATCH"], spec["NHEADS"], "dim_tiles_runtime"),
-    )
+    @K.kernel(warps=4, arch="sm_100a", grid=(spec["BATCH"], spec["NHEADS"], "dim_tiles_runtime"))
     def selective_state_update_stp_simple(
         state: K.gptr[spec["STATE_DTYPE"]],
         state_scale: K.gptr[K.f32],

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py
@@ -20,7 +20,18 @@ from . import selective_state_update_stp_simple as _simple
 KERNEL_META = {
     "name": "selective_state_update_stp_vertical",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 

--- a/tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py
+++ b/tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py
@@ -48,7 +48,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "flashinfer_add_rmsnorm_fp4quant",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _DTYPES = ("float16", "bfloat16")

--- a/tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py
@@ -38,7 +38,18 @@ from ._kern_helpers import (
 KERNEL_META = {
     "name": "flashinfer_fused_add_rmsnorm",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _VARIANTS = ("fused_add_rmsnorm", "gemma_fused_add_rmsnorm")

--- a/tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py
+++ b/tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py
@@ -48,7 +48,18 @@ from .rmsnorm_quant import (
 KERNEL_META = {
     "name": "flashinfer_fused_add_rmsnorm_quant",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _INPUT_DTYPES = ("float16", "bfloat16")

--- a/tirx_kernels/flashinfer/norm/fused_dit_layernorm.py
+++ b/tirx_kernels/flashinfer/norm/fused_dit_layernorm.py
@@ -21,7 +21,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "flashinfer_fused_dit_layernorm",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _HIDDEN_SIZE = 3072

--- a/tirx_kernels/flashinfer/norm/layernorm.py
+++ b/tirx_kernels/flashinfer/norm/layernorm.py
@@ -16,8 +16,22 @@ from typing import Any
 import tirx_kernels.kern as K
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "flashinfer_layernorm", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "flashinfer_layernorm",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 _DEFAULT_EPS = 1e-6
 _LAYOUTS = ("compact", "strided")
 _GUARD_ELEMENTS = 64

--- a/tirx_kernels/flashinfer/norm/qk_rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/qk_rmsnorm.py
@@ -15,8 +15,22 @@ from typing import Any
 import tirx_kernels.kern as K
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "flashinfer_qk_rmsnorm", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "flashinfer_qk_rmsnorm",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 _VARIANT_CODE = {"rmsnorm": "rms", "gemma_rmsnorm": "gemma"}
 _DTYPE_CODE = {"float16": "f16", "bfloat16": "bf16"}
 _LAYOUT_CODE = {"compact": "c", "strided": "s"}

--- a/tirx_kernels/flashinfer/norm/rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm.py
@@ -16,8 +16,22 @@ from typing import Any
 import tirx_kernels.kern as K
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "flashinfer_rmsnorm", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "flashinfer_rmsnorm",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 _VARIANTS = ("rmsnorm", "gemma_rmsnorm")
 _DTYPES = ("float16", "bfloat16")
 _LAYOUTS = ("compact", "strided")

--- a/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py
@@ -27,7 +27,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "flashinfer_rmsnorm_fp4quant",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _DTYPES = ("float16", "bfloat16")

--- a/tirx_kernels/flashinfer/norm/rmsnorm_quant.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm_quant.py
@@ -21,7 +21,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "flashinfer_rmsnorm_quant",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _INPUT_DTYPES = ("float16", "bfloat16")

--- a/tirx_kernels/flashinfer/quantization/mxfp4_quantize.py
+++ b/tirx_kernels/flashinfer/quantization/mxfp4_quantize.py
@@ -47,8 +47,22 @@ from tirx_kernels.flashinfer.utils.fp_quant_kern import (
 )
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "mxfp4_quantize", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "mxfp4_quantize",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 _DTYPES = ("float16", "bfloat16")
 _SF_LAYOUTS = ("linear", "128x4", "8x4")
 

--- a/tirx_kernels/flashinfer/quantization/mxfp8_quantize.py
+++ b/tirx_kernels/flashinfer/quantization/mxfp8_quantize.py
@@ -44,8 +44,22 @@ from tirx_kernels.flashinfer.utils.fp_quant_kern import (
 )
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "mxfp8_quantize", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "mxfp8_quantize",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 _DTYPES = ("float16", "bfloat16")
 _SF_LAYOUTS = ("linear", "128x4", "8x4")
 

--- a/tirx_kernels/flashinfer/quantization/nvfp4_quantize.py
+++ b/tirx_kernels/flashinfer/quantization/nvfp4_quantize.py
@@ -53,8 +53,22 @@ from tirx_kernels.flashinfer.utils.fp_quant_kern import (
 )
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "nvfp4_quantize", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "nvfp4_quantize",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 _DTYPES = ("float16", "bfloat16")
 _SF_LAYOUTS = ("linear", "128x4", "8x4")
 

--- a/tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py
+++ b/tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py
@@ -77,7 +77,18 @@ def _process_block_pt(in_global, elem_off, encode_scale, *, dtype):
 KERNEL_META = {
     "name": "nvfp4_quantize_per_token",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 _DTYPES = ("float16", "bfloat16")

--- a/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
+++ b/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
@@ -60,7 +60,22 @@ from tirx_kernels.flashinfer.utils.filtered_topk_ops import st_global_bits
 from tirx_kernels.flashinfer.utils.topk_harness import source_module, torch_dtype
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "fast_topk_clusters", "category": "flashinfer", "compute_capability": 10}
+KERNEL_META = {
+    "name": "fast_topk_clusters",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 
 
 # `clusterCtaIdx.x` is requested only when the cluster is real; a one-CTA cluster

--- a/tirx_kernels/flashinfer/topk/filtered_topk.py
+++ b/tirx_kernels/flashinfer/topk/filtered_topk.py
@@ -103,8 +103,22 @@ _OVERFLOW_PATTERNS = ("tie_heavy", "quantized")
 # fallback to be reachable at all, so the overflow patterns get a long row.
 _OVERFLOW_LENGTH = 131072
 
-KERNEL_META = {"name": "filtered_topk", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "filtered_topk",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 # The unified kernel takes the 128 KiB candidate arena as dynamic shared memory;
 # the finalize kernel's BlockRadixSort scratch is static-sized per (BT, IPT).
 LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")

--- a/tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py
+++ b/tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py
@@ -118,8 +118,22 @@ NUM_SCALARS_MULTI_CTA = 4
 # Staging iterations per thread above which the deeper unroll pays for itself.
 STAGING_DEEP_UNROLL_TRIPS = 16
 
-KERNEL_META = {"name": "radix_topk_multi_cta", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "radix_topk_multi_cta",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
 
 # ---------------------------------------------------------------------------

--- a/tirx_kernels/flashinfer/topk/radix_topk_single_cta.py
+++ b/tirx_kernels/flashinfer/topk/radix_topk_single_cta.py
@@ -67,8 +67,22 @@ from tirx_kernels.flashinfer.utils.topk_radix import (
 )
 from tirx_kernels.runner import bench
 
-KERNEL_META = {"name": "radix_topk_single_cta", "category": "flashinfer", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "radix_topk_single_cta",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
 LAUNCH_TAGS = ("blockIdx.x", "threadIdx.x", "tirx.use_dyn_shared_memory")
 
 # ---------------------------------------------------------------------------

--- a/tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py
+++ b/tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py
@@ -63,7 +63,18 @@ from tirx_kernels.runner import bench
 KERNEL_META = {
     "name": "stable_sort_topk_by_value",
     "category": "flashinfer",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
 }
 
 # The kernel declares no dynamic shared memory and the port declares none either:

--- a/tirx_kernels/flashmla/flash_mla_sparse_fwd.py
+++ b/tirx_kernels/flashmla/flash_mla_sparse_fwd.py
@@ -31,8 +31,11 @@ from tirx_kernels.flashmla import sparse_prefill_head128_phase1 as _head128
 from tirx_kernels.flashmla import sparse_prefill_head128_small_topk_phase1 as _small_topk
 from tvm.tirx.cuda import iket
 
-KERNEL_META = {"name": "flash_mla_sparse_fwd", "category": "flashmla", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "flash_mla_sparse_fwd",
+    "category": "flashmla",
+    "runtime_cuda_archs": ["sm_100a"],
+}
 _HEAD64_NAME = _head64.KERNEL_META["name"]
 _HEAD128_NAME = _head128.KERNEL_META["name"]
 _SMALL_TOPK_NAME = _small_topk.KERNEL_META["name"]

--- a/tirx_kernels/flashmla/sparse_decode_head64.py
+++ b/tirx_kernels/flashmla/sparse_decode_head64.py
@@ -263,7 +263,17 @@ CONFIGS = [
 KERNEL_META = {
     "name": "sparse_flashmla_decode_head64",
     "category": "flashmla",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flash-mla",
+            "git": {
+                "url": "https://github.com/deepseek-ai/FlashMLA.git",
+                "commit": "9241ae3ef9bac614dd25e45e507e089f888280e0",
+            },
+            "import": "flash_mla",
+        },
+    ),
 }
 
 

--- a/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_phase1.py
@@ -177,7 +177,7 @@ CONFIGS = [
 KERNEL_META = {
     "name": "sparse_flashmla_prefill_head128_phase1",
     "category": "flashmla",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
 }
 
 

--- a/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py
@@ -94,7 +94,7 @@ CONFIGS = [
 KERNEL_META = {
     "name": "sparse_flashmla_prefill_head128_small_topk_phase1",
     "category": "flashmla",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
 }
 
 

--- a/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
+++ b/tirx_kernels/flashmla/sparse_prefill_head64_phase1.py
@@ -110,7 +110,7 @@ CONFIGS = [
 KERNEL_META = {
     "name": "sparse_flashmla_prefill_head64_phase1",
     "category": "flashmla",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
 }
 
 

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import inspect
 import linecache
+import os
 import sys
 import sysconfig
 import threading
@@ -331,7 +332,11 @@ class Kernel:
         return tvm.IRModule({"main": self.func})
 
     def target(self):
-        return tvm.target.Target({"kind": "cuda", "arch": self.arch})
+        # The decorator records the author's native/default target. Prepared
+        # runs compile for the GPU that will execute the kernel, including
+        # callers using Kernel.compile() instead of runner.compile_kernel().
+        arch = os.environ.get("TIRX_PREPARE_CUDA_ARCH", self.arch)
+        return tvm.target.Target({"kind": "cuda", "arch": arch})
 
     def compile(self, target=None):
         """Compile to a runnable module (``tir_pipeline="tirx"``)."""

--- a/tirx_kernels/msa/sparse_atten_fwd.py
+++ b/tirx_kernels/msa/sparse_atten_fwd.py
@@ -32,8 +32,23 @@ from tirx_kernels.msa.utils._scalar_ops import (
     udiv_i32,
 )
 
-KERNEL_META = {"name": "msa_sparse_atten_fwd_sm100", "category": "msa", "compute_capability": 10}
-
+KERNEL_META = {
+    "name": "msa_sparse_atten_fwd_sm100",
+    "category": "msa",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "msa",
+            "git": {
+                "url": "https://github.com/MiniMax-AI/MSA.git",
+                "commit": "80434d7f67877c6570ca19cac444b84bc9855dac",
+            },
+            "import": "fmha_sm100",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.5.3", "import": "cutlass"},
+        {"package": "quack-kernels", "specifier": "==0.5.0", "import": "quack"},
+    ),
+}
 # `__init__` restricts both to a single supported value (:75-79, :99-107).
 HEAD_DIM = 128
 BLK_KV = 128
@@ -2263,9 +2278,7 @@ def _make_kernel(**config):
             # ``tidx - stage * 128`` it also makes the 0..127 range explicit to
             # unsigned quotient lowering without relying on a separate warp-id
             # predicate to constrain ``tidx``.
-            group_tidx = K.local_scalar(
-                "int32", init=K.bitwise_and(tidx, SOFTMAX_THREADS - 1)
-            )
+            group_tidx = K.local_scalar("int32", init=K.bitwise_and(tidx, SOFTMAX_THREADS - 1))
             kv_block_sm = ld_shared_i32(s_row_meta, 1)
             count_raw_sm = ld_shared_i32(s_row_meta, 3)
             kv_valid_cols = ld_shared_i32(s_row_meta, 4)
@@ -2379,13 +2392,9 @@ def _make_kernel(**config):
                                 # an int32 literal and stays one `and.b32` with an
                                 # immediate rather than a shift plus a test.
                                 imm = K.local_scalar(
-                                    "int32",
-                                    init=K.int32((1 << i) if i < 31 else -(1 << 31)),
+                                    "int32", init=K.int32((1 << i) if i < 31 else -(1 << 31))
                                 )
-                                with (
-                                    K.If(K.bitwise_and(signed_bits, imm) == K.int32(0)),
-                                    K.Then(),
-                                ):
+                                with K.If(K.bitwise_and(signed_bits, imm) == K.int32(0)), K.Then():
                                     K.assign(s_regs[chunk * MASK_R2P_CHUNK + i], NEG_INF)
 
                     # One KV block per Q group, so this is always the first and

--- a/tirx_kernels/msa/sparse_atten_fwd_combine.py
+++ b/tirx_kernels/msa/sparse_atten_fwd_combine.py
@@ -27,7 +27,19 @@ import tirx_kernels.kern as K
 KERNEL_META = {
     "name": "msa_sparse_atten_fwd_combine_sm100",
     "category": "msa",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "msa",
+            "git": {
+                "url": "https://github.com/MiniMax-AI/MSA.git",
+                "commit": "80434d7f67877c6570ca19cac444b84bc9855dac",
+            },
+            "import": "fmha_sm100",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.5.3", "import": "cutlass"},
+        {"package": "quack-kernels", "specifier": "==0.5.0", "import": "quack"},
+    ),
 }
 
 # The host entry fixes every one of these for the production dispatch domain:
@@ -185,12 +197,7 @@ def make_kernel(
     NUM_ROWS, OUT_ROWS, SPLITS_PT = o_rows, out_rows, splits_pt
     NUM_VALS = o_elems
 
-    @K.kernel(
-        warps=WARPS,
-        arch="sm_100a",
-        min_blocks_per_sm=min_blocks_per_sm,
-        grid=False,
-    )
+    @K.kernel(warps=WARPS, arch="sm_100a", min_blocks_per_sm=min_blocks_per_sm, grid=False)
     def msa_sparse_atten_fwd_combine(
         o_partial: K.gptr[partial_ty],
         lse_partial: K.gptr[K.f32],

--- a/tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py
+++ b/tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py
@@ -40,7 +40,19 @@ from tirx_kernels.msa.utils._scalar_ops import (
 KERNEL_META = {
     "name": "msa_sparse_atten_fwd_nvfp4_kv_sm100",
     "category": "msa",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "msa",
+            "git": {
+                "url": "https://github.com/MiniMax-AI/MSA.git",
+                "commit": "80434d7f67877c6570ca19cac444b84bc9855dac",
+            },
+            "import": "fmha_sm100",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.5.3", "import": "cutlass"},
+        {"package": "quack-kernels", "specifier": "==0.5.0", "import": "quack"},
+    ),
 }
 
 HEAD_DIM = 128

--- a/tirx_kernels/msa/sparse_prepare_flat_schedule.py
+++ b/tirx_kernels/msa/sparse_prepare_flat_schedule.py
@@ -38,7 +38,19 @@ from tirx_kernels.msa.utils._scalar_ops import (
 KERNEL_META = {
     "name": "msa_sparse_prepare_flat_schedule_sm100",
     "category": "msa",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "msa",
+            "git": {
+                "url": "https://github.com/MiniMax-AI/MSA.git",
+                "commit": "80434d7f67877c6570ca19cac444b84bc9855dac",
+            },
+            "import": "fmha_sm100",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.5.3", "import": "cutlass"},
+        {"package": "quack-kernels", "specifier": "==0.5.0", "import": "quack"},
+    ),
 }
 
 # `__init__(num_threads=128)` (:127-135); the kernel takes no shared memory.

--- a/tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py
+++ b/tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py
@@ -50,7 +50,19 @@ from tirx_kernels.msa.utils._scalar_ops import (
 KERNEL_META = {
     "name": "msa_sparse_prepare_fwd_split_atomic_sm100",
     "category": "msa",
-    "compute_capability": 10,
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "msa",
+            "git": {
+                "url": "https://github.com/MiniMax-AI/MSA.git",
+                "commit": "80434d7f67877c6570ca19cac444b84bc9855dac",
+            },
+            "import": "fmha_sm100",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.5.3", "import": "cutlass"},
+        {"package": "quack-kernels", "specifier": "==0.5.0", "import": "quack"},
+    ),
 }
 
 # `__init__(num_threads=256)` (:351-358); validated a multiple of 32.

--- a/tirx_kernels/reference_requirements.py
+++ b/tirx_kernels/reference_requirements.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Validation and availability checks for kernel correctness references."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name
+
+_IMPORT_NAME_PATTERN = re.compile(r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*\Z")
+_FULL_GIT_COMMIT_PATTERN = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})\Z")
+
+
+@dataclass(frozen=True)
+class GitRequirement:
+    """Exact source identity required by a correctness reference."""
+
+    url: str
+    commit: str
+
+
+@dataclass(frozen=True)
+class ReferenceRequirement:
+    """Canonical form of one literal KERNEL_META requirement."""
+
+    package: str
+    import_name: str
+    specifier: str | None = None
+    git: GitRequirement | None = None
+
+
+def parse_reference_requirements(
+    value: object,
+) -> tuple[tuple[ReferenceRequirement, ...], list[str]]:
+    """Parse the optional literal metadata field without importing its packages."""
+    if value is None:
+        return (), []
+    if not isinstance(value, tuple):
+        return (), ["'reference_requirements' must be tuple"]
+    if not value:
+        return (), ["'reference_requirements' must not be empty when present"]
+
+    requirements: list[ReferenceRequirement] = []
+    errors: list[str] = []
+    packages: set[str] = set()
+    allowed = {"package", "import", "specifier", "git"}
+    for index, item in enumerate(value):
+        owner = f"reference_requirements[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{owner} must be dict")
+            continue
+        unknown = set(item) - allowed
+        if unknown:
+            errors.append(f"{owner} has unsupported field(s): {sorted(unknown)}")
+
+        package = item.get("package")
+        import_name = item.get("import")
+        specifier = item.get("specifier")
+        git_value = item.get("git")
+        if not isinstance(package, str) or not package:
+            errors.append(f"{owner}.package must be a non-empty string")
+        if not isinstance(import_name, str) or _IMPORT_NAME_PATTERN.fullmatch(import_name) is None:
+            errors.append(f"{owner}.import must be a canonical Python import name")
+        if specifier is None and git_value is None:
+            errors.append(f"{owner} requires at least one of 'specifier' or 'git'")
+
+        if specifier is not None:
+            if not isinstance(specifier, str) or not specifier:
+                errors.append(f"{owner}.specifier must be a non-empty PEP 440 string")
+            else:
+                try:
+                    SpecifierSet(specifier)
+                except InvalidSpecifier as error:
+                    errors.append(f"{owner}.specifier is invalid: {error}")
+
+        git = None
+        if git_value is not None:
+            if not isinstance(git_value, dict):
+                errors.append(f"{owner}.git must be dict")
+            else:
+                git_unknown = set(git_value) - {"url", "commit"}
+                if git_unknown:
+                    errors.append(f"{owner}.git has unsupported field(s): {sorted(git_unknown)}")
+                url = git_value.get("url")
+                commit = git_value.get("commit")
+                if not isinstance(url, str) or not url:
+                    errors.append(f"{owner}.git.url must be a non-empty string")
+                if (
+                    not isinstance(commit, str)
+                    or _FULL_GIT_COMMIT_PATTERN.fullmatch(commit) is None
+                ):
+                    errors.append(f"{owner}.git.commit must be a full lowercase Git SHA")
+                if isinstance(url, str) and url and isinstance(commit, str):
+                    git = GitRequirement(url=url, commit=commit)
+
+        if isinstance(package, str) and package:
+            canonical_package = canonicalize_name(package)
+            if canonical_package in packages:
+                errors.append(f"{owner}.package duplicates {package!r}")
+            packages.add(canonical_package)
+        if (
+            isinstance(package, str)
+            and package
+            and isinstance(import_name, str)
+            and _IMPORT_NAME_PATTERN.fullmatch(import_name) is not None
+        ):
+            requirements.append(
+                ReferenceRequirement(
+                    package=package,
+                    import_name=import_name,
+                    specifier=specifier if isinstance(specifier, str) and specifier else None,
+                    git=git,
+                )
+            )
+
+    if errors:
+        return (), errors
+    return tuple(requirements), []
+
+
+def _normalized_git_url(url: str) -> str:
+    value = url.strip()
+    if value.startswith("git@") and ":" in value:
+        authority, path = value.split(":", 1)
+        value = f"ssh://{authority}/{path}"
+    parsed = urlparse(value)
+    if parsed.scheme and parsed.hostname:
+        path = parsed.path.rstrip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        return f"{parsed.hostname.lower()}/{path.lstrip('/')}"
+    return value.removesuffix(".git").rstrip("/")
+
+
+def _git_checkout_info(path: Path) -> tuple[str, str] | None:
+    try:
+        root = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        commit = subprocess.run(
+            ["git", "-C", root, "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+        ).stdout.strip()
+        url = subprocess.run(
+            ["git", "-C", root, "remote", "get-url", "origin"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return url, commit
+
+
+def _direct_url(package: str) -> dict | None:
+    try:
+        payload = importlib.metadata.distribution(package).read_text("direct_url.json")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    if payload is None:
+        return None
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _git_identity(requirement: ReferenceRequirement, module_spec) -> tuple[str, str] | None:
+    direct = _direct_url(requirement.package)
+    if direct is not None:
+        vcs = direct.get("vcs_info")
+        url = direct.get("url")
+        if isinstance(vcs, dict) and isinstance(url, str):
+            commit = vcs.get("commit_id")
+            if isinstance(commit, str):
+                return url, commit
+        if isinstance(url, str):
+            parsed = urlparse(url)
+            if parsed.scheme == "file":
+                checkout = _git_checkout_info(Path(unquote(parsed.path)))
+                if checkout is not None:
+                    return checkout
+
+    origin = getattr(module_spec, "origin", None)
+    candidates = []
+    if isinstance(origin, str) and origin not in {"built-in", "frozen"}:
+        candidates.append(Path(origin).parent)
+    locations = getattr(module_spec, "submodule_search_locations", None)
+    if locations is not None:
+        candidates.extend(Path(location) for location in locations)
+    for candidate in candidates:
+        checkout = _git_checkout_info(candidate)
+        if checkout is not None:
+            return checkout
+    return None
+
+
+@cache
+def probe_reference_requirement(requirement: ReferenceRequirement) -> str | None:
+    """Return an unmet-requirement reason, or None when it is satisfied."""
+    try:
+        module_spec = importlib.util.find_spec(requirement.import_name)
+    except ModuleNotFoundError as error:
+        return f"{requirement.package}: import {requirement.import_name!r} is unavailable ({error})"
+    if module_spec is None:
+        return f"{requirement.package}: import {requirement.import_name!r} is unavailable"
+
+    if requirement.specifier is not None:
+        try:
+            installed = importlib.metadata.version(requirement.package)
+        except importlib.metadata.PackageNotFoundError:
+            return f"{requirement.package}: installed distribution version is unavailable"
+        accepted = SpecifierSet(requirement.specifier)
+        if not accepted.contains(installed, prereleases=True):
+            return (
+                f"{requirement.package}: requires {requirement.specifier}, "
+                f"installed version is {installed}"
+            )
+
+    if requirement.git is not None:
+        identity = _git_identity(requirement, module_spec)
+        if identity is None:
+            return f"{requirement.package}: Git source identity cannot be verified"
+        actual_url, actual_commit = identity
+        if _normalized_git_url(actual_url) != _normalized_git_url(requirement.git.url):
+            return (
+                f"{requirement.package}: requires Git URL {requirement.git.url}, "
+                f"installed source is {actual_url}"
+            )
+        if actual_commit.lower() != requirement.git.commit:
+            return (
+                f"{requirement.package}: requires Git commit {requirement.git.commit}, "
+                f"installed source is {actual_commit}"
+            )
+    return None
+
+
+def unmet_reference_requirements(value: object) -> tuple[str, ...]:
+    """Return every unmet reason for a validated literal metadata value."""
+    requirements, errors = parse_reference_requirements(value)
+    if errors:
+        raise ValueError("invalid reference requirements: " + "; ".join(errors))
+    return tuple(
+        reason
+        for requirement in requirements
+        if (reason := probe_reference_requirement(requirement)) is not None
+    )

--- a/tirx_kernels/registry.py
+++ b/tirx_kernels/registry.py
@@ -16,6 +16,7 @@ import importlib
 import io
 import logging
 import pkgutil
+import re
 import tokenize
 from dataclasses import dataclass
 from functools import lru_cache
@@ -23,6 +24,10 @@ from pathlib import Path
 from types import ModuleType
 
 import tirx_kernels
+from tirx_kernels.reference_requirements import ReferenceRequirement, parse_reference_requirements
+from tirx_kernels.reference_requirements import (
+    unmet_reference_requirements as _unmet_reference_requirements,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -32,7 +37,8 @@ _SKIP_CATEGORIES = frozenset({"bench", "test", "bench_suite", "experimental"})
 # Shared-helper subpackages inside a category — they hold no kernel modules.
 _SKIP_SUBPACKAGES = frozenset({"utils"})
 
-_REQUIRED_META_TYPES = {"name": str, "category": str, "compute_capability": int}
+_REQUIRED_META_TYPES = {"name": str, "category": str, "runtime_cuda_archs": list}
+_CUDA_ARCH_PATTERN = re.compile(r"sm_[1-9][0-9]*(?:a|f)?")
 
 
 @dataclass(frozen=True)
@@ -41,7 +47,8 @@ class KernelRecord:
 
     name: str
     category: str
-    compute_capability: int
+    runtime_cuda_archs: tuple[str, ...]
+    reference_requirements: tuple[ReferenceRequirement, ...]
     module_name: str
     source_path: Path
 
@@ -146,6 +153,27 @@ def _validate_meta(meta: object, *, category: str, owner: str) -> list[str]:
         errors.append(
             f"'category' is {meta.get('category')!r}, expected containing category {category!r}"
         )
+    if isinstance(meta.get("runtime_cuda_archs"), list):
+        runtime_cuda_archs = meta["runtime_cuda_archs"]
+        if not runtime_cuda_archs:
+            errors.append("'runtime_cuda_archs' must not be empty")
+        elif not all(isinstance(arch, str) for arch in runtime_cuda_archs):
+            errors.append("'runtime_cuda_archs' entries must be strings")
+        else:
+            invalid = [
+                arch for arch in runtime_cuda_archs if _CUDA_ARCH_PATTERN.fullmatch(arch) is None
+            ]
+            if invalid:
+                errors.append(
+                    "'runtime_cuda_archs' entries must be canonical sm_* strings: "
+                    + ", ".join(repr(arch) for arch in invalid)
+                )
+            if len(runtime_cuda_archs) != len(set(runtime_cuda_archs)):
+                errors.append("'runtime_cuda_archs' entries must be unique")
+    _requirements, requirement_errors = parse_reference_requirements(
+        meta.get("reference_requirements")
+    )
+    errors.extend(requirement_errors)
     return errors
 
 
@@ -184,7 +212,10 @@ def _build_kernel_index(
         record = KernelRecord(
             name=name,
             category=category,
-            compute_capability=meta["compute_capability"],
+            runtime_cuda_archs=tuple(meta.get("runtime_cuda_archs", ())),
+            reference_requirements=parse_reference_requirements(meta.get("reference_requirements"))[
+                0
+            ],
             module_name=module_name,
             source_path=path,
         )
@@ -224,11 +255,20 @@ def _import_record(record: KernelRecord, *, strict: bool) -> ModuleType | None:
             errors.append(
                 f"runtime name {meta.get('name')!r} does not match source index {record.name!r}"
             )
-        if meta.get("compute_capability") != record.compute_capability:
+        runtime_cuda_archs_value = meta.get("runtime_cuda_archs", ())
+        runtime_cuda_archs = (
+            tuple(runtime_cuda_archs_value) if isinstance(runtime_cuda_archs_value, list) else ()
+        )
+        if runtime_cuda_archs != record.runtime_cuda_archs:
             errors.append(
-                "runtime compute_capability "
-                f"{meta.get('compute_capability')!r} does not match source index "
-                f"{record.compute_capability!r}"
+                f"runtime runtime_cuda_archs {runtime_cuda_archs!r} does not match source index "
+                f"{record.runtime_cuda_archs!r}"
+            )
+        runtime_requirements = parse_reference_requirements(meta.get("reference_requirements"))[0]
+        if runtime_requirements != record.reference_requirements:
+            errors.append(
+                f"runtime reference_requirements {runtime_requirements!r} does not match "
+                f"source index {record.reference_requirements!r}"
             )
     if errors:
         message = f"{record.module_name} has invalid runtime KERNEL_META: " + "; ".join(errors)
@@ -264,23 +304,27 @@ def check_workload_imports(workloads: list[dict], *, strict: bool = True) -> lis
 
 
 def discover_kernels(
-    *, min_compute_capability: int | None = None, category: str | None = None, strict: bool = False
+    *, cuda_arch: str | None = None, category: str | None = None, strict: bool = False
 ) -> dict[str, ModuleType]:
     """Return ``{public_name: module}`` for all matching registered kernels."""
+    if cuda_arch is not None and _CUDA_ARCH_PATTERN.fullmatch(cuda_arch) is None:
+        raise ValueError(f"invalid exact CUDA architecture {cuda_arch!r}")
     records = kernel_index(strict=strict)
     result: dict[str, ModuleType] = {}
     for name, record in records.items():
         if category is not None and record.category != category:
             continue
-        if (
-            min_compute_capability is not None
-            and record.compute_capability != min_compute_capability
-        ):
+        if cuda_arch is not None and cuda_arch not in record.runtime_cuda_archs:
             continue
         module = _import_record(record, strict=strict)
         if module is not None:
             result[name] = module
     return result
+
+
+def unmet_reference_requirements(value: object) -> tuple[str, ...]:
+    """Public resolver for a literal ``KERNEL_META`` requirement tuple."""
+    return _unmet_reference_requirements(value)
 
 
 if __name__ == "__main__":
@@ -293,7 +337,7 @@ if __name__ == "__main__":
         "--format", choices=["text", "json", "benchrun"], default="text", help="Output format"
     )
     parser.add_argument("--category", type=str, default=None)
-    parser.add_argument("--cc", type=int, default=None, help="Compute capability filter")
+    parser.add_argument("--arch", type=str, default=None, help="Exact CUDA architecture filter")
     parser.add_argument(
         "--strict",
         action="store_true",
@@ -301,9 +345,9 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    all_kernels = discover_kernels(
-        min_compute_capability=args.cc, category=args.category, strict=args.strict
-    )
+    if args.arch is not None and _CUDA_ARCH_PATTERN.fullmatch(args.arch) is None:
+        parser.error("--arch must be a canonical architecture such as sm_100a")
+    all_kernels = discover_kernels(cuda_arch=args.arch, category=args.category, strict=args.strict)
 
     if args.format == "json":
         out = []
@@ -325,5 +369,6 @@ if __name__ == "__main__":
             n_configs = len(getattr(mod, "CONFIGS", []))
             print(
                 f"  {name:30s}  {meta.get('category', '?'):12s}  "
-                f"sm{meta.get('compute_capability', '?') * 10}  ({n_configs} configs)"
+                f"{','.join(meta.get('runtime_cuda_archs', ())) or '?':16s}  "
+                f"({n_configs} configs)"
             )

--- a/tirx_kernels/runner.py
+++ b/tirx_kernels/runner.py
@@ -35,6 +35,8 @@ PREPARE_NUM_SMS_ENV = "TIRX_PREPARE_NUM_SMS"
 PREPARE_CUDA_ARCH_ENV = "TIRX_PREPARE_CUDA_ARCH"
 TVM_FFI_DISABLE_TORCH_C_DLPACK_ENV = "TVM_FFI_DISABLE_TORCH_C_DLPACK"
 TVM_COMPILE_FORCE_FALLBACK_ENV = "TVM_COMPILE_FORCE_FALLBACK"
+TVM_CUDA_COMPILE_MODE_ENV = "TVM_CUDA_COMPILE_MODE"
+TVM_CUDA_NVRTC_EXTRA_OPTS_ENV = "TVM_CUDA_NVRTC_EXTRA_OPTS"
 _EXTERNAL_REFERENCES_ENV = "TIRX_INTERNAL_BENCH_REFERENCES"
 AB_CURRENT_BENCHMARK_ROOT_ENV = "TIRX_INTERNAL_AB_CURRENT_BENCHMARK_ROOT"
 _AB_CURRENT_MODULES: dict[tuple[Path, str], ModuleType] = {}
@@ -569,6 +571,24 @@ def _offline_nvcc_arch(arch: str) -> str | list[str]:
     return arch
 
 
+def _offline_cuda_compile_parameters(arch: str) -> dict[str, Any]:
+    """Select the same default CUDA compiler as TVM without initializing CUDA."""
+    compiler = os.environ.get(TVM_CUDA_COMPILE_MODE_ENV, "nvrtc").lower()
+    if compiler == "nvrtc":
+        return {"target_format": "cubin", "arch": arch, "options": None, "compiler": compiler}
+    if compiler == "nvcc":
+        options = shlex.split(os.environ.get(TVM_CUDA_NVRTC_EXTRA_OPTS_ENV, ""))
+        return {
+            "target_format": "fatbin",
+            "arch": _offline_nvcc_arch(arch),
+            "options": options or None,
+            "compiler": compiler,
+        }
+    raise ValueError(
+        f"Invalid {TVM_CUDA_COMPILE_MODE_ENV}: {compiler}. Expected 'nvcc' or 'nvrtc'."
+    )
+
+
 def _materialize_cuda_import(module: Any, target: tvm.target.Target) -> Any:
     """Compile one fallback CUDA source offline and rebuild a lazy runtime module."""
     if module.kind != "cuda" or module.is_runnable():
@@ -583,15 +603,8 @@ def _materialize_cuda_import(module: Any, target: tvm.target.Target) -> Any:
 
     from tvm.support.nvcc import compile_cuda
 
-    nvcc_options = shlex.split(os.environ.get("TVM_CUDA_NVRTC_EXTRA_OPTS", ""))
     with target:
-        compiled = compile_cuda(
-            source,
-            target_format="fatbin",
-            arch=_offline_nvcc_arch(target.arch),
-            options=nvcc_options or None,
-            compiler="nvcc",
-        )
+        compiled = compile_cuda(source, **_offline_cuda_compile_parameters(target.arch))
     serialized = tvm.ir.save_json(module)
     previous_callback = tvm.get_global_func("tvm_callback_cuda_compile")
 
@@ -739,12 +752,21 @@ def compile_kernel(func, *, arch: str | None = None, cuda_compile_mode: str | No
 
 def run_kernel_test(kernel_name: str, config: dict[str, Any], *, registry=None):
     """Delegate to a kernel's correctness test."""
+    from unittest import SkipTest
+
+    from tirx_kernels.reference_requirements import unmet_reference_requirements
+
     if registry is None:
         from tirx_kernels.registry import discover_kernels
 
         registry = discover_kernels()
 
     mod = registry[kernel_name]
+    unmet = unmet_reference_requirements(
+        getattr(mod, "KERNEL_META", {}).get("reference_requirements")
+    )
+    if unmet:
+        raise SkipTest("unsatisfied reference requirements: " + "; ".join(unmet))
     params = {k: v for k, v in config.items() if k != "label"}
     mod.run_test(**params)
 

--- a/tirx_kernels/test/__main__.py
+++ b/tirx_kernels/test/__main__.py
@@ -41,7 +41,7 @@ def main():
     parser.add_argument("--kernel", type=str, default=None, help="Run only this kernel")
     parser.add_argument("--config", type=str, default=None, help="Run only this config label")
     parser.add_argument("--json", action="store_true", help="Output JSON results")
-    parser.add_argument("--cc", type=int, default=None, help="Compute capability filter")
+    parser.add_argument("--arch", type=str, default=None, help="Exact CUDA architecture filter")
     parser.add_argument(
         "--num-gpus",
         type=int,
@@ -52,7 +52,7 @@ def main():
     if args.num_gpus is not None and args.num_gpus < 1:
         parser.error("--num-gpus must be positive")
 
-    all_kernels = discover_kernels(min_compute_capability=args.cc)
+    all_kernels = discover_kernels(cuda_arch=args.arch)
 
     if args.kernel:
         if args.kernel not in all_kernels:


### PR DESCRIPTION
## Summary

Rubin (SM107a) kernel ports, exact runtime-architecture registry metadata, and default kernel rosters for SM103a / SM107a.

This squashes the following changes:
- Record exact CUDA runtime architectures in the kernel registry
- Validate kernel registry on SM107 GPUs
- Port SM100 blk128 BSA backward to TIRx
- Port FlashInfer Rubin FP8 BMM to TIRx
- Port cuDNN GDN backward to TIRx
- Add exact runtime and reference dependency metadata
- Enable SM107a default kernels
- Enable SM103a default kernels
- Drop DSA backward defaults on sm_107a and the GDN bprop FP64 oracle

## Changes

- **Registry**: every kernel declares `runtime_cuda_archs` as exact architectures (sm_100a / sm_103a / sm_107a) plus reference-dependency metadata. `tirx_kernels.registry --strict` and the bench suite partition workloads by the device's exact architecture.
- **New ports**: FlashInfer Rubin FP8 batched GEMM (`bmm_fp8_rubin`, sm_107a), cuDNN GDN backward (`gdn_bprop_f16`), cuDNN SM100 blk128 block-sparse attention backward.
- **Defaults**: default rosters enabled on sm_103a and sm_107a. The DSA backward defaults are withdrawn on sm_107a because the pinned cuDNN-frontend reference `FlashAttentionDSABackwardSm100` has an order-dependent device-memory bug (documented with the Compute Sanitizer reproducer in its yaml).
- **Validation**: `gdn_bprop_f16` compares TIRx against the pinned source and the exact replay (FP64 oracle removed).

## Dependencies

Requires the TIRx PTX ISA 9.4 / CUDA 13.4 SM103a/SM107a support in TVM (apache/tvm#20261: https://github.com/apache/tvm/pull/20261).

## Verification

Verified on CUDA 13.4, 4x sm_107a:
- `bench-suite --check-imports`
- `tirx_kernels.registry --strict`
- `tests/`
- full tvm `tests/python/tirx` suite
