### PR TITLE
fix(cudnn): close backward kernel synchronization gaps

### DIFF
--- a/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/kernel.py
+++ b/tirx_kernels/cudnn/bsa/_block_sparse_attention_backward_sm100_blk128/kernel.py
@@ -451,15 +451,16 @@ def get_kernel(**config):
         smem_base = K.local_scalar("uint32")
         K.assign(smem_base, K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
         sp = K.specialize(chain_dispatch=True)
-        r_load = sp.role("load", warps=[13])
-        r_mma = sp.role("mma", warps=[12])
-        r_compute = sp.role("compute", warps=list(range(4, 12)))
-        r_reduce = sp.role("reduce", warps=list(range(4)))
-        r_idle = sp.role("idle", warps=[14])
-        r_empty = sp.role("empty", warps=[15])
+        # Roles 12-15 share physical warpgroup 3, so all four must execute the
+        # collective setmaxnreg transition with the same target.
+        r_load = sp.role("load", warps=[13], regs=88)
+        r_mma = sp.role("mma", warps=[12], regs=88)
+        r_compute = sp.role("compute", warps=list(range(4, 12)), regs=136)
+        r_reduce = sp.role("reduce", warps=list(range(4)), regs=152)
+        r_idle = sp.role("idle", warps=[14], regs=88)
+        r_empty = sp.role("empty", warps=[15], regs=88)
 
         with r_load:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(88))
             leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
             q_prod = K.PipelineState(2, phase=0)
             do_prod = K.PipelineState(1, phase=0)
@@ -572,7 +573,6 @@ def get_kernel(**config):
                 sum_pipe.empty.wait(do_prod.stage, do_prod.phase ^ 1)
 
         with r_mma:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(88))
             K.ptx[TMEM_ALLOC](
                 K.cuda.cvta_generic_to_shared(tmem_mailbox.ptr_to([0])), K.uint32(TMEM_COLUMNS)
             )
@@ -701,7 +701,6 @@ def get_kernel(**config):
             K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             K.ptx[TMEM_DEALLOC](tcol, K.uint32(TMEM_COLUMNS))
         with r_compute:
-            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(136))
             K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             tcol = K.local_scalar("uint32")
             K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
@@ -855,6 +854,10 @@ def get_kernel(**config):
                 bh = K.cast(batch_idx, "int64") * K.int64(heads) + K.cast(head, "int64")
                 for is_dk in (False, True):
                     dkdv_pipe.full.wait(dkdv_cons.stage, dkdv_cons.phase)
+                    # The completion wait orders TCGen's async shared-memory
+                    # reads.  Bridge that proxy before the compute warps reuse
+                    # the same Q/dO storage through generic shared stores.
+                    K.ptx.fence.proxy.async_.shared__cta()
                     tmem_offset = tmem_dk if is_dk else TMEM_DV
                     epi_base = off_sq if is_dk else off_sdo
                     if direct_dkv:
@@ -1008,7 +1011,6 @@ def get_kernel(**config):
                                 )
             K.ptx.bar.arrive(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
         with r_reduce:
-            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(152))
             K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             tcol = K.local_scalar("uint32")
             K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
@@ -1077,10 +1079,8 @@ def get_kernel(**config):
             K.ptx.bar.arrive(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
 
         with r_idle:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(24))
             pass
         with r_empty:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(24))
             pass
 
         required_block_size.__exit__(None, None, None)

--- a/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
@@ -1519,6 +1519,11 @@ def _make_main(
                             product0, product1, beta_rows[pair * 2], beta_rows[pair * 2 + 1]
                         )
                         K.assign(kk_pack[pair], _pack_io_pair(value0, value1, io_dtype))
+                    # A prior reverse iteration used this scratch for the
+                    # dgate reduction.  Delay only the next overwrite until
+                    # every CG0 warp has completed that reduction.
+                    with K.If(reverse_index > 0), K.Then():
+                        K.ptx.bar.sync(K.uint32(2), K.uint32(128))
                     for fragment in range(4):
                         _stmatrix_x4(
                             arena.ptr_to(
@@ -2072,10 +2077,6 @@ def _make_main(
                             gate_partial + dgate_sum,
                         )
 
-                    # The next reverse iteration writes a new KK tile into the
-                    # same scratch.  Keep all CG0 writers behind the 64-thread
-                    # reduction above, even when its next input was prefetched.
-                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
                     _arrive_barrier(arena, _BAR_GATE_DONE, gate_stage)
                     _arrive_barrier(arena, _BAR_BETA_DONE, beta_stage)
                 sched_consume(sched_state, tile)

--- a/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
@@ -1538,6 +1538,7 @@ def _make_main(
                                 kk_pack[fragment * 4 + 3],
                             ],
                         )
+                    _tcgen_wait_load()
                     with K.If(reverse_index < cend - first_state_chunk), K.Then():
                         _arrive_barrier(arena, _BAR_KK_DONE)
 
@@ -1577,6 +1578,7 @@ def _make_main(
                                 a_pack[fragment * 4 + 3],
                             ],
                         )
+                    _tcgen_wait_load()
                     K.ptx.fence.proxy.async_.shared__cta()
                     _arrive_barrier(arena, _BAR_A_READY, a_stage)
 
@@ -1690,61 +1692,60 @@ def _make_main(
                         _tcgen_wait_store()
                         _arrive_barrier(arena, _BAR_DQ_SCALE_DONE)
 
+                    state_dot = K.local_scalar("float32", init=K.float32(0.0))
                     with K.If(have_dstate), K.Then():
                         _wait_barrier(arena, _BAR_DSTATE_SMEM_READY, 0, dstate_smem_cursor.phase)
                         dstate_smem_cursor.advance()
-                    state_dot_lo = K.alloc_local((4,), "float32")
-                    state_dot_hi = K.alloc_local((4,), "float32")
-                    for word in range(4):
-                        K.assign(state_dot_lo[word], _opaque_zero())
-                        K.assign(state_dot_hi[word], _opaque_zero())
-                    for octet in range(16):
-                        dstate_words = K.alloc_local((4,), "uint32")
-                        state_words = K.alloc_local((4,), "uint32")
-                        K.ptx.ld.shared.v4.b32(
-                            dstate_words[0],
-                            dstate_words[1],
-                            dstate_words[2],
-                            dstate_words[3],
-                            arena.ptr_to([_state_byte(_DSTATE_BASE, cg0_thread, octet * 8)]),
-                        )
-                        K.ptx.ld.shared.v4.b32(
-                            state_words[0],
-                            state_words[1],
-                            state_words[2],
-                            state_words[3],
-                            arena.ptr_to([_state_byte(_STATE_BASE, cg0_thread, octet * 8)]),
-                        )
+                        state_dot_lo = K.alloc_local((4,), "float32")
+                        state_dot_hi = K.alloc_local((4,), "float32")
                         for word in range(4):
-                            dstate_value0 = K.local_scalar("float32")
-                            dstate_value1 = K.local_scalar("float32")
-                            state0 = K.local_scalar("float32")
-                            state1 = K.local_scalar("float32")
-                            _unpack_io_pair(
-                                dstate_words[word], dstate_value0, dstate_value1, io_dtype
+                            K.assign(state_dot_lo[word], _opaque_zero())
+                            K.assign(state_dot_hi[word], _opaque_zero())
+                        for octet in range(16):
+                            dstate_words = K.alloc_local((4,), "uint32")
+                            state_words = K.alloc_local((4,), "uint32")
+                            K.ptx.ld.shared.v4.b32(
+                                dstate_words[0],
+                                dstate_words[1],
+                                dstate_words[2],
+                                dstate_words[3],
+                                arena.ptr_to([_state_byte(_DSTATE_BASE, cg0_thread, octet * 8)]),
                             )
-                            _unpack_io_pair(state_words[word], state0, state1, io_dtype)
-                            next0, next1 = _ffma2(
-                                dstate_value0,
-                                dstate_value1,
-                                state0,
-                                state1,
-                                state_dot_lo[word],
-                                state_dot_hi[word],
+                            K.ptx.ld.shared.v4.b32(
+                                state_words[0],
+                                state_words[1],
+                                state_words[2],
+                                state_words[3],
+                                arena.ptr_to([_state_byte(_STATE_BASE, cg0_thread, octet * 8)]),
                             )
-                            K.assign(state_dot_lo[word], next0)
-                            K.assign(state_dot_hi[word], next1)
-                    state_dot = K.local_scalar(
-                        "float32",
-                        init=(
+                            for word in range(4):
+                                dstate_value0 = K.local_scalar("float32")
+                                dstate_value1 = K.local_scalar("float32")
+                                state0 = K.local_scalar("float32")
+                                state1 = K.local_scalar("float32")
+                                _unpack_io_pair(
+                                    dstate_words[word], dstate_value0, dstate_value1, io_dtype
+                                )
+                                _unpack_io_pair(state_words[word], state0, state1, io_dtype)
+                                next0, next1 = _ffma2(
+                                    dstate_value0,
+                                    dstate_value1,
+                                    state0,
+                                    state1,
+                                    state_dot_lo[word],
+                                    state_dot_hi[word],
+                                )
+                                K.assign(state_dot_lo[word], next0)
+                                K.assign(state_dot_hi[word], next1)
+                        K.assign(
+                            state_dot,
                             (state_dot_lo[0] + state_dot_lo[1])
                             + (state_dot_lo[2] + state_dot_lo[3])
                             + (state_dot_hi[0] + state_dot_hi[1])
-                            + (state_dot_hi[2] + state_dot_hi[3])
-                        ),
-                    )
-                    for distance in (1, 2, 4, 8, 16):
-                        K.assign(state_dot, state_dot + _shfl_bfly_f32(state_dot, distance))
+                            + (state_dot_hi[2] + state_dot_hi[3]),
+                        )
+                        for distance in (1, 2, 4, 8, 16):
+                            K.assign(state_dot, state_dot + _shfl_bfly_f32(state_dot, distance))
                     _arrive_barrier(arena, _BAR_STATE_DOT_DONE)
 
                     k_stage = K.local_scalar("int32", init=k_cursor.stage)
@@ -2025,6 +2026,11 @@ def _make_main(
                         K.Then(),
                     ):
                         K.assign(dgate_last, dgate_last + cumprod_total * state_dot)
+                    # All four CG0 warps read the shared KK tile through
+                    # ldmatrix above.  Do not let a faster warp reuse that
+                    # storage for the dgate reduction until every peer has
+                    # finished its read.
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
                     token0 = (lane // 4) * 8 + (lane % 4) * 2
                     K.ptx.st.shared.f32(
                         arena.ptr_to([_KK_BASE + (warp_in_group * 64 + token0) * 4]), dgate0
@@ -2067,6 +2073,10 @@ def _make_main(
                             gate_partial + dgate_sum,
                         )
 
+                    # The next reverse iteration writes a new KK tile into the
+                    # same scratch.  Keep all CG0 writers behind the 64-thread
+                    # reduction above, even when its next input was prefetched.
+                    K.ptx.bar.sync(K.uint32(2), K.uint32(128))
                     _arrive_barrier(arena, _BAR_GATE_DONE, gate_stage)
                     _arrive_barrier(arena, _BAR_BETA_DONE, beta_stage)
                 sched_consume(sched_state, tile)
@@ -2421,6 +2431,7 @@ def _make_main(
                             + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
                             packed,
                         )
+                    _tcgen_wait_load()
                     _tcgen_wait_store()
                     _arrive_barrier(arena, _BAR_DU_INP_READY)
 
@@ -2448,6 +2459,7 @@ def _make_main(
                                     ),
                                 )
                             store_col_fragment(_V_U_BASE, v_stage, sub, matrix_row, packed)
+                    _tcgen_wait_load()
                     K.ptx.fence.proxy.async_.shared__cta()
                     _arrive_barrier(arena, _BAR_U_READY)
 
@@ -2478,6 +2490,7 @@ def _make_main(
                             + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
                             dyp_pack,
                         )
+                    _tcgen_wait_load()
                     _tcgen_wait_store()
                     _arrive_barrier(arena, _BAR_DYP_INP_READY)
 
@@ -2591,6 +2604,7 @@ def _make_main(
                             arena.ptr_to([_DQ_BASE + (256 + warp_in_group * 64 + token0 + 1) * 4]),
                             part_g1,
                         )
+                    _tcgen_wait_load()
                     K.ptx.bar.sync(K.uint32(5), K.uint32(128))
                     with K.If(cg1_thread < 64), K.Then():
                         ysum = K.local_scalar("float32", init=K.float32(0.0))

--- a/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
@@ -1692,60 +1692,61 @@ def _make_main(
                         _tcgen_wait_store()
                         _arrive_barrier(arena, _BAR_DQ_SCALE_DONE)
 
-                    state_dot = K.local_scalar("float32", init=K.float32(0.0))
                     with K.If(have_dstate), K.Then():
                         _wait_barrier(arena, _BAR_DSTATE_SMEM_READY, 0, dstate_smem_cursor.phase)
                         dstate_smem_cursor.advance()
-                        state_dot_lo = K.alloc_local((4,), "float32")
-                        state_dot_hi = K.alloc_local((4,), "float32")
+                    state_dot_lo = K.alloc_local((4,), "float32")
+                    state_dot_hi = K.alloc_local((4,), "float32")
+                    for word in range(4):
+                        K.assign(state_dot_lo[word], _opaque_zero())
+                        K.assign(state_dot_hi[word], _opaque_zero())
+                    for octet in range(16):
+                        dstate_words = K.alloc_local((4,), "uint32")
+                        state_words = K.alloc_local((4,), "uint32")
+                        K.ptx.ld.shared.v4.b32(
+                            dstate_words[0],
+                            dstate_words[1],
+                            dstate_words[2],
+                            dstate_words[3],
+                            arena.ptr_to([_state_byte(_DSTATE_BASE, cg0_thread, octet * 8)]),
+                        )
+                        K.ptx.ld.shared.v4.b32(
+                            state_words[0],
+                            state_words[1],
+                            state_words[2],
+                            state_words[3],
+                            arena.ptr_to([_state_byte(_STATE_BASE, cg0_thread, octet * 8)]),
+                        )
                         for word in range(4):
-                            K.assign(state_dot_lo[word], _opaque_zero())
-                            K.assign(state_dot_hi[word], _opaque_zero())
-                        for octet in range(16):
-                            dstate_words = K.alloc_local((4,), "uint32")
-                            state_words = K.alloc_local((4,), "uint32")
-                            K.ptx.ld.shared.v4.b32(
-                                dstate_words[0],
-                                dstate_words[1],
-                                dstate_words[2],
-                                dstate_words[3],
-                                arena.ptr_to([_state_byte(_DSTATE_BASE, cg0_thread, octet * 8)]),
+                            dstate_value0 = K.local_scalar("float32")
+                            dstate_value1 = K.local_scalar("float32")
+                            state0 = K.local_scalar("float32")
+                            state1 = K.local_scalar("float32")
+                            _unpack_io_pair(
+                                dstate_words[word], dstate_value0, dstate_value1, io_dtype
                             )
-                            K.ptx.ld.shared.v4.b32(
-                                state_words[0],
-                                state_words[1],
-                                state_words[2],
-                                state_words[3],
-                                arena.ptr_to([_state_byte(_STATE_BASE, cg0_thread, octet * 8)]),
+                            _unpack_io_pair(state_words[word], state0, state1, io_dtype)
+                            next0, next1 = _ffma2(
+                                dstate_value0,
+                                dstate_value1,
+                                state0,
+                                state1,
+                                state_dot_lo[word],
+                                state_dot_hi[word],
                             )
-                            for word in range(4):
-                                dstate_value0 = K.local_scalar("float32")
-                                dstate_value1 = K.local_scalar("float32")
-                                state0 = K.local_scalar("float32")
-                                state1 = K.local_scalar("float32")
-                                _unpack_io_pair(
-                                    dstate_words[word], dstate_value0, dstate_value1, io_dtype
-                                )
-                                _unpack_io_pair(state_words[word], state0, state1, io_dtype)
-                                next0, next1 = _ffma2(
-                                    dstate_value0,
-                                    dstate_value1,
-                                    state0,
-                                    state1,
-                                    state_dot_lo[word],
-                                    state_dot_hi[word],
-                                )
-                                K.assign(state_dot_lo[word], next0)
-                                K.assign(state_dot_hi[word], next1)
-                        K.assign(
-                            state_dot,
+                            K.assign(state_dot_lo[word], next0)
+                            K.assign(state_dot_hi[word], next1)
+                    state_dot = K.local_scalar(
+                        "float32",
+                        init=(
                             (state_dot_lo[0] + state_dot_lo[1])
                             + (state_dot_lo[2] + state_dot_lo[3])
                             + (state_dot_hi[0] + state_dot_hi[1])
-                            + (state_dot_hi[2] + state_dot_hi[3]),
-                        )
-                        for distance in (1, 2, 4, 8, 16):
-                            K.assign(state_dot, state_dot + _shfl_bfly_f32(state_dot, distance))
+                            + (state_dot_hi[2] + state_dot_hi[3])
+                        ),
+                    )
+                    for distance in (1, 2, 4, 8, 16):
+                        K.assign(state_dot, state_dot + _shfl_bfly_f32(state_dot, distance))
                     _arrive_barrier(arena, _BAR_STATE_DOT_DONE)
 
                     k_stage = K.local_scalar("int32", init=k_cursor.stage)

--- a/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py
@@ -1538,7 +1538,6 @@ def _make_main(
                                 kk_pack[fragment * 4 + 3],
                             ],
                         )
-                    _tcgen_wait_load()
                     with K.If(reverse_index < cend - first_state_chunk), K.Then():
                         _arrive_barrier(arena, _BAR_KK_DONE)
 
@@ -1578,7 +1577,6 @@ def _make_main(
                                 a_pack[fragment * 4 + 3],
                             ],
                         )
-                    _tcgen_wait_load()
                     K.ptx.fence.proxy.async_.shared__cta()
                     _arrive_barrier(arena, _BAR_A_READY, a_stage)
 
@@ -2432,7 +2430,6 @@ def _make_main(
                             + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
                             packed,
                         )
-                    _tcgen_wait_load()
                     _tcgen_wait_store()
                     _arrive_barrier(arena, _BAR_DU_INP_READY)
 
@@ -2460,7 +2457,6 @@ def _make_main(
                                     ),
                                 )
                             store_col_fragment(_V_U_BASE, v_stage, sub, matrix_row, packed)
-                    _tcgen_wait_load()
                     K.ptx.fence.proxy.async_.shared__cta()
                     _arrive_barrier(arena, _BAR_U_READY)
 
@@ -2491,7 +2487,6 @@ def _make_main(
                             + K.shift_left(warp_in_group * 32 + sub * 16, K.int32(16)),
                             dyp_pack,
                         )
-                    _tcgen_wait_load()
                     _tcgen_wait_store()
                     _arrive_barrier(arena, _BAR_DYP_INP_READY)
 
@@ -2605,7 +2600,6 @@ def _make_main(
                             arena.ptr_to([_DQ_BASE + (256 + warp_in_group * 64 + token0 + 1) * 4]),
                             part_g1,
                         )
-                    _tcgen_wait_load()
                     K.ptx.bar.sync(K.uint32(5), K.uint32(128))
                     with K.If(cg1_thread < 64), K.Then():
                         ysum = K.local_scalar("float32", init=K.float32(0.0))


### PR DESCRIPTION
## Summary

Fix checker error-class synchronization issues in the SM100 BSA blk128 backward and GDN backward kernels.

Review-only diagnostics are intentionally left unchanged.

## Changes

### BSA backward blk128

- Make the `setmaxnreg` transition uniform across all four warps in physical warpgroup 3.
- Express register targets through specialization role metadata while preserving the existing compute and reduction allocations.
- Add an async-to-generic shared-memory proxy fence after `dkdv_pipe.full.wait`, before the Q/dO scratch storage is reused through generic stores.

### GDN backward

- Add a 128-thread CG0 barrier before reusing the previous KK tile as dgate partial scratch.
- Order the previous iteration's dgate reduction before the next `_KK_BASE` overwrite.
- Execute the cross-iteration barrier only for `reverse_index > 0` and place it immediately before the overwrite, avoiding an unnecessary barrier for single-chunk work items.

This PR intentionally does not:

- add TCGen load waits solely to silence `async_lifetime_not_drained` review findings;
- change the existing optional-state scratch behavior for `have_dstate == false`.

## Validation

Tested against TVM main `15b607d6`.

- BSA numerical/oracle: passed
- BSA Synccheck: clean
- BSA Racecheck: clean
- GDN Racecheck phase 0: clean, 32/32 tasks
- GDN Racecheck phase 1:
  - 0 errors
  - 12/12 tasks completed
  - no incomplete execution
  - existing review-only diagnostics remain
- GDN multi-iteration source comparison and deterministic replay passed with:
  - `seq_lens=(1, 63, 64, 65, 0)`
  - 193 tokens, 2 heads
- Ruff and `git diff --check`: passed

## Performance

B200 paired A/B, 15 rounds, with a strict `after / before < 1.01` direct gate:

| Kernel / config | Before | After | Change | Gate |
|---|---:|---:|---:|---|
| BSA p00 | 15.64 us | 15.35 us | +1.90% | PASS |
| BSA p02 | 416.12 us | 389.01 us | +6.51% | PASS |
| BSA p11 | 5554.12 us | 5562.25 us | -0.15% | PASS |
| GDN S2048 | 175.65 us | 176.81 us | -0.66% | PASS |
| GDN S8192 | 684.18 us | 688.79 us | -0.67% | PASS |
| GDN B4 S32768 H64 | 6457.96 us | 6449.27 us | +0.13% | PASS |

All six direct performance gates pass.