### PR TITLE
feat(kernel): port Cake VSA, FP4 FA4, fast.cu NVFP4 GEMM, SM107 block-scaled GEMM and GDN2 recompute

### DIFF
--- a/.agents/sketch/cudnn/sm100_gdn2_recompute_f16.md
+++ b/.agents/sketch/cudnn/sm100_gdn2_recompute_f16.md
@@ -1,0 +1,914 @@
+<!--
+Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Modifications Copyright (c) 2026 The TIRx Authors.
+SPDX-License-Identifier: Apache-2.0
+
+This design sketch documents a modified TIRx port of cuDNN Frontend's
+python/cudnn/linear_attention/frost/kernel/gdn2_recompute_f16.py at commit
+aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5.
+-->
+
+# cuDNN SM100 GDN2 FP16/BF16 recompute: coarse WASP pipeline sketch
+
+This is a non-executable operation sketch, not Python, a builder API, a new IR,
+or a mathematical reference. It freezes the source program before device-code
+transcription. The executable source of truth belongs in
+[`tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py`](../../../tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py).
+
+The frozen source is the standalone `chunk_gdn2_recompute_sm100` two-launch
+entry at the commit above. It is the state/checkpoint-only GDN2 path: BF16 or
+FP16 I/O, BF16 or FP32 state, `BT=16`, `DK=DV=128`, one CTA per cluster, 512
+main threads, 1024 prologue threads, and no Q or O operand. It supports absent
+or present initial/final state, optional checkpoints at a positive multiple of
+16 tokens, grouped K/V heads, ragged and zero-length sequences, natural-log or
+safe gate, optional K L2 normalization, optional beta sigmoid, split work rows,
+generated or caller-staged ordering, and static grid-stride or dynamic ticket
+scheduling. At least checkpoint or final-state output must be enabled.
+
+Writer evidence is under
+`.porting/gdn2_recompute_f16/source_export_ptx92/`. Both accepted source
+specializations declare PTX 9.2 and `sm_100a`; the main launch declares 512
+threads and the prologue 1024. The no-state/state main digests are respectively
+`4b94c20c6df31d8895dbc0d92cba2ec5a159ddc8fb5840bf6ce7831f5b3521f5`
+and `3c9f74f76c125330ddfc7414d502db8706329ce8374b28ea9717715631f1a98c`.
+The common prologue digest is
+`5bff2d1fbd4b6f6bfa58019af97dca70096d0472442db1811fd740e04468e1cd`.
+
+After the independent sketch reviewer returns PASS, this file is immutable.
+
+## Pipeline at a glance
+
+| Warps | Register cap | Source-order role | Principal publications |
+| --- | ---: | --- | --- |
+| 0..7 | 160 | two four-warp ping-pong CG0 groups; gate prefix, K normalization/beta, K inverse/decay/restore, state diagonal | raw done, decay ready, diagonal/QK ready |
+| 8..11 | 136 | CG1 state owner; seed/repack state, form `Y=W*V-state*(beta*K)`, repack U, stage checkpoints, store final state | state/Y/U inputs, checkpoint ready, TMEM done |
+| 12 | 56 | register MMA for `KK`, strict-lower `L`, and three Neumann-doubling rounds for `T_inv` | T-inverse and decay-super done |
+| 13 | 56 | allocate TMEM and issue four logical `tcgen05.mma` chains | state-K, state decay, U, state update |
+| 14 | 56 | persistent scheduler and five TensorMap GMEM-to-SMEM input loads | K/V/Gate/Beta/W ready |
+| 15 | 56 | checkpoint TensorMap store drain | checkpoint done |
+
+Dispatch order is exactly source order: warp 14, warp 12, warp 13, warp 15,
+warps 0..7, then warps 8..11. Each role has an independent persistent cursor.
+Its rolling stage/phase state starts once, advances across work-item boundaries,
+and is not reset for a new row.
+
+## Primitive vocabulary and transcription boundary
+
+All storage is one-dimensional. Matrix names below are semantic labels on
+scalar integer byte/row/column functions; they are never layout objects, views,
+tiles, fragments, or first-class mappings.
+
+```python
+linear_buffer(space, dtype, elements, byte_offset, alignment, lifetime)
+reg_array(dtype, elements)
+smem_byte(arena, base, stage, row, col,
+          stage_bytes, row_bytes, elem_bytes, xor_mask)
+tmem_cell(base_column, row, column)  # base_column + column + (row << 16)
+gmem_element(base, scalar_index)
+descriptor_slot(workspace, array, batch)  # (array*B+batch)*128 bytes
+```
+
+Movement uses only `copy_p2g`, `copy_g2s`, `copy_s2g`, `copy_g2r`,
+`copy_r2g`, `copy_s2r`, `copy_r2s`, `copy_t2r`, and `copy_r2t`. Computation
+uses only `fill`, `cast`, `add`, `sub`, `mul`, `fma`, `max`, `select`, `exp2`,
+`tanh`, `rsqrt`, `rcp`, `shuffle_xor`, and `gemm`. Barrier actions, fences,
+waits, commits, cursor advancement, register-budget changes, TensorMap field
+replacement, and TMEM lifecycle operations remain explicit schedule actions.
+
+The executable module imports device language only as
+`import tirx_kernels.kern as K`. It may use scalar K control flow, opaque
+TensorMaps, raw `K.ptx[...]`, rank-one shared storage, and integer descriptor
+assembly. It must not use direct TVM script namespaces, a tile primitive,
+`TilePrimitiveCall`, a first-class layout, rank>1 SMEM, `K.cuda.func_call`, or
+an inline-CUDA exemption. Nothing under `tirx_kernels/kern/` is modified.
+
+## Complete non-executable sketch
+
+```python
+@specialize(
+    IO_DTYPE={"bf16", "f16"}, STATE_DTYPE={"f32", "bf16"},
+    USE_INITIAL_STATE={False,True}, STORE_FINAL_STATE={False,True},
+    CHECKPOINTS={False,True}, L2NORM={False,True},
+    SAFE_GATE={False,True}, BETA_SIGMOID={False,True},
+    BT=16, DK=128, DV=128, ACC_DTYPE="f32",
+    RAW_STAGES=(4 if CHECKPOINTS else 5),
+    RAW_READY_STAGES=(4 if CHECKPOINTS else 6),
+    CHECKPOINT_STAGES=(2 if CHECKPOINTS else 1),
+    DECAY_STAGES=2, INTERMEDIATE_STAGES=2,
+    DIAG_STAGES=4, QK_READY_STAGES=4,
+    SCHED_STAGES=8, CLUSTER=(1,1,1),
+)
+def gdn2_recompute_factory(...):
+    return descriptor_order_prologue, persistent_gdn2_recompute
+
+# ========================================================================
+# Launch 1: source-order work table and six TensorMap descriptor arrays
+# ========================================================================
+
+@kernel(grid=(1,1,1), block=(1024,1,1), warps=32, target="sm_100a")
+def descriptor_order_prologue(
+    RUN_ORDER, ORDER_GENERATE, HAS_DYNAMIC_SCHEDULER, BT,
+    base_k, base_v, base_gate, base_beta, base_w, base_checkpoint,
+    descriptor_workspace, cu_seqlens,
+    k, v, gate, beta, w, checkpoints_or_dummy,
+    staging_items_or_dummy, work_count, work_items,
+    sched_all_or_dummy, batch_count,
+    k_row_stride, v_row_stride, gate_row_stride,
+    beta_row_stride, w_row_stride, checkpoint_row_stride,
+    checkpoint_every_n_tokens,
+):
+    tid = thread_id()
+    warp = tid // 32
+    arena = linear_buffer("smem", "u8", 32776, 0, 16, "whole launch")
+    order_key = integer_region(arena, 0, 4096, "i32")
+    order_idx = integer_region(arena, 16384, 4096, "i32")
+    order_spread = integer_region(arena, 32768, 2, "i32")
+
+    if tid == 0 and HAS_DYNAMIC_SCHEDULER:
+        for counter in range(sched_all_or_dummy.shape[0]):
+            copy_r2g(i32(0),sched_all_or_dummy[counter])
+            # instruction_selection: st.global.b32; extent: one scalar per
+            # iteration, serially covering the complete scheduler array
+
+    if RUN_ORDER:
+        n = batch_count*HO if ORDER_GENERATE else copy_g2r(work_count[0])
+        if ORDER_GENERATE and tid == 0:
+            copy_r2g(n, work_count[0])
+            # instruction_selection: st.global.b32; extent: one scalar
+        if n > 4096:
+            for item in range(tid,n,1024):
+                row = generate_uncut_row(item) if ORDER_GENERATE else copy_g2r(
+                    staging_items[item,0:8])
+                copy_r2g(row,work_items[item,0:8])
+                # instruction_selection: generated rows may use two
+                # st.global.v4.b32; staged rows retain scalar global loads and
+                # stores; extent: one eight-i32 work row
+        else:
+            if tid == 0:
+                copy_r2s(i32_max,order_spread[0])
+                copy_r2s(i32_min,order_spread[1])
+            padded = next_power_of_two(n)
+            barrier(0,1024)
+            # instruction_selection: barrier.sync 0,1024; extent: whole CTA
+            for element in range(4):
+                item=tid+1024*element
+                if item<padded:
+                    key=i32_min
+                    if item<n:
+                        row=generate_or_load_eight_fields(item)
+                        key=row_span(row)
+                    copy_r2s(key,order_key[item])
+                    copy_r2s(item,order_idx[item])
+            shared_atomic_minmax(order_spread,local_min,local_max)
+            # instruction_selection: atom.shared::cta.min/max.s32;
+            # extent: one pair per thread after four local items
+            barrier(0,1024)
+            # instruction_selection: barrier.sync 0,1024; extent: whole CTA
+            stable_lpt_bitonic_sort(order_key,order_idx,n,order_spread)
+            barrier(0,1024)
+            # instruction_selection: barrier.sync 0,1024; extent: whole CTA
+            for rank in range(tid,n,1024):
+                row=generate_or_load_eight_fields(copy_s2r(order_idx[rank]))
+                copy_r2g(row,work_items[rank,0:8])
+                # instruction_selection: global i32 load/store family;
+                # extent: one eight-i32 work row
+
+    base_maps=(base_k,base_v,base_gate,base_beta,base_w,base_checkpoint)
+    checkpoint_prefix=0
+    if warp<6 and elected_lane():
+        for batch in range(batch_count):
+            bos=copy_g2r(cu_seqlens[batch])
+            eos=copy_g2r(cu_seqlens[batch+1])
+            length=eos-bos
+            dst=descriptor_slot(descriptor_workspace,warp,batch)
+            copy_p2g(base_maps[warp],dst)
+            # instruction_selection: grid-constant parameter loads and sixteen
+            # st.global.b64 stores; extent: one 128-byte descriptor
+            if warp==5:
+                count=0 if length==0 else (length-1)//checkpoint_every_n_tokens+1
+                replace_global_address(dst,checkpoints_or_dummy+
+                                       checkpoint_prefix*checkpoint_row_stride)
+                replace_global_dim(dst,checkpoint_ordinal,count)
+                checkpoint_prefix+=count
+            else:
+                replace_global_address(dst,tensor_base(warp)+bos*row_stride(warp))
+                replace_global_dim(dst,sequence_ordinal(warp),length)
+        fence("tensormap_generic_release_gpu",warp)
+        # instruction_selection: tensormap.replace.tile.global_address/global_dim
+        # followed by fence.proxy.tensormap::generic.release.gpu;
+        # extent: one serial per-batch descriptor-array walk
+
+# ========================================================================
+# Launch 2 ABI, rank-one arena, exact offsets, and protocol
+# ========================================================================
+
+@kernel(grid=(MAX_ACTIVE_CLUSTERS,1,1), block=(512,1,1), warps=16,
+        cluster=(1,1,1), min_blocks_per_sm=1, target="sm_100a")
+def persistent_gdn2_recompute(
+    descriptor_workspace, n_desc,
+    k, v, gate, a_log_or_dummy, dt_bias_or_dummy, beta, w,
+    cu_seqlens, initial_state_or_dummy, final_state_or_dummy,
+    work_items, work_count, sched_counter_or_dummy,
+    checkpoint_every_n_tokens,
+):
+    tid=thread_id(); warp=warp_uniform(tid//32); lane=tid&31
+    cta=block_id_x(); grid_x=grid_dim_x(); total_tiles=copy_g2r(work_count[0])
+
+    def decode_work(tile):
+        row=copy_g2r(work_items[tile,0:8])
+        batch,head,wstart,wend,cstart,cend,bos,eos=row
+        return row_with_derived_fields(row,num_chunks=ceil_div(eos-bos,16))
+        # instruction_selection: role-projected global i32 loads; extent: one
+        # eight-field work row with only downstream-used fields retained
+
+    arena = linear_buffer(
+        "smem", "u8", 206848 if CHECKPOINTS else 165888,
+        0, 1024, "whole launch")
+
+    # Declaration-order protocol offsets for checkpoint / no-checkpoint.
+    # Tuple: name, ready offset, done offset, ready/done stages,
+    # ready/done arrivals, init owner.
+    CHECKPOINT_PROTOCOL=(
+      ("k",0,32,4,4,1,128,14), ("v",64,96,4,4,1,128,14),
+      ("w",128,160,4,4,1,128,14), ("gate",192,224,4,4,1,128,14),
+      ("beta",256,288,4,4,1,128,14),
+      ("state_k",320,None,1,0,1,None,13),
+      ("u_acc",328,None,1,0,1,None,13),
+      ("state_inp",336,None,1,0,128,None,13),
+      ("y_inp",344,None,1,0,128,None,13),
+      ("u_inp",352,None,1,0,128,None,13),
+      ("k_decay",360,376,2,2,128,1,12),
+      ("decay_super",392,None,2,0,32,None,13),
+      ("k_restore",408,None,2,0,1,None,13),
+      ("qk_scale",424,None,4,0,128,None,12),
+      ("diag_done",456,None,4,0,1,None,13),
+      ("t_inv",488,504,2,2,32,1,12),
+      ("state_read",520,None,1,0,128,None,15),
+      ("tmem_done",528,None,1,0,128,None,13),
+      ("checkpoint",536,552,2,2,128,32,15),
+      ("scheduler",568,632,8,8,1,15,15),
+    )
+    # With checkpoints disabled the same declaration order uses raw-ready
+    # depth six, raw data depth five, checkpoint depth one, and ends at byte
+    # 800 before the mailbox. The exact consecutive offsets are:
+    NO_CHECKPOINT_PROTOCOL=(
+      ("k",0,48),("v",88,136),("w",176,224),
+      ("gate",264,312),("beta",352,400),
+      ("state_k",440,None),("u_acc",448,None),("state_inp",456,None),
+      ("y_inp",464,None),("u_inp",472,None),
+      ("k_decay",480,496),("decay_super",512,None),
+      ("k_restore",528,None),("qk_scale",544,None),
+      ("diag_done",576,None),("t_inv",608,624),
+      ("state_read",640,None),("tmem_done",648,None),
+      ("checkpoint",656,664),("scheduler",672,736),
+    )
+
+    TMEM_MAILBOX=696 if CHECKPOINTS else 800
+    SCHED_BASE=704 if CHECKPOINTS else 816
+    if CHECKPOINTS:
+        K_DECAY_BASE=1024; K_RESTORE_BASE=9216; INTERMEDIATE_BASE=17408
+        K_RAW_BASE=18432; V_RAW_BASE=34816; GATE_RAW_BASE=51200
+        DIAG_BASE=83968; K_INV_BASE=100352; BETA_RAW_BASE=108544
+        W_RAW_BASE=124928; CHECKPOINT_BASE=141312
+    else:
+        K_DECAY_BASE=1024; K_RESTORE_BASE=9216; INTERMEDIATE_BASE=17408
+        K_RAW_BASE=18432; V_RAW_BASE=38912; GATE_RAW_BASE=59392
+        DIAG_BASE=100352; K_INV_BASE=116736; BETA_RAW_BASE=124928
+        W_RAW_BASE=145408; CHECKPOINT_BASE=V_RAW_BASE
+
+    # Payload bytes: K-decay 8192, K-restore 8192, intermediate 1024,
+    # K/V/Beta/W each RAW_STAGES*4096, Gate RAW_STAGES*8192,
+    # diagonal 16384, K-inverse 8192, checkpoint 65536 when enabled.
+    # All physical mappings use scalar SW128/SW32 XOR offset functions.
+
+    protocol=CHECKPOINT_PROTOCOL if CHECKPOINTS else NO_CHECKPOINT_PROTOCOL
+    pool=smem_pool(base=arena)
+    allocate_protocol_in_declaration_order(pool,protocol)
+    for i in range(tid,8192,512):
+        copy_r2s(cast(IO_DTYPE,0),arena[DIAG_BASE+2*i])
+        # instruction_selection: st.shared.u16; extent: strided diagonal arena
+
+    if warp==14: init_raw_ready_and_done(protocol)
+    elif warp==13: init_tcgen_owned_edges(protocol)
+    elif warp==12: init_register_mma_owned_edges(protocol)
+    elif warp==15: init_scheduler_checkpoint_and_state_read(protocol)
+    # instruction_selection: mbarrier.init.shared.b64; extent: 87 static
+    # sites in each accepted checkpoint PTX
+    fence("mbarrier_init_release_cluster")
+    # instruction_selection: fence.mbarrier_init.release.cluster;
+    # extent: one CTA initialization publication
+    barrier(0,512)
+    # instruction_selection: barrier.sync 0,512;
+    # extent: one CTA-wide synchronization
+
+    STATE_ACC=0; STATE_INPUT=128; STATE_K_ACC=192
+    U_ACC=208; Y_INPUT=224; U_INPUT=232
+    assert U_INPUT+8==240 and 240<=512
+
+    def wait_edge(name,stage,phase):
+        wait(protocol_ptr(name,stage),phase)
+        # instruction_selection:
+        # mbarrier.try_wait.parity.acquire.cta.shared::cta.b64;
+        # extent: one rolling edge wait
+    def arrive_edge(name,stage=0):
+        arrive(protocol_ptr(name,stage))
+        # instruction_selection: mbarrier.arrive.shared.b64;
+        # extent: one publication/return
+    def expect_edge(name,stage,nbytes):
+        expect_bytes(protocol_ptr(name,stage),nbytes)
+        # instruction_selection: mbarrier.arrive.expect_tx.shared.b64;
+        # extent: one TMA transaction start
+    def commit_edge(name,stage=0):
+        commit(protocol_ptr(name,stage))
+        # instruction_selection:
+        # tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64;
+        # extent: one logical GEMM publication
+
+    def scheduler_publish(cursor,tile):
+        if DYNAMIC:
+            wait_edge("scheduler_done",cursor.stage,cursor.phase)
+            if elected_lane():
+                ticket=atomic_add(sched_counter[0],1)
+                copy_r2s(grid_x+ticket,arena[SCHED_BASE+4*cursor.stage])
+                # instruction_selection: st.shared.b32;
+                # extent: one scheduler-ring cell
+            warp_sync()
+            # instruction_selection: bar.warp.sync 0xffffffff;
+            # extent: the scheduler-producer warp
+            next_tile=copy_s2r(arena[SCHED_BASE+4*cursor.stage])
+            # instruction_selection: ld.shared.b32;
+            # extent: one scheduler-ring cell after warp synchronization
+            if elected_lane(): arrive_edge("scheduler",cursor.stage)
+            return next_tile,advance(cursor)
+        return tile+grid_x,cursor
+        # instruction_selection: atom.global.add.u32 in dynamic mode;
+        # extent: one elected-lane ticket per completed work row
+
+    def scheduler_consume(cursor,tile):
+        if DYNAMIC:
+            wait_edge("scheduler",cursor.stage,cursor.phase)
+            next_tile=copy_s2r(arena[SCHED_BASE+4*cursor.stage])
+            # instruction_selection: ld.shared.b32;
+            # extent: one scheduler-ring cell after the ready wait
+            if elected_lane(): arrive_edge("scheduler_done",cursor.stage)
+            return next_tile,advance(cursor)
+        return tile+grid_x,cursor
+
+    # ====================================================================
+    # Warp 14: five raw TensorMap loads and scheduler producer
+    # ====================================================================
+    if warp==14:
+        set_register_budget("decrease",56)
+        raw=producer_cursor(RAW_STAGES,phase=1)
+        ready=producer_cursor(RAW_READY_STAGES,phase=0)
+        sched=producer_cursor(8,phase=1); tile=cta
+        while tile<total_tiles:
+            item=decode_work(tile)
+            kh=item.head if K_RATIO==1 else item.head//K_RATIO
+            vh=item.head if V_RATIO==1 else item.head//V_RATIO
+            for array in (K,V,GATE,BETA,W):
+                if elected_lane():
+                    acquire_descriptor(array,item.batch)
+                    # instruction_selection:
+                    # fence.proxy.tensormap::generic.acquire.gpu [descriptor],128;
+                    # extent: one 128-byte elected-lane acquire per active descriptor
+            for chunk in range(item.cstart,item.wend):
+                for name,array,head,nbytes,subtiles in (
+                    ("k",K,kh,4096,2),("v",V,vh,4096,2),
+                    ("beta",BETA,item.head,4096,2),
+                    ("w",W,item.head,4096,2),
+                    ("gate",GATE,item.head,8192,4)):
+                    wait_edge(name+"_done",raw.stage,raw.phase)
+                    if elected_lane(): expect_edge(name,ready.stage,nbytes)
+                    copy_g2s(descriptor(array,item.batch),
+                             raw_stage_base(name,raw.stage),
+                             (0,head,chunk*16),
+                             completion=protocol_ptr(name,ready.stage))
+                    # instruction_selection:
+                    # cp.async.bulk.tensor.3d.shared::cta.global.tile
+                    # .mbarrier::complete_tx::bytes; extent: two 64-channel
+                    # subtiles for K/V/Beta/W, four 32-channel subtiles for Gate
+                raw=advance(raw); ready=advance(ready)
+            tile,sched=scheduler_publish(sched,tile)
+
+    # ====================================================================
+    # Warp 12: register KK and T-inverse
+    # ====================================================================
+    elif warp==12:
+        set_register_budget("decrease",56)
+        sched=consumer_cursor(8,phase=0); serial_base=0; tile=cta
+        while tile<total_tiles:
+            item=decode_work(tile)
+            for local_chunk in range(item.wend-item.cstart):
+                serial=serial_base+local_chunk
+                decay_stage=serial%2; inter_stage=serial%2
+                wait_edge("k_decay",decay_stage,(serial//2)&1)
+                kk=fill(reg_array("f32",8),0)
+                for k_block in range(8):
+                    lhs=copy_s2r(k_decay_ldmatrix_address(decay_stage,k_block,lane))
+                    rhs=copy_s2r(k_inverse_ldmatrix_address(decay_stage,k_block,lane))
+                    # instruction_selection:
+                    # ldmatrix.sync.aligned.m8n8.x4.shared.b16;
+                    # extent: one A and one B fragment per k block
+                    gemm(kk,lhs,rhs,accumulate=k_block>0)
+                    # instruction_selection: two
+                    # mma.sync.aligned.m16n8k16.row.col.f32.{f16|bf16}.{f16|bf16}.f32;
+                    # extent: sixteen instructions over eight k blocks
+                L=select(strict_lower_fragment(lane),kk,0)
+                Lpacked=cast(IO_DTYPE,L)
+                Tinv=identity_fragment(lane)-cast("f32",Lpacked)
+                Lpow=Lpacked
+                moved=[move_matrix(Lpow[pair]) for pair in range(4)]
+                # instruction_selection: four
+                # movmatrix.sync.aligned.m8n8.trans.b16; extent: initial Lpow
+                for round in range(3):
+                    Lpow=cast(IO_DTYPE,gemm(Lpow,moved))
+                    moved=[move_matrix(Lpow[pair]) for pair in range(4)]
+                    Tround=cast(IO_DTYPE,Tinv)
+                    Tinv=cast("f32",Tround)+gemm(Tround,moved)
+                    # instruction_selection: four movmatrix and four
+                    # mma.sync sites per round plus packed conversion/add;
+                    # extent: twelve MMA and twelve moved fragments
+                wait_edge("t_inv_done",inter_stage,(serial//2+1)&1)
+                copy_r2s(cast(IO_DTYPE,Tinv),tinv_stmatrix_address(inter_stage,lane))
+                # instruction_selection: stmatrix.sync.aligned.m8n8.x4.shared.b16;
+                # extent: one complete 16x16 T-inverse
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta;
+                # extent: T-inverse shared-store publication
+                arrive_edge("t_inv",inter_stage)
+                arrive_edge("decay_super",decay_stage)
+            serial_base+=item.wend-item.cstart
+            tile,sched=scheduler_consume(sched,tile)
+
+    # ====================================================================
+    # Warp 13: TMEM allocation and four logical tcgen05 chains
+    # ====================================================================
+    elif warp==13:
+        set_register_budget("decrease",56)
+        allocate_tmem_warp_level(TMEM_MAILBOX,columns=512,cta_group=1)
+        # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32;
+        # extent: one warp-level allocation
+        barrier(3,160)
+        # instruction_selection: barrier.sync 3,160; extent: warp 13 and all
+        # four CG1 warps
+        tmem_base=copy_s2r(arena[TMEM_MAILBOX:TMEM_MAILBOX+4])
+        # instruction_selection: ld.shared.b32; extent: one mailbox load per
+        # warp-13 lane after allocation publication
+        sched=consumer_cursor(8,phase=0); serial_base=0; tile=cta
+        state_inp=consumer_cursor(1,phase=0)
+        state_read=consumer_cursor(1,phase=0)
+        y_inp=consumer_cursor(1,phase=0); u_inp=consumer_cursor(1,phase=0)
+        diag=consumer_cursor(4,phase=0)
+        while tile<total_tiles:
+            item=decode_work(tile)
+            for local_chunk in range(item.wend-item.cstart):
+                serial=serial_base+local_chunk
+                have_state=USE_INITIAL_STATE or local_chunk>0
+                decay_stage=serial%2; inter_stage=serial%2
+                wait_edge("k_decay",decay_stage,(serial//2)&1)
+                if have_state:
+                    wait_edge("state_inp",0,state_inp.phase); state_inp=advance(state_inp)
+                    for kphase in range(8):
+                        gemm(tmem_cell(tmem_base,0,STATE_K_ACC),
+                             tmem_state_input_subtile(kphase),
+                             smem_k_decay_subtile(decay_stage,kphase),
+                             accumulate=kphase>0)
+                    # instruction_selection: eight
+                    # tcgen05.mma.cta_group::1.kind::f16.collector::a::discard;
+                    # extent: 128x16x128
+                    commit_edge("state_k")
+                commit_edge("decay_tcgen05",decay_stage)
+
+                if CHECKPOINTS and have_state:
+                    wait_edge("state_read",0,state_read.phase); state_read=advance(state_read)
+                wait_edge("qk_scale",diag.stage,diag.phase)
+                if have_state:
+                    for key_block in range(8):
+                        gemm(tmem_cell(tmem_base,0,STATE_ACC+16*key_block),
+                             tmem_state_input_block(key_block),
+                             smem_diag_block(diag.stage,key_block),False)
+                    # instruction_selection: eight
+                    # tcgen05.mma.cta_group::1.kind::f16.collector::a::discard;
+                    # extent: eight
+                    # independent 128x16x16 diagonal-block products
+                commit_edge("diag_done",diag.stage)
+
+                wait_edge("t_inv",inter_stage,(serial//2)&1)
+                wait_edge("y_inp",0,y_inp.phase); y_inp=advance(y_inp)
+                gemm(tmem_cell(tmem_base,0,U_ACC),tmem_y_input(),
+                     smem_tinv(inter_stage),False)
+                # instruction_selection: one
+                # tcgen05.mma.cta_group::1.kind::f16.collector::a::discard;
+                # extent: 128x16x16
+                commit_edge("u_acc"); commit_edge("t_inv_done",inter_stage)
+
+                wait_edge("u_inp",0,u_inp.phase); u_inp=advance(u_inp)
+                gemm(tmem_cell(tmem_base,0,STATE_ACC),tmem_u_input(),
+                     smem_k_restore(decay_stage),accumulate=have_state)
+                # instruction_selection: one
+                # tcgen05.mma.cta_group::1.kind::f16.collector::a::discard;
+                # extent: 128x128x16
+                commit_edge("k_restore",decay_stage)
+                diag=advance(diag)
+            serial_base+=item.wend-item.cstart
+            tile,sched=scheduler_consume(sched,tile)
+        wait_edge("tmem_done",0,0)
+        relinquish_tmem_alloc_permit(cta_group=1)
+        deallocate_tmem(tmem_base,columns=512,cta_group=1)
+        # instruction_selection: tcgen05.relinquish_alloc_permit and
+        # tcgen05.dealloc.cta_group::1.sync.aligned.b32; extent: one teardown
+
+    # ====================================================================
+    # Warp 15: checkpoint TensorMap store drain
+    # ====================================================================
+    elif warp==15:
+        set_register_budget("decrease",56)
+        sched=consumer_cursor(8,phase=0)
+        ready=consumer_cursor(CHECKPOINT_STAGES,phase=0); tile=cta
+        while tile<total_tiles:
+            item=decode_work(tile)
+            if CHECKPOINTS:
+                if elected_lane():
+                    acquire_descriptor(CHECKPOINT,item.batch)
+                    # instruction_selection:
+                    # fence.proxy.tensormap::generic.acquire.gpu [descriptor],128;
+                    # extent: one 128-byte elected-lane acquire per work row
+                cadence_chunks=checkpoint_every_n_tokens//16
+                quotient=(item.cstart+1)//cadence_chunks
+                modulo=(item.cstart+1)%cadence_chunks
+                if item.wend>item.cstart and item.wstart==0:
+                    stage=ready.stage; wait_edge("checkpoint",stage,ready.phase)
+                    ready=advance(ready)
+                    copy_s2g(checkpoint_stage_base(stage),
+                             checkpoint_coord(item.head,0))
+                    # instruction_selection:
+                    # cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group;
+                    # extent: two 64-key subtiles over a 128x128 state
+                    store_commit()
+                    # instruction_selection: cp.async.bulk.commit_group;
+                    # extent: one checkpoint store group
+                    store_wait_group(0)
+                    # instruction_selection: cp.async.bulk.wait_group.read 0;
+                    # extent: drain the checkpoint store group
+                    arrive_edge("checkpoint_done",stage)
+                for local_chunk in range(1,item.wend-item.cstart):
+                    chunk=item.cstart+local_chunk
+                    if modulo==0 and chunk>=item.wstart:
+                        stage=ready.stage; wait_edge("checkpoint",stage,ready.phase)
+                        ready=advance(ready)
+                        copy_s2g(checkpoint_stage_base(stage),
+                                 checkpoint_coord(item.head,quotient))
+                        # instruction_selection: same rank-4 bulk-group TMA
+                        # store family; extent: two 64-key subtiles
+                        store_commit()
+                        # instruction_selection: cp.async.bulk.commit_group;
+                        # extent: one checkpoint store group
+                        store_wait_group(0)
+                        # instruction_selection: cp.async.bulk.wait_group.read 0;
+                        # extent: drain the checkpoint store group
+                        arrive_edge("checkpoint_done",stage)
+                    modulo+=1
+                    if modulo==cadence_chunks: modulo=0; quotient+=1
+            tile,sched=scheduler_consume(sched,tile)
+
+    # ====================================================================
+    # Warps 0..7: two four-warp CG0 groups
+    # ====================================================================
+    elif 0<=warp<=7:
+        set_register_budget("increase",160)
+        group=warp//4; local_warp=warp%4
+        prefix_dim=local_warp*32+lane
+        sched=consumer_cursor(8,phase=0); serial_base=0; tile=cta
+        while tile<total_tiles:
+            item=decode_work(tile)
+            if SAFE_GATE and item.wend>item.cstart:
+                aexp=exp2(copy_g2r(a_log[item.head])*LOG2_E)
+                dbias=copy_g2r(dt_bias[item.head,prefix_dim])
+            barrier(5,256)
+            # instruction_selection: barrier.sync 5,256; extent: both CG0
+            # ping-pong groups at work-item entry
+            for local_chunk in range(group,item.wend-item.cstart,2):
+                serial=serial_base+local_chunk
+                raw_stage=rolling_data_stage_from_group(serial,RAW_STAGES)
+                ready_stage=rolling_ready_stage_from_group(serial,RAW_READY_STAGES)
+                decay_stage=serial%2; diag_stage=serial%4
+                wait_edge("gate",ready_stage,ready_phase(serial))
+                gates=copy_s2r(gate_fragment(raw_stage,local_warp,lane))
+                if SAFE_GATE:
+                    gates=select(valid_rows,
+                        GATE_SCALE_LOG2*(tanh(aexp*(gates+dbias)*0.5)*0.5+0.5),0)
+                else:
+                    gates=select(valid_rows,gates*LOG2_E,0)
+                # instruction_selection: vector shared f32 loads, fma/mul,
+                # tanh.approx where enabled, and predicates; extent: 16 rows
+                prefix=inclusive_scan_16_in_source_pair_order(gates)
+                # instruction_selection: packed add.rn.f32x2 plus scalar
+                # add.f32 in eight row pairs; extent: one channel scan
+                exp_prefix=exp2(prefix); exp_last=exp_prefix[15]
+                # instruction_selection: ex2.approx.ftz.f32; extent: 16 values
+                copy_r2s(exp_prefix,gate_fragment(raw_stage,local_warp,lane))
+                # instruction_selection: vector shared f32 stores; extent: 16
+                wait_edge("diag_done",diag_stage,(serial//4+1)&1)
+                copy_r2s(cast(IO_DTYPE,exp_last),diagonal_cell(diag_stage,prefix_dim))
+                # instruction_selection: cvt.rn.{bf16|f16}.f32 and st.shared.u16;
+                # extent: one diagonal element per lane
+                barrier(1+group,128)
+                # instruction_selection: barrier.sync {1|2},128; extent: the
+                # selected four-warp CG0 group
+
+                wait_edge("k",ready_stage,ready_phase(serial))
+                wait_edge("beta",ready_stage,ready_phase(serial))
+                raw_k,raw_beta=copy_two_x8_vectors(raw_stage,local_warp,lane)
+                # instruction_selection: ld.shared.v4.b32; extent: two
+                # 64-channel halves for K and Beta
+                if BETA_SIGMOID:
+                    raw_beta=cast("f32",cast(IO_DTYPE,
+                        tanh(raw_beta*0.5)*0.5+0.5))
+                if L2NORM:
+                    norm=rsqrt(max(group_sum_source_order(raw_k*raw_k),EPS2))
+                    # instruction_selection: fma.rn.f32, shfl.sync.bfly.b32 at
+                    # XOR 4/2/1, max.f32, rsqrt.approx.ftz.f32; extent: one
+                    # 128-channel norm per token row
+                else: norm=opaque_one()
+
+                wait_edge("decay_super",decay_stage,(serial//2+1)&1)
+                wait_edge("decay_tcgen05",decay_stage,(serial//2+1)&1)
+                k_norm=cast(IO_DTYPE,raw_k*norm)
+                k_decay=packed_mul(cast(IO_DTYPE,cast("f32",k_norm)*raw_beta),
+                                   cast(IO_DTYPE,exp_prefix))
+                k_inv=packed_mul(k_norm,cast(IO_DTYPE,rcp(exp_prefix)))
+                copy_r2s(k_decay,k_decay_sw128(decay_stage))
+                copy_r2s(k_inv,k_inverse_sw128(decay_stage))
+                # instruction_selection: packed f16x2/bf16x2 multiply,
+                # st.shared.v4.b32; extent: two eight-value halves
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta;
+                # extent: K-decay and K-inverse shared-store publication
+                arrive_edge("k_decay",decay_stage)
+                arrive_edge("k_done",raw_stage)
+                arrive_edge("gate_done",raw_stage)
+                arrive_edge("beta_done",raw_stage)
+
+                wait_edge("k_restore",decay_stage,(serial//2+1)&1)
+                k_restore=packed_mul(k_inv,cast(IO_DTYPE,exp_last))
+                copy_r2s(k_restore,k_restore_sw128_transposed(decay_stage))
+                # instruction_selection: packed f16x2/bf16x2 multiply and
+                # st.shared.v4.b32; extent: two eight-value halves
+                fence("async_shared_cta")
+                # instruction_selection: fence.proxy.async.shared::cta;
+                # extent: K-restore shared-store publication
+                arrive_edge("qk_scale",diag_stage)
+                advance_group_owned_raw_and_diag_cursors_by_two()
+            serial_base+=item.wend-item.cstart
+            tile,sched=scheduler_consume(sched,tile)
+
+    # ====================================================================
+    # Warps 8..11: state, Y/U, checkpoint staging, and final state
+    # ====================================================================
+    elif 8<=warp<=11:
+        set_register_budget("increase",136)
+        barrier(3,160)
+        # instruction_selection: barrier.sync 3,160; extent: warp 13 and all
+        # four CG1 warps
+        tmem_base=copy_s2r(arena[TMEM_MAILBOX:TMEM_MAILBOX+4])
+        # instruction_selection: ld.shared.b32; extent: one mailbox load per
+        # CG1 lane after allocation publication
+        value_dim=(warp-8)*32+lane
+        sched=consumer_cursor(8,phase=0)
+        checkpoint_done=producer_cursor(CHECKPOINT_STAGES,phase=1)
+        state_k=consumer_cursor(1,phase=0); u_acc=consumer_cursor(1,phase=0)
+        k_restore=consumer_cursor(2,phase=0)
+        raw=consumer_cursor(RAW_STAGES,phase=0)
+        ready=consumer_cursor(RAW_READY_STAGES,phase=0)
+        tile=cta
+        while tile<total_tiles:
+            item=decode_work(tile); chunks=item.wend-item.cstart
+            if chunks>0:
+                if USE_INITIAL_STATE:
+                    if item.cstart==0:
+                        state=copy_g2r(initial_state[
+                            item.batch,item.head,value_dim,0:128])
+                    else: state=fill(reg_array("f32",128),0)
+                    copy_r2t(state,tmem_state_rows(value_dim))
+                    # instruction_selection: vector global loads and four
+                    # tcgen05.st.sync.aligned.32x32b.x32.b32; extent: 128 FP32
+                    wait_tmem_store()
+                    # instruction_selection: tcgen05.wait::st.sync.aligned;
+                    # extent: all preceding seed stores
+                    state=copy_t2r(tmem_state_rows(value_dim))
+                    # instruction_selection: eight
+                    # tcgen05.ld.sync.aligned.32x32b.x16.b32; extent: state row
+                    packed=cast(IO_DTYPE,state,source_pair_xor=4)
+                    copy_r2t(packed,tmem_state_input_rows(value_dim))
+                    # instruction_selection: eight
+                    # tcgen05.st.sync.aligned.32x32b.x8.b32; extent: packed row
+                    wait_tmem_store()
+                    # instruction_selection: tcgen05.wait::st.sync.aligned;
+                    # extent: all preceding packed-state stores
+                    arrive_edge("state_inp")
+                    if CHECKPOINTS and item.wstart==0:
+                        cp=checkpoint_done.stage
+                        wait_edge("checkpoint_done",cp,checkpoint_done.phase)
+                        checkpoint_done=advance(checkpoint_done)
+                        copy_r2s(cast(IO_DTYPE,state),checkpoint_stage_rows(cp,value_dim))
+                        # instruction_selection: st.shared.v4.b32; extent:
+                        # 128 state values per value row in SW128 order
+                        wait_tmem_load()
+                        # instruction_selection: tcgen05.wait::ld.sync.aligned;
+                        # extent: all preceding state loads
+                        fence("async_shared_cta")
+                        # instruction_selection: fence.proxy.async.shared::cta;
+                        # extent: checkpoint shared-store publication
+                        arrive_edge("checkpoint",cp)
+                    if CHECKPOINTS: arrive_edge("state_read")
+                elif CHECKPOINTS and item.wstart==0:
+                    cp=checkpoint_done.stage
+                    wait_edge("checkpoint_done",cp,checkpoint_done.phase)
+                    checkpoint_done=advance(checkpoint_done)
+                    copy_r2s(cast(IO_DTYPE,0),checkpoint_stage_rows(cp,value_dim))
+                    # instruction_selection: st.shared.v4.b32 zero stores;
+                    # extent: one complete zero checkpoint
+                    fence("async_shared_cta")
+                    # instruction_selection: fence.proxy.async.shared::cta;
+                    # extent: zero-checkpoint shared-store publication
+                    arrive_edge("checkpoint",cp)
+
+                for local_chunk in range(chunks):
+                    serial=global_serial_for_role(local_chunk)
+                    if local_chunk>0:
+                        state_repack=copy_t2r(
+                            tmem_state_rows_x16(value_dim,blocks=8))
+                        # instruction_selection:
+                        # tcgen05.ld.sync.aligned.32x32b.x16.b32; extent:
+                        # eight 16-key blocks for one value row
+                        packed=cast(IO_DTYPE,state_repack,source_pair_xor=4)
+                        copy_r2t(packed,tmem_state_input_rows(value_dim))
+                        # instruction_selection:
+                        # tcgen05.st.sync.aligned.32x32b.x8.b32; extent:
+                        # eight 16-key blocks
+                        wait_tmem_store()
+                        # instruction_selection: tcgen05.wait::st.sync.aligned;
+                        # extent: all preceding packed-state stores
+                        arrive_edge("state_inp")
+                        if CHECKPOINTS and checkpoint_boundary(item.cstart+local_chunk) \
+                           and item.cstart+local_chunk>=item.wstart:
+                            cp=checkpoint_done.stage
+                            wait_edge("checkpoint_done",cp,checkpoint_done.phase)
+                            checkpoint_done=advance(checkpoint_done)
+                            checkpoint_state=copy_t2r(
+                                tmem_state_rows_x32(value_dim,blocks=4))
+                            # instruction_selection:
+                            # tcgen05.ld.sync.aligned.32x32b.x32.b32;
+                            # extent: four distinct 32-key rereads after the
+                            # state-input publication
+                            copy_r2s(cast(IO_DTYPE,checkpoint_state),
+                                     checkpoint_stage_rows(cp,value_dim))
+                            wait_tmem_load()
+                            # instruction_selection:
+                            # tcgen05.wait::ld.sync.aligned; extent: all four
+                            # checkpoint rereads
+                            arrive_edge("state_read")
+                            fence("async_shared_cta")
+                            # instruction_selection:
+                            # fence.proxy.async.shared::cta; extent:
+                            # checkpoint shared-store publication
+                            arrive_edge("checkpoint",cp)
+                        elif CHECKPOINTS: arrive_edge("state_read")
+
+                    wait_edge("v",ready.stage,ready.phase)
+                    raw_v=copy_s2r(v_ldmatrix_transposed(raw.stage,value_dim,lane))
+                    wait_edge("w",ready.stage,ready.phase)
+                    raw_w=copy_s2r(w_ldmatrix_transposed(raw.stage,value_dim,lane))
+                    # instruction_selection: four
+                    # ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 sites;
+                    # extent: two value halves for V and W
+                    if USE_INITIAL_STATE or local_chunk>0:
+                        wait_edge("state_k",0,state_k.phase); state_k=advance(state_k)
+                        erase=copy_t2r(tmem_state_k_rows(value_dim))
+                        # instruction_selection: two
+                        # tcgen05.ld.sync.aligned.16x256b.x2.b32; extent: 16 tokens
+                        y=packed_sub(packed_mul(raw_w,raw_v),cast(IO_DTYPE,erase))
+                    else: y=packed_mul(raw_w,raw_v)
+                    copy_r2t(y,tmem_y_input_rows(value_dim))
+                    # instruction_selection: two
+                    # tcgen05.st.sync.aligned.16x128b.x2.b32; extent: 16 tokens
+                    wait_tmem_store()
+                    # instruction_selection: tcgen05.wait::st.sync.aligned;
+                    # extent: the two preceding Y stores
+                    arrive_edge("v_done",raw.stage)
+                    arrive_edge("w_done",raw.stage); arrive_edge("y_inp")
+
+                    wait_edge("u_acc",0,u_acc.phase); u_acc=advance(u_acc)
+                    u=copy_t2r(tmem_u_rows(value_dim))
+                    # instruction_selection:
+                    # tcgen05.ld.sync.aligned.32x32b.x16.b32; extent: 16 FP32
+                    copy_r2t(cast(IO_DTYPE,u,source_pair_xor=4),
+                             tmem_u_input_rows(value_dim))
+                    # instruction_selection:
+                    # tcgen05.st.sync.aligned.32x32b.x8.b32; extent: 16 packed
+                    wait_tmem_store()
+                    # instruction_selection: tcgen05.wait::st.sync.aligned;
+                    # extent: the preceding packed-U store
+                    arrive_edge("u_inp")
+                    wait_edge("k_restore",k_restore.stage,k_restore.phase)
+                    k_restore=advance(k_restore); raw=advance(raw); ready=advance(ready)
+
+                if STORE_FINAL_STATE and item.wend==item.num_chunks:
+                    state=copy_t2r(tmem_state_rows(value_dim))
+                    copy_r2g(cast(STATE_DTYPE,state),
+                             final_state[item.batch,item.head,value_dim,0:128])
+                    # instruction_selection: four tcgen05 32x32 state loads
+                    # followed by 16-byte vector global stores; extent: one
+                    # final-state row
+            elif STORE_FINAL_STATE:
+                for key in range(128):
+                    value=(copy_g2r(initial_state[item.batch,item.head,value_dim,key])
+                           if USE_INITIAL_STATE else cast(STATE_DTYPE,0))
+                    copy_r2g(value,final_state[item.batch,item.head,value_dim,key])
+                    # instruction_selection: scalar global load/store or zero
+                    # store; extent: one empty-sequence state row
+            tile,sched=scheduler_consume(sched,tile)
+        arrive_edge("tmem_done")
+```
+
+## Logical tcgen05 GEMMs
+
+| # | FP32 TMEM destination | A operand | B operand | logical MxNxK | issues | accumulate |
+| ---: | --- | --- | --- | --- | ---: | --- |
+| 1 | state-K col 192 | packed state TMEM | K-decay SMEM | 128x16x128 | 8 | no |
+| 2 | state cols 0..127 | packed state TMEM | four-stage block diagonal | 128x128x16 per key block | 8 | no |
+| 3 | U col 208 | packed Y TMEM | T-inverse SMEM | 128x16x16 | 1 | no |
+| 4 | state cols 0..127 | packed U TMEM | K-restore SMEM transposed | 128x128x16 | 1 | runtime `have_state` |
+
+The accepted PTX therefore has 18 static `tcgen05.mma` sites and six static
+commit sites. The super-MMA warp has 28 register-MMA sites: sixteen for KK and
+twelve for the three Neumann rounds. Publication remains separate from compute.
+
+## Numerical order frozen by the schedule
+
+For each token, the source recurrence represented by the chunk factorization is
+
+```text
+S_decayed = exp(g_t) * S
+erase     = (beta_t * k_t) @ S_decayed
+v_new     = w_t * v_t - erase
+S         = S_decayed + outer(k_t, v_new)
+```
+
+The exact source order is observable: gate is transformed to log2 and
+prefix-scanned in packed pair order; K normalization reduces even/odd FMA
+chains and then XOR 4/2/1; beta sigmoid is rounded through I/O dtype;
+K-decay/inverse/restore are rounded and multiplied in packed pairs; T-inverse
+uses register MMA; state and U accumulate in FP32 TMEM. Tail gate rows become
+zero increments and TensorMap OOB fill supplies zero K/V/Beta/W values.
+
+## Source / PTX / sketch correspondence
+
+| Source action | Source lines | Accepted PTX evidence | Sketch owner |
+| --- | ---: | --- | --- |
+| dynamic scheduler | 234..261 | `atom.global.add.u32`, rolling scheduler barriers | scheduler helpers |
+| five raw TensorMap loads | 274..417 | 12 static rank-3 G2S sites, five expect-tx sites | warp 14 |
+| KK and Neumann inverse | 419..599 | 28 register MMA, 16 movmatrix, one stmatrix site | warp 12 |
+| four tcgen chains/lifecycle | 601..806 | 18 tcgen MMA, six commits, alloc/relinquish/dealloc | warp 13 |
+| checkpoint store drain | 808..882 | four static rank-4 S2G sites and bulk-group waits | warp 15 |
+| gate and K operands | 884..1218 | packed f32/I/O arithmetic and shared traffic | warps 0..7 |
+| state/value/checkpoint/final | 1220..1720 | TMEM load/store, ldmatrix, shared/global stores | warps 8..11 |
+| main ABI/storage/init/dispatch | 1770..2040 | `.reqntid 512`, 87 mbarrier init sites | launch 2 |
+| configuration and physical sizes | 2040..2204 | folded constants and shared offsets | specialization/storage |
+| six descriptor bodies | 2205..2268 | 96 `st.global.b64`, 12 replace sites, six release fences | launch 1 descriptors |
+| order/generation prologue | 2269..2456 plus split/order helper | shared min/max and work-row traffic | launch 1 order |
+| initial/final state difference | compile-time branch | state PTX adds one wait and two arrivals | CG1 / warp 13 |
+
+## Static instruction evidence for the BF16 checkpoint anchor
+
+| Instruction family | No state | Initial+final state | Owner |
+| --- | ---: | ---: | --- |
+| `mbarrier.init.shared.b64` | 87 | 87 | distributed initialization |
+| `mbarrier.try_wait*` | 41 | 42 | role-local waits |
+| `mbarrier.arrive.shared.b64` | 29 | 31 | publications/returns |
+| `mbarrier.arrive.expect_tx*` | 5 | 5 | warp 14 |
+| `tcgen05.mma*kind::f16` | 18 | 18 | warp 13 |
+| `tcgen05.commit*mbarrier` | 6 | 6 | warp 13 |
+| `mma.sync.aligned.m16n8k16*` | 28 | 28 | warp 12 |
+| rank-3 TMA GMEM-to-SMEM | 12 | 12 | warp 14 |
+| rank-4 TMA SMEM-to-GMEM | 4 | 4 | warp 15 |
+| `ldmatrix*` / `stmatrix*` / `movmatrix*` | 24 / 1 / 16 | 24 / 1 / 16 | warps 12 and CG1 |
+| `tcgen05.alloc/relinquish/dealloc` | 1 / 1 / 1 | 1 / 1 / 1 | warp 13 |
+
+## Validation and benchmark contract
+
+`get_kernel` returns `[descriptor_order_prologue, persistent_gdn2_recompute]`
+in launch order. Source and TIRx receive identical immutable logical inputs but
+independent descriptor workspaces, work tables, scheduler counters, checkpoint
+buffers, and final-state buffers. Correctness first requires exact tensor
+equality against the pinned source; any tolerance fallback must be no larger
+than an observed output ULP and separately justified. Canary regions guard all
+outputs, and lowered IR is rejected if it contains an inline CUDA function call.
+
+Benchmark timing includes both launches for each implementation. Descriptor
+construction, reference/TIRx compilation, and data preparation stay outside
+the timed closures. `prepare_bench` is CPU-only. Only `bench_suite` reference
+rows decide performance, with matched source/TIRx PTX versions (GB200 9.2,
+GB300 9.3, VR200 9.4). Every frozen row must have finite positive raw samples
+and satisfy strict `mean(cudnn_frontend) / mean(tirx) > 0.99`.

--- a/.agents/sketch/fastcu_nvfp4_gemm_gb300.md
+++ b/.agents/sketch/fastcu_nvfp4_gemm_gb300.md
@@ -1,0 +1,781 @@
+<!--
+This file is a design sketch for a TIRx port of code from fast.cu
+(https://github.com/pranjalssh/fast.cu @ 2dfe5e26aecfd9e5f27bf9d5837deea01acda24b),
+Copyright (c) 2024 Pranjal Shankhdhar.
+SPDX-License-Identifier: Apache-2.0 AND MIT
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# fast.cu GB300 NVFP4 GEMM r9: coarse WASP pipeline sketch
+
+This is a non-executable operation-level sketch for
+[`tirx_kernels/fastcu/nvfp4_gemm_gb300.py`](../../tirx_kernels/fastcu/nvfp4_gemm_gb300.py),
+which becomes the executable source of truth. It freezes the source r9 kernel's
+fixed two-CTA tile, seven-warp split, six-slot A/B feed, seven-slot scale feed,
+two overlapping TMEM accumulators, exact K96/K64 issue order, direct FP16
+epilogue, and L2-side-owned persistent schedule.
+
+The scope is `gb300/nvfp4/gemm9.cuh::nvfp4::nvfp4_gemm_kernel` at commit
+`2dfe5e26aecfd9e5f27bf9d5837deea01acda24b`: packed E2M1 A/B, VEC16_UE4M3
+block-16 scales, FP32 accumulation, and FP16 output on `sm_103a`. Other
+`gemm*.cuh` rungs, other scale formats, other output dtypes, and other GPU
+architectures are out of scope. The runtime domain is positive M/N and K >= 16
+with K divisible by 16; the benchmark domain is the five requested square
+shapes.
+
+The writer export is
+`.porting/fastcu_nvfp4_gemm_gb300/source_export/writer/gemm9.ptx`, SHA256
+`25dd14c7142af7d5a31cfa8902a2d141c9bbffe15cab3f19437cb2d023ca891a`.
+It was produced by CUDA 13.3.73 with `-O3 -DNDEBUG -lineinfo` and
+`compute_103a`, contains 3,625 `.loc` records, and maps `.file 1` to the pinned
+`gemm9.cuh`. The GEMM entry occupies PTX lines 22-11312. All instruction
+selections below come from that entry. The intentional route-table address-space
+adaptation is called out separately and must be checked against the generated
+TIRx PTX and the performance gate.
+
+After the independent sketch reviewer returns PASS, this file is immutable.
+
+## Pipeline at a glance
+
+| warp / CTA role | tile program | publication / reuse edges |
+| --- | --- | --- |
+| warps 0-3, both CTAs | each warp owns 32 rows; wait for one accumulator, drain eight 32-column bands in parity-dependent order, convert packed FP32 pairs to FP16, store directly to C, and release the accumulator after the shared 36-column edge is drained | `acc_ready` from warp 4; fused `tcgen05.wait::ld` then lane-0 remote `acc_free` arrive to the even CTA |
+| warp 4, even CTA only | walk every tile assigned to the cluster; consume scale and A/B rings; stage nine scale tiles per scale slot to TMEM; issue the K96 stream and exact K64 tail subclass; publish one completed accumulator per tile | `sf_ready -> sf_free`, `ab_ready -> ab_free`, `acc_free -> acc_ready`; all tcgen05 copy/MMA/commit instructions have one lane issuer |
+| warp 4, odd CTA | no mainloop work | participates in the prologue TMEM-allocation rendezvous, then remains idle/exits; epilogue warp 0 handles teardown |
+| warp 5 lane 0, both CTAs | use the scalar route entry; per live A/B window wait for reuse, issue one self-multicast A TMA and one peer-local B TMA, then advance the six-slot cursor | `ab_free -> ab_ready`; even CTA declares 65,536 expected bytes, both CTAs contribute transfers |
+| warp 6 lane 0, both CTAs | use the scalar route entry; per live scale slot issue one self-multicast SFA TMA and one two-peer SFB multicast, then advance the seven-slot cursor | `sf_free -> sf_ready`; even CTA declares 9,216 expected bytes, both CTAs contribute transfers |
+| warp 0, both CTAs | lane 0 initializes 29 mbarriers and publishes them cluster-wide; the full warp allocates pair TMEM; after all epilogue work, all warp-0 lanes relinquish and arrive at the peer deallocation barrier, wait locally, then deallocate | init fence -> cluster release/acquire barrier; named barrier 2 publishes TMEM address to warps 0-4; named barrier 3 joins epilogue warps before teardown |
+
+## Primitive vocabulary
+
+The sketch uses no tile primitive and no first-class layout. All storage is a
+rank-one byte/register allocation plus scalar index functions:
+
+```python
+linear_smem(name, bytes, alignment)
+linear_gmem(name, dtype, elements)
+reg_array(name, dtype, elements)
+smem_byte_offset(region, slot, lane_or_atom)
+tmem_column(base, buffer, band, row_band)
+tensor_map(name, rank, scalar_fields)
+```
+
+Directional movement and computation are deliberately primitive:
+
+```python
+copy_g2s(src_map, coords, smem_byte, completion, multicast_mask)
+copy_s2t(smem_descriptor, tmem_column)
+copy_t2r(tmem_column, registers)
+copy_r2g(registers, global_pointer, predicate)
+cast(dst, src, rounding)
+gemm(dst, a_descriptor, b_descriptor, sfa_column, sfb_column,
+     instruction_descriptor, accumulate)
+```
+
+`init`, `wait`, `expect_bytes`, `arrive`, `commit`, `fence`, `barrier`,
+`allocate_tmem`, `relinquish_tmem`, `deallocate_tmem`, and cursor updates are
+schedule operations. Descriptor creation below is ordinary scalar shift/mask/OR
+arithmetic yielding raw PTX operands; it creates no mapping object. One
+`copy_g2s`, `copy_s2t`, `copy_t2r`, `copy_r2g`, or `gemm` denotes one
+instruction or an explicitly stated loop of one instruction family.
+
+## Complete sketch
+
+```python
+# Static target and runtime ABI.
+@kernel(
+    target="sm_103a",
+    grid_in_clusters=(1, 1, 76),
+    clusters=(2, 1, 1),
+    block=(224, 1, 1),
+    min_blocks_per_sm=1,
+    dynamic_smem_bytes=230400,
+)
+# instruction_selection: `.version 9.3`, `.target sm_103a`,
+#   `.reqntid 224,1,1`, `.minnctapersm 1`, `.reqnctapercluster 2,1,1`,
+#   `.blocksareclusters`, and `.extern .shared .align 1024`; extent: one entry
+def fastcu_nvfp4_gemm_gb300(
+    A_tmap, B_tmap, SFA_tmap, SFB_tmap,  # four by-value 128-byte TensorMaps
+    C,                                   # f16 [M,N]
+    M, N, K,                             # runtime i32 source ABI
+    route_table,                         # read-only i32 [4096]
+    sm_side, cluster_side,               # read-only i32 [256], [128]
+    placement_errors,                    # u32 [1]
+):
+    CTA_GROUP = 2
+    BLOCK_M = 128
+    BLOCK_N = 256
+    BLOCK_N_PEER = 128
+    MMA_K = 96
+    AB_RING = 6
+    SF_RING = 7
+    D_STRIDE = 220
+    SF_TMEM_BASE = 476
+    TMEM_COLUMNS = 512
+    AB_TX = 65536
+    SF_TX = 9216
+
+    tid = thread_id()
+    warp = tid >> 5
+    lane = tid & 31
+    crank = cluster_cta_rank()
+    m_pair = crank & 1
+    cluster_id = cluster_id_from_block()
+    num_clusters = grid_cluster_count()
+
+    cluster_grid_m = ceil_div(M, 256)
+    grid_n = ceil_div(N, 256)
+    total_tiles = cluster_grid_m * grid_n
+    full_groups = K // 768
+    tail_cells = ceil_div(K - full_groups * 768, 96)
+    t_sf = ceil_div(tail_cells, 2)
+    num_groups = full_groups + (tail_cells != 0)
+    k_rem = K - full_groups * 768
+    b64_try = 1 if k_rem % 96 == 64 else (2 if k_rem % 96 == 32 else 0)
+    a64 = tail_cells - b64_try
+    b64 = b64_try if b64_try != 0 and k_rem % 32 == 0 and a64 >= 0 and even(a64) else 0
+    t_win = ceil_div(k_rem // 2, 128) if b64 else 3
+
+    # One source SmemCD object becomes one rank-one K u8 allocation.
+    smem = linear_smem("smem", 230400, alignment=1024)
+    smem_base = shared_address(smem)
+    AB_READY = [0 + 8*s for s in range(6)]
+    AB_FREE = [48 + 8*s for s in range(6)]
+    SF_READY = [96 + 8*s for s in range(7)]
+    SF_FREE = [152 + 8*s for s in range(7)]
+    ACC_READY = 208
+    ACC_FREE = 216
+    DEALLOC = 224
+    TMEM_ADDR = 232
+    A_BASE = 1024
+    B_BASE = 99328
+    SFA_BASE = 197632
+    SFB_BASE = 208896
+
+    def a_slot(slot): return A_BASE + slot * 16384
+    def b_slot(slot): return B_BASE + slot * 16384
+    def sfa_slot(slot): return SFA_BASE + slot * 1536
+    def sfb_slot(slot): return SFB_BASE + slot * 3072
+
+    # Scalar descriptor/index mappings; these produce raw integer operands,
+    # never a layout value.
+    def sf_cp_src_desc(region_base, slot, slot_u, tile_u):
+        base = smem_base + region_base
+        fixed = ((base >> 4) & 0x3fc0) | 0x400800010000
+        return fixed + slot*slot_u + tile_u
+
+    # The single reused TMEM SF area is overwritten only after its batch MMAs.
+    SF_COPY = (
+        # region, source tile, slot stride in 16B units, destination column
+        (SFA_BASE, 0,  96, 476), (SFA_BASE, 1,  96, 480),
+        (SFA_BASE, 2,  96, 484), (SFB_BASE, 0, 192, 488),
+        (SFB_BASE, 3, 192, 492), (SFB_BASE, 1, 192, 496),
+        (SFB_BASE, 4, 192, 500), (SFB_BASE, 2, 192, 504),
+        (SFB_BASE, 5, 192, 508),
+    )
+    # instruction_selection: the nine entries above issue nine predicated
+    #   `tcgen05.cp.cta_group::2.32x128b.warpx4` instructions in exact
+    #   SFA 0,1,2; SFB 0,3,1,4,2,5 source order.
+
+    def ab_desc(region_base, slot, atom):
+        base = smem_base + region_base + slot*16384
+        addr = ((base >> 4) & 0x7fc0) + atom
+        lbo = (base << 12) & 0x7fc00000
+        return addr | lbo | 0x4010404000000000
+
+    def ab_desc_straddle(region_base, addr_slot, lbo_slot, atom):
+        return ((ab_desc(region_base, addr_slot, atom) & 0xffff)
+                | (ab_desc(region_base, lbo_slot, 0) & 0xffff0000)
+                | (ab_desc(region_base, addr_slot, atom) & 0xffffffff00000000))
+
+    def ab_desc_k64(region_base, slot, atom):
+        d = ab_desc(region_base, slot, atom)
+        return (d & 0xffff) | (((d >> 32) & ~(1 << 20)) << 32)
+
+    def sf_id_bits(words):
+        sfa, sfb = words
+        return ((sfa >> 1) & 0x60000000) | ((sfb >> 26) & 48)
+
+    # Cell -> (A/B descriptor form, SF form). W0/W1/W2 name consecutive
+    # A/B ring slots at this group entry.
+    K96_CELL = (
+        (0, "plain(W0,0)",             "word0"),
+        (1, "plain(W0,3)",             "word1-with-id"),
+        (2, "straddle(W0,W1,6)",       "word0"),
+        (3, "plain(W1,1)",             "word1-with-id"),
+        (4, "plain(W1,4)",             "word0"),
+        (5, "straddle(W1,W2,7)",       "word1-with-id"),
+        (6, "plain(W2,2)",             "word0"),
+        (7, "plain(W2,5)",             "word1-with-id"),
+    )
+    def sf_word0(taddr): return (taddr + 476, taddr + 488)
+    def sf_word1(taddr):
+        return ((taddr + 480) | 0x80000000,
+                (taddr + 496) | 0x80000000)
+    def idesc96_word0(taddr): return 0x90400480 | sf_id_bits(sf_word0(taddr))
+    def idesc96_word1(taddr): return 0x90400480 | sf_id_bits(sf_word1(taddr))
+    # K64 legacy operands mask descriptor lows to 16 bits and clear descriptor
+    # bit 52 (high-word bit 20); idesc bit 31 is clear. Its two forms use plain
+    # id-0 columns (476,488) and (480,496), respectively.
+    def k64_word0(taddr): return (taddr + 476, taddr + 488)
+    def k64_word1(taddr): return (taddr + 480, taddr + 496)
+    def idesc64_word0(taddr): return 0x10400480 | sf_id_bits(k64_word0(taddr))
+    def idesc64_word1(taddr): return 0x10400480 | sf_id_bits(k64_word1(taddr))
+
+    def stage_sf(slot, phase):
+        wait(SF_READY[slot], phase, acquire=None)
+        # instruction_selection: retry loop around
+        #   `mbarrier.try_wait.parity.shared.b64`; extent: one live SF batch
+        for region, tile, slot_u, dst_col in SF_COPY:
+            copy_s2t(sf_cp_src_desc(region, slot, slot_u, tile*32),
+                     taddr + dst_col)
+        commit(SF_FREE[slot], mask=0x3)
+        # instruction_selection: one predicated multicast tcgen05 commit after
+        #   the exact nine-copy sequence; extent: one live SF batch
+        return advance_ring(slot, phase, 7)
+
+    # The placement audit precedes all role dispatch.
+    actual_side = load_readonly(sm_side[sm_id()])
+    planned_side = load_readonly(cluster_side[cluster_id])
+    # instruction_selection: source has two `ld.const.b32` at PTX 153/157;
+    #   adaptation uses two `ld.global.nc.b32`; extent: two scalar loads/thread
+    if tid == 0 and actual_side != planned_side:
+        atomic_add(placement_errors[0], 1)
+        # instruction_selection: predicated `atom.global.add.u32`; extent: one audit site
+
+    # Warp 0 lane 0 initializes the source fields in declaration order.
+    if warp == 0 and lane == 0:
+        for s in static_range(6):
+            init(AB_READY[s], 1)
+            # instruction_selection: `mbarrier.init.shared.b64`; extent: one slot
+            init(AB_FREE[s], 1)
+            # instruction_selection: `mbarrier.init.shared.b64`; extent: one slot
+        for s in static_range(7):
+            init(SF_READY[s], 1)
+            # instruction_selection: `mbarrier.init.shared.b64`; extent: one slot
+            init(SF_FREE[s], 1)
+            # instruction_selection: `mbarrier.init.shared.b64`; extent: one slot
+        init(ACC_READY, 1)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: one slot
+        init(ACC_FREE, 8)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: one slot
+        init(DEALLOC, 32)
+        # instruction_selection: `mbarrier.init.shared.b64`; extent: one slot
+        fence_mbarrier_init_release_cluster()
+        # instruction_selection: `fence.mbarrier_init.release.cluster`; extent: one fence
+    cluster_barrier_release_acquire()
+    # instruction_selection: `barrier.cluster.arrive.release.aligned` then
+    #   `barrier.cluster.wait.acquire.aligned`; extent: all threads in both CTAs
+
+    # Warps 0-4 see the TMEM grant; TMA producer warps do not wait here.
+    if warp <= 4:
+        if warp == 0:
+            allocate_tmem(smem + TMEM_ADDR, 512)
+            # instruction_selection: `tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32`;
+            #   extent: all warp-0 lanes as required by the instruction
+        barrier(id=2, threads=160)
+        # instruction_selection: `barrier.cta.sync`; extent: warps 0-4
+        taddr = load_shared_u32(smem + TMEM_ADDR)
+        # instruction_selection: `ld.shared.b32`; extent: one scalar/thread in warps 0-4
+
+    def producer_tile(t):
+        # Source PTX has one scalar `ld.const.b32` in each producer copy of this helper.
+        tile = load_readonly(route_table[t])
+        # instruction_selection: intentional adaptation `ld.global.nc.b32`;
+        #   extent: one lane-0 scalar load per persistent tile in warp 5 or 6
+        return tile
+
+    def epilogue_tile(t):
+        tile_lane = load_readonly(route_table[t])
+        # instruction_selection: intentional adaptation `ld.global.nc.b32`;
+        #   extent: one scalar load per lane before uniformization
+        tile = warp_min(tile_lane, mask=0xffffffff)
+        # instruction_selection: `redux.sync.min.u32`; extent: one warp collective
+        return tile
+
+    # Warp 5 lane 0: A/B TMA producer, six-slot cursor starts phase 1.
+    if warp == 5 and lane == 0:
+        slot, free_phase = 0, 1
+        for t in range(cluster_id, total_tiles, num_clusters):
+            tile = producer_tile(t)
+            m_row, n_group = tile % cluster_grid_m, tile // cluster_grid_m
+            m_block = 2*m_row + m_pair
+            n_block = 2*n_group + m_pair
+            for group in rolled_range(num_groups):
+                for sub in static_range(3):
+                    if group == full_groups and sub >= t_win:
+                        break
+                    wait(AB_FREE[slot], free_phase, acquire="cta")
+                    # instruction_selection: retry loop around
+                    #   `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+                    #   extent: one live A/B window
+                    if m_pair == 0:
+                        expect_bytes(AB_READY[slot] with peer_bit_cleared, AB_TX)
+                        # instruction_selection:
+                        #   `mbarrier.arrive.expect_tx.release.cta.shared::cta.b64`;
+                        #   extent: one even-CTA arrival per live A/B window
+                    copy_g2s(A_tmap, (group*384 + sub*128, m_block*128, 0),
+                             a_slot(slot), AB_READY[slot], 1 << m_pair)
+                    # instruction_selection:
+                    #   `cp.async.bulk.tensor.3d.cta_group::2.shared::cluster.global`
+                    #   `.mbarrier::complete_tx::bytes.multicast::cluster`;
+                    #   extent: one 128x128-byte source box
+                    copy_g2s(B_tmap, (group*384 + sub*128, n_block*128, 0),
+                             b_slot(slot), AB_READY[slot], multicast_mask=None)
+                    # instruction_selection:
+                    #   `cp.async.bulk.tensor.3d.cta_group::2.shared::cluster.global`
+                    #   `.mbarrier::complete_tx::bytes`; extent: one 128x128-byte source box
+                    slot, free_phase = advance_ring(slot, free_phase, 6)
+        last_slot, last_phase = previous_ring(slot, free_phase, 6)
+        wait(AB_FREE[last_slot], last_phase, acquire="cta")
+        # instruction_selection: same acquire CTA parity retry loop; extent: producer tail
+        if m_pair == 0:
+            expect_bytes(AB_READY[last_slot] with peer_bit_cleared, AB_TX)
+            # instruction_selection: same expect-tx instruction; extent: clean-shutdown token
+
+    # Warp 6 lane 0: scale TMA producer, seven-slot cursor starts phase 1.
+    elif warp == 6 and lane == 0:
+        slot, free_phase = 0, 1
+        for t in range(cluster_id, total_tiles, num_clusters):
+            tile = producer_tile(t)
+            m_row, n_group = tile % cluster_grid_m, tile // cluster_grid_m
+            m_block = 2*m_row + m_pair
+            for group in rolled_range(num_groups):
+                for sub in static_range(4):
+                    if group == full_groups and sub >= t_sf:
+                        break
+                    wait(SF_FREE[slot], free_phase, acquire="cta")
+                    # instruction_selection: retry loop around
+                    #   `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+                    #   extent: one live scale slot
+                    if m_pair == 0:
+                        expect_bytes(SF_READY[slot] with peer_bit_cleared, SF_TX)
+                        # instruction_selection: same expect-tx instruction;
+                        #   extent: one even-CTA arrival per live scale slot
+                    sf_group = (group*4 + sub)*3
+                    copy_g2s(SFA_tmap, (0, 0, sf_group, m_block),
+                             sfa_slot(slot), SF_READY[slot], 1 << m_pair)
+                    # instruction_selection:
+                    #   `cp.async.bulk.tensor.4d.cta_group::2.shared::cluster.global`
+                    #   `.mbarrier::complete_tx::bytes.multicast::cluster`;
+                    #   extent: one 128x4x3 scale box
+                    copy_g2s(SFB_tmap, (0, 0, sf_group, 2*n_group + m_pair),
+                             sfb_slot(slot) + m_pair*1536, SF_READY[slot], 0x3)
+                    # instruction_selection: same rank-4 multicast family;
+                    #   extent: one peer half of the byte-identical SFB slot
+                    slot, free_phase = advance_ring(slot, free_phase, 7)
+        last_slot, last_phase = previous_ring(slot, free_phase, 7)
+        wait(SF_FREE[last_slot], last_phase, acquire="cta")
+        # instruction_selection: same acquire CTA parity retry loop; extent: producer tail
+        if m_pair == 0:
+            expect_bytes(SF_READY[last_slot] with peer_bit_cleared, SF_TX)
+            # instruction_selection: same expect-tx instruction; extent: clean-shutdown token
+
+    # Warp 4 lane 0 of the even CTA: the only copy/MMA issuer.
+    elif warp == 4 and m_pair == 0 and lane == 0:
+        state = (d_parity=1, ab_phase=0, ab_slot=0, sf_phase=0, sf_slot=0)
+        for t in range(cluster_id, total_tiles, num_clusters):
+            acc_wait_phase = state.d_parity
+            state.d_parity ^= 1
+            d_tmem = taddr + state.d_parity*220
+            accumulate = False
+
+            # Each complete group is rolled; SF staging and MMAs are
+            # deliberately interleaved around the one reused TMEM SF area.
+            for group in rolled_range(full_groups):
+                W0, ph0 = state.ab_slot, state.ab_phase
+                W1, ph1 = advance_ring(W0, ph0, 6)
+                W2, ph2 = advance_ring(W1, ph1, 6)
+
+                # Batch 0: cells 0/1, atoms 0/3.
+                state.sf_slot, state.sf_phase = stage_sf(
+                    state.sf_slot, state.sf_phase)
+                wait(AB_READY[W0], ph0, acquire=None)
+                # instruction_selection: relaxed parity mbarrier retry loop;
+                #   extent: W0 once per complete group
+                if group == 0:
+                    wait(ACC_FREE, acc_wait_phase, acquire=None)
+                    # instruction_selection: gated relaxed parity retry loop;
+                    #   extent: exactly once per output tile
+                gemm(cell=K96_CELL[0], windows=(W0,W1,W2),
+                     idesc=idesc96_word0(taddr), sf=sf_word0(taddr),
+                     accumulate=accumulate)
+                gemm(cell=K96_CELL[1], windows=(W0,W1,W2),
+                     idesc=idesc96_word1(taddr), sf=sf_word1(taddr), accumulate=True)
+                accumulate = True
+
+                # Batch 1: cells 2/3, atoms 6/1.
+                state.sf_slot, state.sf_phase = stage_sf(
+                    state.sf_slot, state.sf_phase)
+                wait(AB_READY[W1], ph1, acquire=None)
+                gemm(cell=K96_CELL[2], windows=(W0,W1,W2),
+                     idesc=idesc96_word0(taddr), sf=sf_word0(taddr), accumulate=True)
+                commit(AB_FREE[W0], mask=0x3)  # immediately after atom 6
+                gemm(cell=K96_CELL[3], windows=(W0,W1,W2),
+                     idesc=idesc96_word1(taddr), sf=sf_word1(taddr), accumulate=True)
+
+                # Batch 2: atom 4 must issue before the W2 wait; atom 7 follows.
+                state.sf_slot, state.sf_phase = stage_sf(
+                    state.sf_slot, state.sf_phase)
+                gemm(cell=K96_CELL[4], windows=(W0,W1,W2),
+                     idesc=idesc96_word0(taddr), sf=sf_word0(taddr), accumulate=True)
+                wait(AB_READY[W2], ph2, acquire=None)
+                state.ab_slot, state.ab_phase = advance_ring(W2, ph2, 6)
+                gemm(cell=K96_CELL[5], windows=(W0,W1,W2),
+                     idesc=idesc96_word1(taddr), sf=sf_word1(taddr), accumulate=True)
+
+                # Batch 3: r9 delays W1 release until after this SF copy.
+                state.sf_slot, state.sf_phase = stage_sf(
+                    state.sf_slot, state.sf_phase)
+                commit(AB_FREE[W1], mask=0x3)
+                gemm(cell=K96_CELL[6], windows=(W0,W1,W2),
+                     idesc=idesc96_word0(taddr), sf=sf_word0(taddr), accumulate=True)
+                gemm(cell=K96_CELL[7], windows=(W0,W1,W2),
+                     idesc=idesc96_word1(taddr), sf=sf_word1(taddr), accumulate=True)
+                commit(AB_FREE[W2], mask=0x3)
+                # instruction_selection for the eight gemm sites: predicated
+                #   `tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X`;
+                #   exact atom order 0,3,6,1,4,7,2,5. The three releases use
+                #   predicated tcgen05 multicast mbarrier commits.
+
+            if tail_cells != 0:
+                W0, ph0 = state.ab_slot, state.ab_phase
+                W1, ph1 = advance_ring(W0, ph0, 6)
+                W2, ph2 = advance_ring(W1, ph1, 6)
+
+                if b64 != 0:
+                    # Every tuple is cell-indexed in issue order. 96p/96x use
+                    # K96_CELL's plain/straddle descriptor and alternating SF
+                    # word; 64a/64b use legacy low16 + bit52-clear descriptors,
+                    # idesc64_word0/1, and k64_word0/1.
+                    K64_VARIANT = {
+                      (0,1): ("64a(W0,0)",),
+                      (0,2): ("64a(W0,0)", "64b(W0,2)"),
+                      (2,1): ("96p(W0,0,w0)", "96p(W0,3,w1)",
+                              "64a(W0,6)"),
+                      (2,2): ("96p(W0,0,w0)", "96p(W0,3,w1)",
+                              "64a(W0,6)", "64b(W1,0)"),
+                      (4,1): ("96p(W0,0,w0)", "96p(W0,3,w1)",
+                              "96x(W0,W1,6,w0)", "96p(W1,1,w1)",
+                              "64a(W1,4)"),
+                      (4,2): ("96p(W0,0,w0)", "96p(W0,3,w1)",
+                              "96x(W0,W1,6,w0)", "96p(W1,1,w1)",
+                              "64a(W1,4)", "64b(W1,6)"),
+                      (6,1): ("96p(W0,0,w0)", "96p(W0,3,w1)",
+                              "96x(W0,W1,6,w0)", "96p(W1,1,w1)",
+                              "96p(W1,4,w0)", "96x(W1,W2,7,w1)",
+                              "64a(W2,2)"),
+                      (6,2): ("96p(W0,0,w0)", "96p(W0,3,w1)",
+                              "96x(W0,W1,6,w0)", "96p(W1,1,w1)",
+                              "96p(W1,4,w0)", "96x(W1,W2,7,w1)",
+                              "64a(W2,2)", "64b(W2,4)"),
+                    }
+                    variant = K64_VARIANT[(a64, b64)]
+                    N_C = a64 + b64
+                    T_WIN = 1 if (a64,b64) in ((0,1),(0,2),(2,1)) else (
+                            2 if a64 in (2,4) else 3)
+
+                    # Batch 0, cells 0/1.
+                    state.sf_slot, state.sf_phase = stage_sf(
+                        state.sf_slot, state.sf_phase)
+                    wait(AB_READY[W0], ph0, acquire=None)
+                    wait_gated(ACC_FREE, acc_wait_phase,
+                               skip=(full_groups != 0))
+                    issue_if_present(variant, 0, overwrite=(full_groups == 0))
+                    issue_if_present(variant, 1, overwrite=False)
+
+                    # Batch 1 then cells 2/3. The W1 wait is source-positioned
+                    # before cell 2 whenever the variant consumes W1.
+                    if N_C > 2:
+                        state.sf_slot, state.sf_phase = stage_sf(
+                            state.sf_slot, state.sf_phase)
+                    if T_WIN >= 2:
+                        wait(AB_READY[W1], ph1, acquire=None)
+                    issue_if_present(variant, 2, overwrite=False)
+                    commit(AB_FREE[W0], mask=0x3)
+                    issue_if_present(variant, 3, overwrite=False)
+
+                    # Batch 2 then cells 4/5. W2 is waited and the A/B cursor
+                    # written back after cell 4 but before cell 5.
+                    if N_C > 4:
+                        state.sf_slot, state.sf_phase = stage_sf(
+                            state.sf_slot, state.sf_phase)
+                    issue_if_present(variant, 4, overwrite=False)
+                    if T_WIN >= 3:
+                        wait(AB_READY[W2], ph2, acquire=None)
+                    if T_WIN == 1:
+                        state.ab_slot, state.ab_phase = W1, ph1
+                    elif T_WIN == 2:
+                        state.ab_slot, state.ab_phase = W2, ph2
+                    else:
+                        state.ab_slot, state.ab_phase = advance_ring(W2, ph2, 6)
+                    issue_if_present(variant, 5, overwrite=False)
+
+                    # Batch 3, if live, precedes the deliberately delayed W1
+                    # release; cells 6/7 and conditional W2 release follow.
+                    if N_C > 6:
+                        state.sf_slot, state.sf_phase = stage_sf(
+                            state.sf_slot, state.sf_phase)
+                    if T_WIN >= 2:
+                        commit(AB_FREE[W1], mask=0x3)
+                    issue_if_present(variant, 6, overwrite=False)
+                    issue_if_present(variant, 7, overwrite=False)
+                    if T_WIN >= 3:
+                        commit(AB_FREE[W2], mask=0x3)
+                    # instruction_selection: the selected tuple expands to
+                    #   exactly N_C separately materialized mxf4nvf4 MMA sites;
+                    #   96p/96x set idesc bit31, 64a/64b clear it.
+
+                else:
+                    # Ordinary tail: all three A/B windows exist. SF batches
+                    # exist only for their live cell pair and skipped batches
+                    # advance no SF cursor.
+                    state.sf_slot, state.sf_phase = stage_sf(
+                        state.sf_slot, state.sf_phase)
+                    wait(AB_READY[W0], ph0, acquire=None)
+                    wait_gated(ACC_FREE, acc_wait_phase,
+                               skip=(full_groups != 0))
+                    gemm(cell=K96_CELL[0], predicate=True,
+                         accumulate=(full_groups != 0))
+                    gemm(cell=K96_CELL[1], predicate=(tail_cells >= 2),
+                         accumulate=True)
+
+                    if tail_cells > 2:
+                        state.sf_slot, state.sf_phase = stage_sf(
+                            state.sf_slot, state.sf_phase)
+                    wait(AB_READY[W1], ph1, acquire=None)
+                    gemm(cell=K96_CELL[2], predicate=(tail_cells >= 3),
+                         accumulate=True)
+                    commit(AB_FREE[W0], mask=0x3)
+                    gemm(cell=K96_CELL[3], predicate=(tail_cells >= 4),
+                         accumulate=True)
+
+                    if tail_cells > 4:
+                        state.sf_slot, state.sf_phase = stage_sf(
+                            state.sf_slot, state.sf_phase)
+                    gemm(cell=K96_CELL[4], predicate=(tail_cells >= 5),
+                         accumulate=True)
+                    wait(AB_READY[W2], ph2, acquire=None)
+                    state.ab_slot, state.ab_phase = advance_ring(W2, ph2, 6)
+                    gemm(cell=K96_CELL[5], predicate=(tail_cells >= 6),
+                         accumulate=True)
+
+                    if tail_cells > 6:
+                        state.sf_slot, state.sf_phase = stage_sf(
+                            state.sf_slot, state.sf_phase)
+                    commit(AB_FREE[W1], mask=0x3)
+                    gemm(cell=K96_CELL[6], predicate=(tail_cells >= 7),
+                         accumulate=True)
+                    gemm(cell=K96_CELL[7], predicate=(tail_cells >= 8),
+                         accumulate=True)
+                    commit(AB_FREE[W2], mask=0x3)
+                    # instruction_selection: eight predicated mxf4nvf4 K96
+                    #   sites in atom order 0,3,6,1,4,7,2,5; liveness is the
+                    #   issuer predicate and all waits/releases retain source order.
+
+            commit(ACC_READY, mask=0x3)
+            # instruction_selection:
+            #   `tcgen05.commit.cta_group::2.mbarrier::arrive::one`
+            #   `.shared::cluster.multicast::cluster.b64`; extent: one output tile
+        wait(ACC_FREE, state.d_parity, acquire=None)
+        # instruction_selection: relaxed parity retry loop; extent: MMA drain
+
+    # Warps 0-3 in both CTAs: direct TMEM-to-global epilogue. All unmatched
+    # lanes in warps 4-6 are idle, matching the source's outer wg==1 branch.
+    elif warp <= 3:
+        epi_warp = warp
+        row_band_taddr = (epi_warp*32) << 16
+        d_buffer = 0
+        acc_phase = 0
+        for t in range(cluster_id, total_tiles, num_clusters):
+            tile = epilogue_tile(t)
+            m_row, n_group = tile % cluster_grid_m, tile // cluster_grid_m
+            wait(ACC_READY, acc_phase, acquire=None)
+            # instruction_selection: relaxed parity retry loop; extent: one output tile
+            acc_phase ^= 1
+            row = (2*m_row + m_pair)*128 + epi_warp*32 + lane
+            for k in rolled_range(8):
+                band = 7-k if d_buffer == 0 else k
+                words = reg_array("words", "u32", 32)
+                copy_t2r(taddr + d_buffer*220 + band*32 + row_band_taddr, words)
+                # instruction_selection: `tcgen05.ld.sync.aligned.32x32b.x32.b32`;
+                #   extent: one 32-row x 32-column band per epilogue warp
+                if k == 1:
+                    wait_tmem_loads()
+                    # instruction_selection: `tcgen05.wait::ld.sync.aligned`;
+                    #   extent: one early-release site per tile/band walk
+                    if lane == 0:
+                        arrive_remote(ACC_FREE, even_cta_rank=crank & ~1, release="cta")
+                        # instruction_selection:
+                        #   `mbarrier.arrive.release.cta.shared::cluster.b64`;
+                        #   extent: one lane per epilogue warp after the fused wait
+                if row < M:
+                    half_words = reg_array("half_words", "u32", 16)
+                    for j in static_range(16):
+                        cast(half_words[j], (words[2*j+1], words[2*j]), rounding="rn")
+                        # instruction_selection: `cvt.rn.f16x2.f32`;
+                        #   extent: one packed pair
+                    col = n_group*256 + band*32
+                    if output_pointer_and_row_are_32B_aligned and col % 16 == 0:
+                        for q in static_range(2):
+                            c16 = col + q*16
+                            if c16 + 16 <= N:
+                                copy_r2g(half_words[q*8:q*8+8],
+                                         C[row,c16:c16+16], predicate=True)
+                                # instruction_selection:
+                                #   `st.global.L1::no_allocate.L2::evict_first.v8.b32`;
+                                #   extent: one complete aligned 16-half segment
+                            else:
+                                for p in static_range(2):
+                                    c8 = c16 + p*8
+                                    if c8 + 8 <= N:
+                                        copy_r2g(half_words[q*8+p*4:q*8+p*4+4],
+                                                 C[row,c8:c8+8], predicate=True)
+                                        # instruction_selection:
+                                        #   `st.global.L1::no_allocate.v4.b32`;
+                                        #   extent: one complete 8-half tail segment
+                                    else:
+                                        for h in static_range(8):
+                                            copy_r2g(half_at(half_words,q,p,h),
+                                                     C[row,c8+h],
+                                                     predicate=(c8+h < N))
+                                            # instruction_selection: predicated
+                                            #   `st.global.b16`; extent: one half
+                    else:
+                        for q in static_range(4):
+                            c8 = col + q*8
+                            if c8 + 8 <= N:
+                                copy_r2g(half_words[q*4:q*4+4],
+                                         C[row,c8:c8+8], predicate=True)
+                                # instruction_selection:
+                                #   `st.global.L1::no_allocate.v4.b32`;
+                                #   extent: one complete 8-half segment
+                            else:
+                                for h in static_range(8):
+                                    copy_r2g(half_at(half_words,q,h),
+                                             C[row,c8+h],
+                                             predicate=(c8+h < N))
+                                    # instruction_selection: predicated
+                                    #   `st.global.b16`; extent: one half
+            d_buffer ^= 1
+
+    # Only epilogue warps rendezvous and deallocate.
+    if warp <= 3:
+        barrier(id=3, threads=128)
+        # instruction_selection: `barrier.cta.sync`; extent: four epilogue warps
+        if warp == 0:
+            relinquish_tmem()
+            # instruction_selection:
+            #   `tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned`;
+            #   extent: warp 0
+            arrive_remote(DEALLOC, peer_rank=crank ^ 1, release="cta", all_lanes=True)
+            # instruction_selection: `mapa.shared::cluster.u32` plus
+            #   `mbarrier.arrive.release.cta.shared::cluster.b64`;
+            #   extent: all 32 lanes arrive at peer's count-32 barrier
+            wait(DEALLOC, phase=0, acquire="cta")
+            # instruction_selection: retry loop around
+            #   `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+            #   extent: one teardown wait
+            deallocate_tmem(taddr, 512)
+            # instruction_selection:
+            #   `tcgen05.dealloc.cta_group::2.sync.aligned.b32`; extent: warp 0
+```
+
+## TensorMap fields and explicit physical mappings
+
+| map | fastest-first global dimensions | byte strides for dimensions 1+ | box | swizzle / OOB |
+| --- | --- | --- | --- | --- |
+| A | `(K/2, M, 1)` | `(aligned(K/2,16), M*aligned(K/2,16))` | `(128,128,1)` u8 | 128 B / zero |
+| B | `(K/2, N, 1)` | `(aligned(K/2,16), N*aligned(K/2,16))` | `(128,128,1)` u8 | 128 B / zero |
+| SFA | `(128,4,ceil(K/64),ceil(M/128))` | `(128,512,ceil(K/64)*4*128)` | `(128,4,3,1)` u8 | none / zero |
+| SFB | `(128,4,ceil(K/64),ceil(N/128))` | `(128,512,ceil(K/64)*4*128)` | `(128,4,3,1)` u8 | none / zero |
+
+Scale storage uses the source VEC16 offset exactly:
+`((sf_inner//4)*4 + outer_block*sf_inner_dim)*128 + (outer%32)*16 +
+(outer//32)*4 + sf_inner%4`. A/B descriptor atom order is
+`0,3,6,1,4,7,2,5`; atoms 6 and 7 splice the address half from the current
+128-byte window with the absolute-LBO half from the next window.
+
+## Pipeline inventory
+
+| edge | slots / initial phase | producer | consumer | completion / release |
+| --- | --- | --- | --- | --- |
+| A/B | 6 / producer free phase 1, MMA ready phase 0 | warp 5 lane 0 in both CTAs | warp 4 lane 0 in even CTA | even CTA expect 65,536 bytes; tcgen05 commit multicast to both `ab_free` copies at each last reader |
+| scale | 7 / producer free phase 1, MMA ready phase 0 | warp 6 lane 0 in both CTAs | warp 4 lane 0 in even CTA | even CTA expect 9,216 bytes; tcgen05 commit multicast after nine scale copies |
+| accumulator | singleton barriers, two TMEM buffers | warp 4 | eight epilogue warps across two CTAs | tcgen05 commit to both `acc_ready`; each epilogue warp lane 0 remotely arrives at even `acc_free` after the shared edge drains |
+| deallocation | singleton count 32 per CTA | all lanes of peer warp 0 | local warp 0 | release remote arrive, acquire local parity wait |
+
+## Exact-K dispatch table
+
+| remainder class | body | A/B windows | scale batches | instruction descriptor |
+| --- | --- | ---: | ---: | --- |
+| 0 after full K=768 groups | no tail | 0 | 0 | none |
+| ordinary K%16 tail | 1..8 K96 cells with predicated dead sites | 3 | `ceil(tail_cells/2)` | `0x90400480` plus scale IDs |
+| active K64 `a=0,2,4,6`, `b=1` | `a` K96 cells then one K64 cell | `ceil((96a+64)/256)` | `ceil((a+1)/2)` | K96 as above; K64 clears bit 31 and descriptor bit 52 |
+| active K64 `a=0,2,4,6`, `b=2` | `a` K96 cells then two K64 cells | `ceil((96a+128)/256)` | `ceil((a+2)/2)` | second K64 uses the source's plain word-1 scale columns |
+
+The K64 branch is active only when the derived `b64_try` is nonzero, the
+remainder is divisible by 32, and `a` is nonnegative and even. All other
+remainders take the ordinary K96 tail. Cursor movement follows issued windows
+and batches, never the maximum body size.
+
+## L2 schedule and measured address-space adaptation
+
+The host performs the source's census and ownership construction before either
+timed implementation. It supplies the exact selected route order:
+
+- below 128 MiB operand reads: owned-pocket-8x8 only for a 32x32 tile grid,
+  otherwise owned-plain;
+- at or above 128 MiB: owned-pocket-8x4 for near-square grids with low side at
+  least 48 and aspect at most 1.25, otherwise Hilbert-in-owned;
+- no route may exceed 4096 tiles; every table must pass exactly-once coverage
+  and side-ownership verification;
+- the physical SM-to-side and cluster-to-side arrays accompany the route table,
+  and a nonzero post-launch placement counter invalidates correctness or timing.
+
+CUDA r9 declares the three read-only arrays in `.const`, producing five static
+`ld.const.b32` sites in the writer PTX: two audit loads, one in each producer
+body, and one epilogue load followed by `redux.sync.min.u32`. The public K API
+has no module-scope constant declaration or `ld.const` operand. The port
+therefore accepts read-only `K.gptr` buffers and uses `ld.global.nc.b32` while
+preserving load ownership, location, cadence, uniformization, table contents,
+and the placement atomic. This is the sole device-algorithm adaptation; it is
+accepted only if the reviewer finds it auditable, bitwise correctness passes,
+and every requested `bench_suite` ratio exceeds 0.99.
+
+## TIRx module and benchmark contract
+
+- The executable imports the device language only as
+  `import tirx_kernels.kern as K`. It uses rank-one shared allocation, scalar
+  offset functions, `K.TensorMap`, registers, K control flow, and raw `K.ptx`.
+  It uses no tile primitive, layout object, inline CUDA device call, IR checker
+  exemption, or change under `tirx_kernels/kern/`.
+- Correctness runs source and TIRx on byte-identical packed inputs and requires
+  bitwise equality of the complete FP16 output, finite results, complete poison
+  overwrite, unchanged input canaries, a zero placement counter, and repeated
+  deterministic output. The host/cublas checks retain the source's `atol=0.5`,
+  `rtol=2e-3` as secondary checks and never replace the bitwise source comparison.
+- The correctness matrix covers ragged K%16, both active K64 subclasses, an
+  inactive K64-looking remainder, an aligned tail, M/N boundaries, and the five
+  benchmark squares without repeatedly running the full matrix during tuning.
+- `prepare_bench` compiles before GPU timing and returns a prepared benchmark.
+  `run_gpu` allocates once, validates once, and gives the canonical Proton timer
+  exactly one source or TIRx GEMM launch per closure. The lazy reference name is
+  `fastcu_gemm9`; the implementation name is `tirx`.
+- Final performance authority is only `bench_suite`, with external references,
+  Proton, five rounds, one-second cooldown, and the five square configs. Both
+  source and TIRx PTX must say `.version 9.3` and `.target sm_103a` under the
+  same CUDA 13.3 nvcc toolchain.
+
+## Instruction-selection summary
+
+| source decision | emitted consequence in writer PTX |
+| --- | --- |
+| by-value tensor maps, fixed block/cluster | four aligned 128-byte params; `.reqntid 224`; `.reqnctapercluster 2,1,1`; `.blocksareclusters` |
+| `SmemCD` extern allocation | `.extern .shared .align 1024`, with source offsets A=1024, B=99328, SFA=197632, SFB=208896 |
+| lane-0 TMA producers | rank-3 cta-group-2 A multicast and B non-multicast; rank-4 cta-group-2 SFA self-multicast and SFB mask-3 multicast |
+| same-warp scale copy and MMA stream | `tcgen05.cp.cta_group::2.32x128b.warpx4` immediately ordered with `tcgen05.mma...mxf4nvf4...scale_vec::4X` and tcgen05 commits |
+| K96 versus K64 | identical MMA mnemonic; idesc bit 31 selects K=96, legacy descriptor/id-0 scale forms select K=64 |
+| overlap-aware epilogue drain | one x32 TMEM load per 32-column band, packed RN FP16 conversion, high-to-low/low-to-high alternating order, fused load wait before remote buffer release |
+| write-once output policy | aligned full segments use `st.global.L1::no_allocate.L2::evict_first.v8.b32`; smaller segments use no-L1 v4; scalar b16 only for N tails |
+| constant route load in epilogue | source `ld.const.b32` followed by `redux.sync.min.u32`; adaptation replaces only the load with `ld.global.nc.b32` |

--- a/.agents/sketch/flashattention/flash_attention4_fp4.md
+++ b/.agents/sketch/flashattention/flash_attention4_fp4.md
@@ -1,0 +1,890 @@
+<!--
+This sketch is a design artifact, not source. It is written once, reviewed
+once, and then frozen: the implementation follows it, and where the two
+disagree the TIRx module linked below is what runs.
+
+Documents a TIRx port of hao-ai-lab/flash-attention-fp4
+(https://github.com/hao-ai-lab/flash-attention-fp4 @ 5aa37a9680f7b76a11799b5f4846100ed5a3e6d8),
+flash_attn/cute/flash_fwd_sm100_fp4.py. SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# flash_attention4_fp4: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the storage layout, warp roles,
+pipelines, control flow, and PTX-level operations of
+[`tirx_kernels/flashattention/flash_attention4_fp4.py`](../../../tirx_kernels/flashattention/flash_attention4_fp4.py).
+That TIRx module is the authoritative implementation.
+
+The port covers **one kernel**: `FlashAttentionForwardSm100.kernel`
+(`flash_fwd_sm100_fp4.py:1330-1964`, cited below as `:NNNN`) with its trace-time
+launcher `__call__` (`:442-1327`), `__init__`/`_setup_attributes` (`:119-440`) and
+every role helper it dispatches to: `load` (`:1967-2235`), `mma` (`:2238-2722`),
+`softmax_loop`/`softmax_step` (`:2727-3063`, `:3559-3883`),
+`_fused_log2_group_quant` (`:3171-3295`), `_pack_fp8` (`:3332-3346`),
+`correction_loop`/`correction_rescale`/`correction_epilogue` (`:3886-4360`),
+`epilogue_s2g` (`:4405-4510`), `load_Q`/`load_KV` (`:4512-4589`) and
+`mainloop_s2t_copy_and_partition` (`:4591-4631`). The MMA issue sequences live in
+`blackwell_helpers.py` (`bh:`): `gemm_ptx_partial_fp4` (`bh:1224-1554`),
+`gemm_ptx_partial` (`bh:402-665`), `gemm_blockscaled_generic` (`bh:1191-1220`),
+`tmem_ld_red_max` (`bh:1777-1829`), the packers `packed_float_to_e2m1` (`bh:1624`),
+`packed_float_to_ue4m3` (`bh:1596`), `packed_float_to_ue8m0` (`bh:1849`) and
+`ceil_f32` (`bh:1833`). Softmax arithmetic is `SoftmaxSm100` (`softmax.py`, `sm:`),
+the packed fp32 idioms are `utils.py` (`ut:`), masking is `mask.py` (`mk:`), block
+ranges are `block_info.py` (`bi:`), tile order is `tile_scheduler.py` (`ts:`).
+
+**Every tensor core here sees block-scaled or narrow operands directly.** Q and K
+arrive as packed NVFP4 (E2M1 + E4M3 scale per 16) or MXFP8 (E4M3 + E8M0 scale
+per 32); V is BF16, plain E4M3, packed NVFP4 or MXFP8; when V is quantized the
+softmax warps quantize P on the fly and write P's scale factors to shared
+memory for the MMA warp to stage into TMEM. Scale factors travel GMEM -> SMEM
+(TMA) -> TMEM (`tcgen05.cp`) and are consumed by `tcgen05.mma...block_scale`.
+
+## Scope and instantiations
+
+Fixed for every specialization in this port:
+
+| axis | value | why it is fixed |
+| --- | --- | --- |
+| `m_block_size`, `n_block_size` | 128, 128 | `_flash_attn_fwd` defaults (`interface.py:218-219`) |
+| `q_stage` | 2 | `not is_split_kv` (`:166`); the CTA owns 256 Q rows |
+| `epi_stage`, `acc_stage` | 2, 1 | `:369-370` |
+| `cta_group` | 1 | `use_2cta_instrs` hard-asserted False (`:624-625`) |
+| `cluster` | (1,1,1) | `:174`, `:676` |
+| `pack_gqa` | **False** | the interface default is True for GQA (`interface.py:432`), but the fork's FP4 kernel is numerically wrong on that path (measured cos_sim 0.94/0.96 vs fp64 where the unpacked path gives 1.0000); both sides run unpacked, `kv_head = head // qhead_per_kvhead` (`:2014-2016`) |
+| `use_tma_KV`, `use_tma_O` | True | no paged KV, no varlen (`:153`, `:607`) |
+| `s0_s1_barrier` | False | `:198`; the 8 `s0_s1_sequence` mbarriers are allocated and never initialized |
+| `quant_qk` | True | Q/K scales are always supplied |
+| SM103 knobs | `use_ldred_rowmax=True`, `force_e2e=False`, `fp4_pv_log2_quant=True`, `fp8_pv_use_explicit_pack=True`, no store pipelining, `fp8_pv_zero_fill_regs=True`, `sfqk_tmem_slot="s"` | the device probe (`:72-95`) and env defaults (`:282-335`); pinned by the harness |
+| P handoff split knobs | fp8 3/4, fp4 1/2, bf16 3/4 | `:1105-1125` defaults |
+| P store repetition | 16 bf16, 8 fp8/fp4/mxfp8 at every head_dim | `:2790-2807`; the harness pins `FA4_FP8_PV_TMEM_STORE_REP=8`, which the source honours before its d=64 default of 4 (`:2798-2801`) |
+| `mLSE`, `learnable_sink`, `score_mod`, `mask_mod`, block sparsity, `v_descale`, split-KV, varlen, paged, local | absent / off | not in the README GB300 dispatch domain |
+
+In scope, i.e. the specializations this module compiles:
+
+| axis | values | what changes in device code |
+| --- | --- | --- |
+| `qk_format` | `nvfp4` (E2M1, E4M3 scale per 16) / `mxfp8` (E4M3, E8M0 scale per 32) | Q/K tile bytes (8 KB vs 16 KB), TMA swizzle (64B vs 128B), the QK MMA (`kind::mxf4nvf4.block_scale.scale_vec::4X`, K=64, 2 k-tiles at d=128 vs `kind::mxf8f6f4.block_scale.block32`, K=32, 4 k-tiles with per-k `sf_id`), SF bytes per tile (1024 vs 512), `sfqk` TMEM columns (8+8 vs 16+16) |
+| `pv_format` | `bf16` / `fp8` / `nvfp4` / `mxfp8` | V tile bytes and majorness, the PV MMA kind (`f16` K=16 / `f8f6f4` K=32 / `mxf4nvf4` 4X K=64 / `mxf8f6f4` block32 K=32), the P program (bf16x2 pack / e4m3x2 pack / log-domain group quant to E2M1 + E4M3 SF / to E4M3 + E8M0 SF), P columns in TMEM (64 / 32 / 16 / 32), P store shape and split, whether SFP/SFV exist, `rescale_threshold` (8.0 vs 0.0) and `max_offset` (0 / 0 / log2 6 / log2 448), whether the hw tile maxes feed the group maxes (mxfp8 PV only), `kv_stage` |
+| `head_dim` | 128; 64 only for `nvfp4+bf16` and `nvfp4+fp8` | QK k-tiles 2 -> 1, Q/K swizzle 64B -> 32B, `kv_stage` (4 -> 10, 4 -> 20), register split 192/80/48 -> 200/64/48, PV N 128 -> 64 (f16 idesc `0x08210490` -> `0x08110490`, f8f6f4 `0x08210010` -> `0x08110010`), O tile bytes, one TMA store per stage; the P store shape does not change (rep 8 pinned) |
+| `is_causal` | False / True | scheduler (persistent static vs single-tile LPT), `n_block_max` clipping, non-persistent grid, and the softmax body: three inlined `softmax_step` copies (first, diagonal loop, remaining loop), ALL masked with the software row max; the hw `ld.red` max and (mxfp8 PV) hw group maxes are consumed only by the non-causal steady copy |
+| `qhead_per_kvhead` | 1 / >1 | only the KV head index and the tile count; the device program is otherwise identical (unpacked GQA) |
+
+Out of scope, with the predicate that excludes each:
+
+- **`pack_gqa=True`** -- numerically wrong upstream (see the fixed-axes table).
+- **varlen / paged / split-KV / local / LSE / sink / score_mod / mask_mod / block-sparse** -- all gated
+  off at the host; the compiled-out arms are not transcribed.
+- **e2e exp2 emulation** (`force_e2e`), the store-pipelined P paths, the fused fp8
+  pack, the range-unrolled fp8 path -- env-gated off; the export contains none of
+  their instructions.
+- **2-CTA** -- asserted off.
+- Tile (`Tx`) primitives are out of scope everywhere.
+
+## The line-info exports this sketch is annotated from
+
+Every `instruction_selection` annotation below is read out of a line-info PTX
+export, not out of the source text. Sixteen exports are preserved under
+`.porting/flash_attention4_fp4/ptx_lineinfo/<name>/`, produced by
+`.porting/flash_attention4_fp4/export_driver.py` (real quantized data, s=512 so
+both `softmax_step` copies exist, `h=32`, `kv=32` or `kv=8`), with
+`CUTE_DSL_NO_CACHE=1 CUTE_DSL_KEEP=ptx CUTE_DSL_LINEINFO=1`. All are
+`.version 9.3 .target sm_103a`.
+
+| name | mode | causal / GQA | lines | `.loc` |
+| --- | --- | --- | ---: | ---: |
+| `nvfp4_bf16_d128` | 1 | no / MHA | 7617 | 2135 |
+| `nvfp4_fp8_d128` | 2 | no / MHA | 8148 | 2285 |
+| `nvfp4_nvfp4_d128` | 3 | no / MHA | 9247 | 2738 |
+| `nvfp4_mxfp8_d128` | 4 | no / MHA | 9068 | 2562 |
+| `mxfp8_bf16_d128` | 5 | no / MHA | 7430 | 2033 |
+| `mxfp8_fp8_d128` | 6 | no / MHA | 7969 | 2188 |
+| `<mode>_d128_causal_gqa` (six) | 1-6 | yes / h32kv8 | e.g. 11056 | e.g. 3428 |
+| `nvfp4_bf16_d64` (+ `_causal_gqa`) | 1 | both | 6854 | 2017 |
+| `nvfp4_fp8_d64` (+ `_causal_gqa`) | 2 | both | 7429 | 2171 |
+
+The `.file` table sits at the tail of each export and its numbering is assigned PER
+EXPORT: 1 `flash_fwd_sm100_fp4.py`, 2 `tile_scheduler.py`, 3 `copy_utils.py`, 4
+`block_info.py` are stable, but 5/6 are `mma_sm100_desc.py`/`blackwell_helpers.py` in the
+NVFP4-QK exports and swapped in the MXFP8-QK ones (the generic QK path emits
+`.loc 5 1214` there), and 7/8/9 are `mask/utils/softmax` in the non-causal NVFP4+BF16
+export, `softmax/mask/utils` in its causal build, and `mask/softmax/utils` in the causal
+mode-4 build. Resolve the table before attributing any `.loc N`. The annotations below
+therefore cite helper sites by FILE NAME and line (e.g. `blackwell_helpers.py:1828`,
+`mask.py:488`, `utils.py:466-473`, `softmax.py:238`), never by a bare file number. The inline-asm blocks of `gemm_ptx_partial*`
+and `tmem_ld_red_max` carry `.loc 1 442` (the `__call__` decorator line), so
+their identity is settled by opcode and operand shape, not by line.
+
+Facts that settle otherwise-ambiguous source text (unqualified counts are
+`nvfp4_bf16_d128`; counting convention: instruction lines minus predicated lines):
+
+1. **Every packed fp32 op is RN without ftz**: `fma.rn.f32x2` 128, `add.rn.f32x2`
+   127, `mul.rn.f32x2` 256; zero `.rz` anywhere. The scalar sites `mul.f32` (4),
+   `sub.f32` (3), `add.f32` (2) carry no rounding modifier. The only contracted
+   scalar FMAs are in the fp4/mxfp8 group-quant row sum (`fma.rn.f32` 17 in mode 3).
+2. **`tcgen05.ld.red.sync.aligned.32x32b.x32.f32.max`** is issued 4x per
+   softmax step in every mode (8 per non-causal export, 12 per causal one), but its
+   max is *consumed* only in the non-causal steady copy (`softmax.py:238` `max.f32 hw, row_max`
+   appears exactly once, in the non-causal exports). Every masked copy -- the first
+   step, and BOTH steady copies of a causal kernel (`unmasked = const_expr(not
+   is_causal ...)` at `:3001-3006` is False there) -- applies the r2p mask and
+   recomputes the row max with the software tree: 66 `max.f32` per copy
+   (`utils.py:418-432`), 198 in the causal export, and the hw-max instruction is absent
+   from it. For mxfp8 PV the same rule governs the hw tile maxes feeding the group
+   maxes (`:3213-3221`, non-causal steady copy only). In mode 3 the 16-element group
+   maxes add 10 `max.f32` per group.
+3. **One softmax body, two inlined `softmax_step` copies** (first + steady):
+   `ex2.approx.ftz.f32` = 257 = 2x128 + 1 (`acc_scale`); the causal export has a
+   third copy (386 = 3x128 + 2).
+4. **Descriptor high words**: Q/K NVFP4 d128 `0x80004020` (SWIZZLE_64B, SBO 512 B,
+   version 1), d64 `0xC0004010` (SWIZZLE_32B, SBO 256 B), e4m3 K-major `0x40004040`
+   (SWIZZLE_128B, SBO 1024 B) -- the same `0x40004040` is the MN-major bf16 V word and
+   the MN-major e4m3 V word at d128; at d64 the e4m3 V word is `0x80004020` (SW64B,
+   a 64-column e4m3 row is one 64 B swizzle atom). K-tile steps on the low word: `+0x2` (32 B) for FP4 K=64 and e4m3 K=32
+   K-major tiles, `+0x80` (2048 B = 16 rows) for MN-major V per K=16.
+5. **Instruction descriptors** (`mov.b32 idesc, ...` immediates): QK
+   `mxf4nvf4` `0x08201680`; PV `f16` N=128 `0x08210490`, N=64 `0x08110490`; PV
+   `f8f6f4` N=128 `0x08210010`, N=64 `0x08110010`; PV `mxf4nvf4` `0x08201680`; every `mxf8f6f4` use
+   `0x08A00000 | k<<29 | k<<4` for k = 0..3 (`a_sf_id`/`b_sf_id`). Two spellings carry
+   it: the generic QK path of modes 5/6 (`kind::mxf8f6f4.block_scale.block32`) ALSO
+   writes k into the top two bits of both SF TMEM address operands (`0x80`,
+   `0x40000080`, `0x80000080`, `0xC0000080` for SFQ column 128), whereas the
+   inline-asm PV path of mode 4 (`kind::mxf8f6f4.block_scale.scale_vec::1X`) keeps
+   static `[tmem_scale + 0x0]` operands and carries k only in the idesc immediate.
+6. **The MXFP8 QK path is the generic `cute.gemm` one**: it spells
+   `tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32` with a
+   `mov.pred` accumulate flag per instruction and precomputed per-k A/B descriptors
+   (four A descriptors and four B descriptors `+2k`), not the `scale_vec::1X` inline-asm chain.
+7. **TMA shapes**: Q/K/V/O are 4-D maps (coordinates `{col, row, head, batch}`), the
+   scale factors 5-D: SFQ/SFK issue `{0, 0, block, head, batch}` when a 128-row tile
+   spans two 512 B chunks (SF_TILE_K == 2: nvfp4 d128) and `{0, block, 0, head, batch}`
+   when it spans one (SF_TILE_K == 1: mxfp8 d128, nvfp4 d64 -- the block index moves to
+   dim 1, e.g. mxfp8_fp8_d128 `{%r=0, 2*m_block, %r=0, head, batch}`); mxfp8 SFV (one
+   chunk) `{0, 0, n_block, kv_head, batch}`; nvfp4 SFV `{0, 2*n_block, 0, kv_head, batch}`;
+   all with
+   `.L2::cache_hint` and a zero policy. BF16 V and O at d=128 need two 64-column
+   issues per tile (`+0x80` column coordinate 64); e4m3 V and FP4 V one.
+8. **SMEM byte map** (mode 1, from the `+imm` operands): mbarriers 0..327,
+   `tmem_holding_buf` 328, `sScale` 1024, `sO` 3072, `sQ` 68608, `sV` 84992 (K
+   aliases V), `sSFQ` 216064, `sSFK` 218112; each field starts on a 1024 B boundary.
+9. **mbarrier counts** (`mov.b32` before `mbarrier.init`): q_full/q_empty 1/1,
+   kv_full/kv_empty 1/1, P_full_O_rescaled 256, S_full 1, O_full 1,
+   softmax_corr full/empty 128/128, corr_epi full/empty 128/32, tmem_dealloc 384,
+   P_full_2 128, sfqk_load 128; 31 inits at kv_stage 4 (23 + 2 * kv_stage).
+10. **setmaxnreg**: `dec 48` x3 (warps 14, 12, 13), `dec 24` (warp 15), `inc 192`
+    (softmax), `dec 80` (correction); d=64 exports show `inc 200` / `dec 64`.
+
+Reproduce any export with:
+
+```bash
+mkdir -p .porting/flash_attention4_fp4/ptx_lineinfo/<name>
+CUTE_DSL_NO_CACHE=1 CUTE_DSL_KEEP=ptx CUTE_DSL_LINEINFO=1 \
+CUTE_DSL_DUMP_DIR=$PWD/.porting/flash_attention4_fp4/ptx_lineinfo/<name> \
+python .porting/flash_attention4_fp4/export_driver.py <qk> <pv> <head_dim> <causal 0|1> <h> <kv> [seq]
+```
+
+## Pipeline at a glance
+
+16 warps, 512 threads, one CTA per work tile (persistent when non-causal). Role
+selection is a flat sequence of `if warp_idx ...` blocks in source order
+(`:1737-1963`); each role runs its own copy of the tile scheduler loop.
+
+| Warps | Role-local tile program | Main publication / reuse edges |
+| --- | --- | --- |
+| 0..3 | softmax warpgroup 0, Q stage 0: per KV block load S from TMEM (hw row max), mask, online max, scale-subtract, exp2 + P conversion (+ P scales), store P to TMEM, row sum | waits `S_full[0]`; publishes `sfqk_load[1]`, `softmax_corr_full[0]` + `sScale`, `P_full_O_rescaled[0]`, `P_full_2[0]` (+ `sSFP[0]`); waits `softmax_corr_empty[0]` |
+| 4..7 | softmax warpgroup 1, same body with runtime `stage = 1` | the `[1]` slots; publishes `sfqk_load[0]` (and pre-arrives it once) |
+| 8..11 | correction warpgroup: rescale O in TMEM when a row max moved, then normalize O, convert to bf16 and stage it in `sO` | waits `softmax_corr_full[s]`; publishes `softmax_corr_empty[1-s]`, `P_full_O_rescaled[s]` (pre-arrives both once), `corr_epi_full[s]`; waits `O_full[s]`, `corr_epi_empty[s]` |
+| 12 | the single MMA-issue warp; TMEM allocator; stages scale factors SMEM -> TMEM | waits `q_full`, `kv_full`, `sfqk_load[s]`, `P_full_O_rescaled[s]`, `P_full_2[s]`; commits `S_full[s]`, `kv_empty`, `q_empty`, `O_full[s]`; waits `tmem_dealloc` |
+| 13 | epilogue: TMA-stores `sO[s]` | waits `corr_epi_full[s]`; publishes `corr_epi_empty[s]` |
+| 14 | load: TMA Q(+SFQ) x2, then K(+SFK), V(+SFV) per KV block, newest block first | waits `q_empty`, `kv_empty`; arrives `q_full`, `kv_full` with tx bytes |
+| 15 | idle; `setmaxnreg.dec 24` and falls out (`:1737-1739`) | none |
+
+**KV is a ring of `kv_stage` slots shared by K and V**: the loader alternates
+K_i, V_i into successive slots (`:2195-2214`); when K is narrower than V (FP4 K,
+BF16/FP8 V) K lives inside V's slot with V's stage stride (`:1526-1536`); when
+they have the same width V aliases K (`:1523-1525`).
+
+**Blocks are visited newest-first**: `n_block = n_block_max-1 .. n_block_min`
+(`:2187-2214`); the first block is the one that gets the seqlen mask.
+
+**Two Q tiles per CTA, interleaved in the MMA warp**: for every KV block the MMA
+warp issues PV(stage 0), PV(stage 1) and then QK(stage 0), QK(stage 1)
+(`:2494-2637`); softmax warpgroup `s` sees only stage `s`.
+
+## Primitive vocabulary
+
+Structural operations do not compute values:
+
+```python
+tile(space, dtype, shape, align)   # a 1-D linear allocation; no layout attached
+offset(name, ...)                   # a named scalar byte/column offset function
+reg_tile(shape, dtype)              # role-local registers
+tensormap(...)                      # a TMA descriptor: dims, strides, box, swizzle
+tmem_cols(base, count)              # a TMEM column interval (lanes are implicit: 32x32b)
+```
+
+Copies always state their storage direction:
+
+```python
+copy_g2s(map, coords, dst_smem, bar)      # TMA load, completes on `bar`
+copy_s2g(map, coords, src_smem)           # TMA store, bulk group
+copy_s2t(desc, dst_cols)                  # tcgen05.cp: 512 B SF chunk -> 4 TMEM columns
+copy_t2r(cols, regs)                      # tcgen05.ld
+copy_t2r_max(cols, regs, red)             # tcgen05.ld.red ... .max: values + their max
+copy_r2t(cols, regs)                      # tcgen05.st
+store_shared(smem, byte_off, value)       # st.shared
+load_shared(smem, byte_off) -> reg        # ld.shared
+```
+
+The computational vocabulary:
+
+```python
+gemm(dst_cols, a, b, idesc, sfa=None, sfb=None, accumulate)  # one tcgen05.mma
+fill(dst, value)
+fma(dst, a, b, c, lanes=1)          # lanes=2 is one packed two-lane op
+mul(dst, a, b, lanes=1)
+add(dst, a, b, lanes=1)
+sub(dst, a, b)
+max(dst, a, b) / max3(dst, a, b, c) # 2- and 3-source max.f32
+exp2(dst, src)                      # ex2.approx.ftz
+rcp(dst, src)                       # rcp.approx.ftz
+ceil(dst, src)                      # cvt.rpi.f32.f32
+select(dst, pred, a, b)
+cast_bf16x2(dst, hi, lo)            # cvt.rn.bf16x2.f32
+cast_e4m3x2(dst, hi, lo)            # cvt.rn.satfinite.e4m3x2.f32
+cast_e2m1x2(dst, hi, lo)            # cvt.rn.satfinite.e2m1x2.f32 (one byte)
+cast_ue8m0x2(dst, hi, lo)           # cvt.rz.satfinite.ue8m0x2.f32
+shift_right_u32(dst, src, n)        # shr.u32 (saturating)
+```
+
+Small index and mask decodes are written as expressions so no primitive hides a
+computation. There is deliberately no `tree_max`, `tree_sum`, `quantize`,
+`softmax`, `attention`, `mask`, `TMA`, `TCGEN05`, `descriptor` or `epilogue`
+primitive: every reduction tree, every group loop and every conversion pass is
+written out where it occurs.
+
+Schedule operations: `pipe`, `init`, `wait`, `arrive`, `arrive_expect_tx`,
+`commit` (the matrix engine's arrive: `tcgen05.commit`), `release`, `fence`, `elect`,
+`set_register_budget`, `allocate_tmem`, `relinquish_tmem_alloc_permit`,
+`free_tmem`, `wait_tmem_ld`, `wait_tmem_st`, `bulk_commit_group`,
+`bulk_wait_group_read`, and cursor (`slot`, `phase`) updates.
+
+Two of them have a fixed lowering everywhere they appear, stated here once and
+referenced inline as `# release: elect+commit` / `# arrive: mbarrier.arrive`:
+
+- `release(kv_load.empty[s])` (`pipeline_kv.consumer_release`, `:2485/2579/2632/2715`)
+  = `elect.sync` + `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
+  [kv_empty + 8s]`; extent: scalar (the MMA warp's slot release IS a tcgen05 commit).
+- `arrive(x)` = `mbarrier.arrive.shared.b64 [mbar + off], 1` executed by every thread of
+  the calling role (128 for a softmax or correction warpgroup, 32 for the epilogue warp);
+  extent: scalar per thread. 28 static sites in the non-causal export, 32 in the causal one.
+
+**THE_WAIT.** Every mbarrier wait in this kernel is the same inline-asm retry
+loop, never one instruction:
+
+```text
+LAB_WAIT: mbarrier.try_wait.parity.shared.b64 P1, [addr], phase, 10000000;
+          @P1 bra.uni DONE;  bra.uni LAB_WAIT;  DONE:
+```
+
+38 sites are `.shared` in a non-causal export (40 in a causal one: the third
+`softmax_step` copy adds an `S_full` and a `softmax_corr.empty` wait); the 4 embedded
+inside the PV MMA chains are `.shared::cta` with plain `bra`. Extent below is "one
+retry loop".
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+BLK_M = BLK_N = 128;  Q_STAGE = 2;  EPI_STAGE = 2;  TMEM_COLS = 512     # :129-130,:166,:369-370,:219
+qk_format  in {nvfp4, mxfp8}      # q_width 4 | 8, sf_vec 16 | 32, SF dtype E4M3 | E8M0
+pv_format  in {bf16, fp8, nvfp4, mxfp8}   # v_width 16 | 8 | 4 | 8, quant_pv = pv in {nvfp4, mxfp8}
+D  = head_dim in {128, 64};  DV = D                                        # :157-161
+QK_K   = 64 if q_width == 4 else 32;  QK_KT = D // QK_K                  # 256-bit operand tile :344-352
+PV_K   = {16: 16, 8: 32, 4: 64}[v_width];  PV_KT = BLK_N // PV_K
+SF_TILE_K    = D // (4 * sf_vec)            # 512 B SF chunks per Q/K tile: 2 (nvfp4 d128), 1 (mxfp8 d128, nvfp4 d64)
+SF_TILE_K_PV = BLK_N // (4 * sf_vec_pv)     # 2 (nvfp4 PV), 1 (mxfp8 PV)
+regs_softmax, regs_correction, regs_other = (192, 80, 48) if D >= 96 else (200, 64, 48)   # :260-274
+kv_stage   # _setup_attributes :369-424: (227 KiB - fixed) // per-stage; fp8-V cap 4 -> {4,4,13,7,3,4}@d128, {10,20}@d64
+P_COLS     = BLK_N * v_width // 32          # 64 | 32 | 16 | 32
+P_REP      = 16 if v_width == 16 else 8       # :2790-2807 with FA4_FP8_PV_TMEM_STORE_REP=8 pinned (also at d=64)
+P_CHUNKS   = P_COLS // P_REP;  P_SPLIT = mbar_p_split(P_CHUNKS)                  # 3/4 | 3/4 | 1/2 | 3/4 (fp8 d64: 3/4 too)
+PV_SPLIT   = mbar_p_split(PV_KT)            # 6/8 | 3/4 | 1/2 | 3/4                                    :1105-1125
+max_offset = {nvfp4: log2(6) = 0x40257007, mxfp8: log2(448) = 0x410CEAED}.get(pv_format, 0.0)      # :2862-2878
+rescale_threshold = 0.0 if quant_pv else 8.0
+is_causal;  qhead_per_kvhead = H // HKV;  pack_gqa = False;  is_persistent = not is_causal
+# instruction_selection: none; extent: compile-time constants only.
+
+# Runtime ABI (the port's entry; the source passes cute tensors + TMA atoms + layouts :1275-1320)
+mQ, mK        # packed bytes (b, s, h, D/2) e2m1x2 | (b, s, h, D) e4m3
+mV            # (b, s_k, hkv, DV) bf16 | e4m3 (MN-major) ; (b, hkv, DV, s_k/2) e2m1x2 | (b, hkv, DV, s_k) e4m3 (K-major)
+mO            # (b, s_q, h, DV) bf16
+mSFQ, mSFK    # bytes [b][h][s/128][D/(4 sf_vec)][32][4][4]  (the 7-D (32,4,rest_m,4,rest_k,h,b) view :892,:913)
+mSFV          # quant_pv only: [b][hkv][DV/128][s_k/(4 sf_vec_pv)][32][4][4]                       :964
+softmax_scale_log2      # f32 = softmax_scale * log2(e), host-computed                        :1244-1246
+tmaps: Q, K, V, O, SFQ, SFK, [SFV]   # CUtensorMaps encoded on the host (see the TensorMap table)
+# instruction_selection: .param .align 64 .b8 x7 (128-byte tensormaps) and .param .f32; extent: ABI only.
+#   The export's entry takes 4 tensor params, 7 tensormap params (`_param_4..7,15,17` plus
+#   the SF maps), one f32 and the scheduler/shape structs; the port passes the same maps by value.
+
+launch(grid = min(num_SMs, tiles) if is_persistent else tiles,       # ts:338-348 / ts:522-530
+       block = 512, cluster = (1,1,1), smem = sizeof(SharedStorage), min_blocks_per_mp = 1)
+tiles = B * H * ceil(S_Q / 256)
+# instruction_selection: none; extent: launch geometry (:1320-1327).
+
+# ===========================================================================
+# Storage -- one 1-D linear allocation per SharedStorage field, in declaration order
+# (:1139-1192), each 1024-aligned. Byte map for nvfp4+bf16 d128 confirmed from the export's
+# `+imm` operands (fact 8).
+# ===========================================================================
+mbar    = tile("shared", "u64", [33 + 2*kv_stage])      # 41 slots / 328 B at kv_stage 4: q_full[2] @0, q_empty[2] @16, kv_full[kv] @32,
+                                                         # kv_empty[kv] @32+8kv, P_full_O_rescaled[2], S_full[2],
+                                                         # O_full[2], sc_full[2], sc_empty[2], ce_full[2], ce_empty[2],
+                                                         # s0_s1[8] (never initialized), tmem_dealloc[1], P_full_2[2],
+                                                         # sfqk_load[2], sfpv_load[2] (never used)          :1080-1097
+tmem_holding_buf = tile("shared", "u32", [1])            # @328
+sScale  = tile("shared", "f32", [2 * 128 * 2], align=1024)     # @1024; [stage*128 + row] used, +256.. unused (no LSE)
+sO      = tile("shared", "bf16", [2 * 128 * DV], align=1024)   # @3072; 128-B swizzled 64-column halves (see sO_off)
+sQ      = tile("shared", "u8", [2 * 128 * D * q_width // 8], align=1024)     # @68608; K-major, 64B/32B/128B swizzle
+sK      = tile("shared", "u8", [1 if k_aliases_v else kv_stage * 128 * D * k_width // 8], align=1 or 1024)
+sV      = tile("shared", "u8", [1 if v_aliases_k else kv_stage * 128 * DV * v_width // 8], align=1 or 1024)  # @84992
+sSFQ    = tile("shared", "u8", [2 * 512 * SF_TILE_K], align=1024)            # @216064
+sSFK    = tile("shared", "u8", [kv_stage * 512 * SF_TILE_K], align=1024)     # @218112
+sSFP    = tile("shared", "u8", [2 * 512 * SF_TILE_K_PV if quant_pv else 1], align=1024)
+sSFV    = tile("shared", "u8", [kv_stage * 512 * SF_TILE_K_PV if quant_pv else 1], align=1024)
+# K/V aliasing (:1523-1539): FP4 K inside BF16/FP8 V -> K stage s starts at sV + s * v_stage_bytes;
+# same width -> V stage s starts at sK + s * k_stage_bytes.
+def kv_slot_off(s):   return s * max(k_stage_bytes, v_stage_bytes)
+def sf_chunk_off(stage, c): return stage * 512 * SF_TILE_K + 512 * c        # chunk = 32 rows x 4 groups x 4
+def sO_off(stage, r, c):    # r row 0..127, c column 0..DV-1, bf16
+    return stage * 128 * DV * 2 + (c // 64) * 16384 + (r // 8) * 1024 + (r % 8) * 128 \
+           + (((c % 64) // 8) ^ (r % 8)) * 16 + (c % 8) * 2
+def sSFP_off(stage, lane, warp, k_outer): return stage * 512 * SF_TILE_K_PV + lane * 16 + (warp % 4) * 4 + 512 * k_outer   # :3757-3773
+
+# TMEM: 512 columns, all names absolute (the allocation base is asserted to be 0).
+S    = [tmem_cols(0, 128),   tmem_cols(128, 128)]           # :243
+O    = [tmem_cols(256, DV),  tmem_cols(256 + DV, DV)]       # :244-247
+P    = [tmem_cols(64, P_COLS), tmem_cols(192, P_COLS)]      # aliases the upper half of S       :251-256
+SFQ  = [tmem_cols(128, 4*QK_KT), tmem_cols(0, 4*QK_KT)]     # parked on the OPPOSITE S stage      :1618-1644
+SFK  = [tmem_cols(128 + 4*QK_KT, 4*QK_KT), tmem_cols(4*QK_KT, 4*QK_KT)]                          # :1650-1664
+SFP  = [tmem_cols(0, 4*SF_TILE_K_PV),   tmem_cols(128, 4*SF_TILE_K_PV)]        # quant_pv; on S's own stage :1671-1682
+SFV  = [tmem_cols(0 + sfp_cols, ...),   tmem_cols(128 + sfp_cols, ...)]        # sfp_cols = 4*SF_TILE_K_PV = 8 (fp4) | 4 (mxfp8) :1689-1700
+# instruction_selection: none; extent: column arithmetic. Export: SFQ/SFK chunks land at columns
+#   128,132 / 136,140 for stage 0 and 0,4 / 8,12 for stage 1 (nvfp4 d128); 128 / 144 (mxfp8 d128). SFP/SFV
+#   chunks land at 0,4 / 8,12 (mode 3, stage 0; +128 for stage 1) and at 0 / 4 (mode 4, stage 0; 128 / 132 stage 1).
+
+# mbarriers (counts: fact 9)
+q_load        = pipe(2,        full=1 (+tx),  empty=1)       # empty arrive = tcgen05.commit          :1446-1451
+kv_load       = pipe(kv_stage, full=1 (+tx),  empty=1)       # PipelineTmaUmma                        :4644-4658
+P_full_O_rescaled = mbar(2, 256)      # 128 softmax + 128 correction arrivals                          :1479-1482
+S_full        = mbar(2, 1)            # tcgen05.commit                                                :1484
+O_full        = mbar(2, 1)            # tcgen05.commit, tail PV only                                   :1487
+softmax_corr  = pipe(2, full=128, empty=128)                                                          # :1455-1459
+corr_epi      = pipe(2, full=128, empty=32)                                                           # :1469-1475
+tmem_dealloc  = mbar(1, 384)          # softmax 256 + correction 128                                   :1496-1506
+P_full_2      = mbar(2, 128)                                                                          # :1492-1494
+sfqk_load     = mbar(2, 128)                                                                          # :1510-1512
+# instruction_selection: mbarrier.init.shared.b64 x(23 + 2*kv_stage) with the count in a register;
+#   extent: scalar each. Initialized by warps 1,2,4,5,6,7,8 (:1443-1512) and the kv pipeline ctor
+#   (:1514), then fence.mbarrier_init.release.cluster + bar.sync 0 (one CTA-wide pair).
+
+# ===========================================================================
+# Prologue (:1392-1514)
+# ===========================================================================
+warp = warp_id()                          # make_warp_uniform
+if warp == 0:
+    prefetch_descriptor(tmap) for tmap in (Q, K, V, O, SFQ, SFK, [SFV])
+    # instruction_selection: prefetch.tensormap x6/7 (:1394-1407); extent: scalar each.
+# barrier inits as above; then
+fence("mbarrier_init.release.cluster"); barrier()   # cta-wide
+# instruction_selection: fence.mbarrier_init.release.cluster; bar.sync 0; extent: scalar.
+
+# ===========================================================================
+# Role dispatch -- flat `if` blocks in source order (:1737-1963)
+# ===========================================================================
+if warp == 15: set_register_budget(dec=24)                              # :1737-1739 (port: 48, K warpgroup-uniform)
+if warp == 14: set_register_budget(dec=regs_other); load_warp()          # :1750-1782
+if warp == 12: set_register_budget(dec=regs_other); mma_warp()           # :1787-1843
+if warp == 13: set_register_budget(dec=regs_other); epilogue_warp()      # :1848-1861
+if warp <  8:  set_register_budget(inc=regs_softmax); softmax_warpgroup(stage = warp >> 2)   # :1866-1918
+if 8 <= warp < 12: set_register_budget(dec=regs_correction); correction_warpgroup()          # :1939-1962
+# instruction_selection: setmaxnreg.dec.sync.aligned.u32 48 x3, 24 x1, 80 x1; setmaxnreg.inc 192 x1
+#   (fact 10); extent: scalar each. One softmax body with runtime `stage`, not two copies (fact 3).
+```
+
+```python
+# ===========================================================================
+# Load warp 14 (:1967-2235, :4515-4592)
+# ===========================================================================
+def load_warp():
+    q_phase = 1;  kv = cursor(kv_stage, phase=1)        # producer state       :2001-2004
+    sched = scheduler(); tile = sched.initial()
+    while tile.valid:                                      # :2007
+        m_block, head, batch = tile;  kv_head = head // qhead_per_kvhead          # :2014-2016
+        n_min, n_max = block_range(m_block)                # bi:24-55: n_max = ceil(S_K/128), causal min(., ceil(((m_block+1)*256 + S_K - S_Q)/128))
+        # ---- Q0 + SFQ0 -----------------------------------------------------------------
+        load_Q(block = 2*m_block + 0, stage = 0)
+        load_K(n_max - 1); kv.advance()
+        load_Q(block = 2*m_block + 1, stage = 1);  q_phase ^= 1
+        load_V(n_max - 1); kv.advance()
+        for i in range(n_max - 1 - n_min):                 # rolled, unroll=1    :2202
+            n = n_max - 2 - i
+            load_K(n); kv.advance();  load_V(n); kv.advance()
+        sched.advance(); tile = sched.current()
+
+    def load_Q(block, stage):                              # :4512-4529
+        wait(q_load.empty[stage], q_phase)
+        # instruction_selection: THE_WAIT; extent: one retry loop.
+        with elect():
+            arrive_expect_tx(q_load.full[stage], tma_bytes_q)     # 9216 (nvfp4 d128: 8192 tile + 1024 SF) | 16896 (mxfp8) | 4608 (nvfp4 d64)
+            # instruction_selection: elect.sync; mbarrier.arrive.expect_tx.shared.b64 with `mov.b32 9216`; extent: scalar.
+        with elect():
+            copy_g2s(Q, {0, block*128, head, batch}, sQ + stage*q_stage_bytes, q_load.full[stage])
+            # instruction_selection: cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes
+            #   .L2::cache_hint (policy 0), coords {0, block<<7, head, batch} with block = 2*m_block + stage the 128-row
+            #   block index (`%r16 = m_block<<1`, `%r20 = %r16 + 1`, row = block<<7); extent: one (D*q_width/8 B, 128 rows) box.
+        with elect():
+            copy_g2s(SFQ, coords_sf(block, head, batch), sSFQ + stage*512*SF_TILE_K, q_load.full[stage])
+            # instruction_selection: cp.async.bulk.tensor.5d...complete_tx::bytes.L2::cache_hint, coords
+            #   {0, 0, block, head, batch} when SF_TILE_K == 2 (nvfp4 d128) and {0, block, 0, head, batch} when
+            #   SF_TILE_K == 1 (mxfp8 d128, nvfp4 d64: mxfp8_fp8_d128 export `{%r=0, 2*m_block, %r=0, ...}`), with the
+            #   same 128-row block index (2*m_block + stage); extent: one (256 x SF_TILE_K) u16 box = 512*SF_TILE_K bytes.
+
+    def load_K(n) / load_V(n):                             # :4531-4589
+        slot, phase = kv.slot, kv.phase
+        wait(kv_load.empty[slot], phase)                   # instruction_selection: THE_WAIT; extent: one retry loop.
+        with elect():
+            arrive_expect_tx(kv_load.full[slot], tma_bytes_k | tma_bytes_v)    # K: 9216 nvfp4 d128 | 16896 mxfp8 | 4608 nvfp4 d64 ; V: 32768 bf16 d128 | 16384 bf16 d64 | 16384 e4m3 d128 | 8192 e4m3 d64 | 9216 fp4 | 16896 mxfp8
+            # instruction_selection: elect.sync; mbarrier.arrive.expect_tx.shared.b64 (`.loc 1 4565`); extent: scalar.
+        with elect():                                                       # :4574 (cute.copy lowers to one elect per copy)
+            copy_g2s(K, {0, n*128, kv_head, batch}, sK_slot(slot), kv_load.full[slot])
+            # instruction_selection: elect.sync + cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx
+            #   ::bytes.L2::cache_hint (`.loc 1 4574`); extent: one K tile. V: bf16 d128 issues TWO such elected 4d
+            #   copies (column coords 0 and 64, dst +0 and +16384) -- 8 4d loads per export vs 6 for e4m3/FP4 V (fact 7).
+            #   MN-major V (bf16/e4m3) uses the K form {0|64, n*128, kv_head, batch}; K-major V puts the key block on
+            #   dim 0: nvfp4 V {n*64 B, 0, kv_head, batch} (E3c line 702 `{%r=n<<7, 0, kv_head, batch}`, in 4-bit
+            #   elements), mxfp8 V {n*128, 0, kv_head, batch} (mode-4 export `.loc 1 4574`).
+        with elect():                                                       # :4589
+            copy_g2s(SFK, coords_sf(n, kv_head, batch), sSFK slot, kv_load.full[slot])                     # load_K
+            # instruction_selection: elect.sync + cp.async.bulk.tensor.5d...complete_tx::bytes.L2::cache_hint (`.loc 1
+            #   4589`), coords {0, 0, n, kv_head, batch} when SF_TILE_K == 2 (E3c line 610) and {0, n, 0, kv_head, batch}
+            #   when SF_TILE_K == 1 (mxfp8_fp8_d128 / nvfp4_fp8_d64 exports); extent: one 512*SF_TILE_K B box.
+            [copy_g2s(SFV, coords_sfv(n), sSFV slot, kv_load.full[slot])]                                   # load_V, quant_pv
+            # instruction_selection: same 5d copy (`.loc 1 4589`); coords differ per pv_format: nvfp4 PV (sf_vec 16,
+            #   two 512 B chunks per 128 keys) {0, 2n, 0, kv_head, batch} (E3c lines 714/847 `{0, n<<1, 0, ...}`,
+            #   box (256, 2, 1, 1, 1)); mxfp8 PV (sf_vec 32, one chunk) {0, 0, n, kv_head, batch} (mode-4 export,
+            #   box (256, 1, 1, 1, 1)); extent: one 512*SF_TILE_K_PV B box.
+```
+
+```python
+# ===========================================================================
+# MMA warp 12 (:1787-1843, :2238-2722)
+# ===========================================================================
+def mma_warp():
+    allocate_tmem(512, tmem_holding_buf); warp_sync()                       # :1791-1794
+    # instruction_selection: tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [buf], 512; bar.warp.sync; extent: warp.
+    q_phase = 0; kv = cursor(kv_stage, phase=0); p_phase = 0; sfqk_phase = 0     # :2352-2356, :2403
+    sched = scheduler(); tile = sched.initial()
+    while tile.valid:
+        n_min, n_max = block_range(m_block);  n_blocks = n_max - n_min
+        # ---- QK0, QK1 on the newest block -------------------------------------------- :2423-2489
+        for stage in (0, 1):
+            wait(q_load.full[stage], q_phase)                                   # THE_WAIT
+            if stage == 0: wait(kv_load.full[kv.slot], kv.phase)                # THE_WAIT
+            fence("tcgen05.after_thread_sync")                                  # :2441
+            # instruction_selection: tcgen05.fence::after_thread_sync; extent: scalar (4 static).
+            wait(sfqk_load[stage], sfqk_phase)                                  # :2442  THE_WAIT
+            for c in range(SF_TILE_K):                                              # :2446-2450 (one cute.copy = all SFQ chunks)
+                with elect(): copy_s2t(sf_desc(sSFQ, sf_chunk_off(stage, c)), SFQ[stage] + 4c)
+            for c in range(SF_TILE_K):                                              # :2455-2459 (then all SFK chunks)
+                with elect(): copy_s2t(sf_desc(sSFK, sf_chunk_off(kv.slot, c)), SFK[stage] + 4c)
+                # instruction_selection: tcgen05.cp.cta_group::1.32x128b.warpx4 [col], desc, one per 512 B chunk, each under
+                #   its own elect.sync, issue order SFQ c0, SFQ c1, SFK c0, SFK c1 (columns 128,132 then 136,140 for stage 0);
+                #   the chunk descriptor is the SF base descriptor +32 (16 B units) per chunk and + stage_bytes/16 per slot;
+                #   extent: 4 columns per instruction (16 per export at nvfp4 d128).
+            gemm_qk(stage, kv.slot)
+            with elect(): commit(S_full[stage])                                  # :2477-2478
+            # instruction_selection: elect.sync; tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64; extent: scalar.
+        q_phase ^= 1; sfqk_phase ^= 1
+        release(kv_load.empty[kv.slot]); kv.advance()                           # release: elect+commit  :2485-2486
+        # ---- steady loop over the remaining blocks ---------------------------------- :2494-2637
+        accumulate = False
+        for i in range(n_blocks - 1):                                            # rolled, unroll=1
+            wait(kv_load.full[kv.slot], kv.phase)                                # V_i           THE_WAIT
+            v_slot = kv.slot
+            for stage in (0, 1):
+                wait(P_full_O_rescaled[stage], p_phase)                          # :2512          THE_WAIT
+                if quant_pv:
+                    for c in range(SF_TILE_K_PV):                                       # :2527-2531 (all SFP chunks first)
+                        with elect(): copy_s2t(sf_desc(sSFP, sf_chunk_off(stage, c)), SFP[stage] + 4c)
+                    for c in range(SF_TILE_K_PV):                                       # :2535-2539 (then all SFV chunks)
+                        with elect(): copy_s2t(sf_desc(sSFV, sf_chunk_off(v_slot, c)), SFV[stage] + 4c)
+                        # instruction_selection: tcgen05.cp...32x128b.warpx4 x SF_TILE_K_PV each, issue order SFP c0..,
+                        #   then SFV c0.. (mode 3 columns 0,4 then 8,12; mode 4: 0 then 4); extent: 4 columns each
+                        #   (32 cp per export in mode 3, 24 in mode 4).
+                gemm_pv(stage, v_slot, accumulate, wait_bar=(P_full_2[stage], p_phase))
+                if stage == 1: release(kv_load.empty[v_slot])                    # release: elect+commit  :2578-2580
+                if stage == 0: kv.advance(); wait(kv_load.full[kv.slot], kv.phase)   # K_i           :2585-2587
+                fence("tcgen05.after_thread_sync"); wait(sfqk_load[stage], sfqk_phase)   # :2598-2599
+                all SFQ[stage] chunks, then all SFK[stage] chunks, as above      # :2600-2613
+                gemm_qk(stage, kv.slot)
+                with elect(): commit(S_full[stage])                              # :2626-2627
+            release(kv_load.empty[kv.slot]); kv.advance(); p_phase ^= 1; sfqk_phase ^= 1; accumulate = True   # release: elect+commit :2632
+        with elect():
+            for stage in (0, 1): commit(q_load.empty[stage])                     # :2641-2643
+        # ---- tail PV on the last V ---------------------------------------------------- :2645-2716
+        wait(kv_load.full[kv.slot], kv.phase)
+        for stage in (0, 1):
+            wait(P_full_O_rescaled[stage], p_phase)
+            [all SFP[stage] chunks, then all SFV[stage] chunks]                  # :2663-2679
+            gemm_pv(stage, kv.slot, accumulate, wait_bar=(P_full_2[stage], p_phase))
+            with elect(): commit(O_full[stage])                                  # :2710-2711
+        p_phase ^= 1; release(kv_load.empty[kv.slot]); kv.advance()             # release: elect+commit  :2715
+        sched.advance(); tile = sched.current()
+    relinquish_tmem_alloc_permit(); wait(tmem_dealloc, 0); free_tmem(load_shared(tmem_holding_buf), 512)   # :1834-1843
+    # instruction_selection: tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned; THE_WAIT; ld.shared.b32;
+    #   tcgen05.dealloc.cta_group::1.sync.aligned.b32; extent: warp.
+
+def gemm_qk(stage, slot):                     # bh:1326-1408 (nvfp4) / bh:1191-1220 (mxfp8)
+    a_lo = ((sQ + stage*q_stage_bytes) >> 4) | LBO_bits;  b_lo = ((sK_slot(slot)) >> 4) | LBO_bits
+    for k in range(QK_KT):
+        gemm(S[stage], desc(a_lo + 2k, HI_QK), desc(b_lo + 2k, HI_QK), idesc_qk(k),
+             sfa = SFQ[stage] + sf_col(k), sfb = SFK[stage] + sf_col(k), accumulate = (k != 0))
+    # instruction_selection, nvfp4: `@leader tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X
+    #   [tmem_acc], smem_desc_a, smem_desc_b, idesc, [tmem_scale_a], [tmem_scale_b], 0|1` x QK_KT inside ONE inline-asm
+    #   block: `elect.sync _|leader_thread`, descriptor halves assembled with `mov.b64 {lo,hi}`, hi = 0x80004020
+    #   (d128) / 0xC0004010 (d64), lo stepped `add.u32 ..., 0x2` per k-tile, idesc `mov.b32 0x08201680` then
+    #   `and 0xC0000000 / shr 1 / or` and `and / shr 26 / or` of the two SF address top bits (zero here), SF column +4
+    #   per k-tile (scale_vec::4X), first instruction's accumulate operand is the immediate 0 (zero_init), the rest 1;
+    #   extent: QK_KT instructions per issue, 8 per export (d128), 4 (d64).
+    # instruction_selection, mxfp8: `tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d], a_desc, b_desc,
+    #   idesc, [sfa], [sfb], p` x4, one elect.sync region each, `mov.pred p, 0|-1`, precomputed per-k descriptors
+    #   (`%rd7,12,13,14`; b `+2k`), idesc 0x08A00000 | k<<29 | k<<4 and the SF address operands with the same k in
+    #   their top two bits (0x80, 0x40000080, 0x80000080, 0xC0000080 for column 128); the SF column does not move
+    #   (four K=32 phases share one 128-K scale column); extent: 4 instructions per issue (fact 5, 6).
+
+def gemm_pv(stage, slot, accumulate, wait_bar):       # bh:1409-1554 (TS form) / bh:402-665 (f16, f8f6f4)
+    b_lo = (sV_slot(slot) >> 4) | LBO_bits
+    for k in range(PV_KT):
+        if k == PV_SPLIT: wait(*wait_bar)                              # embedded second-half P wait
+        gemm(O[stage], P[stage] + 8k, desc(b_lo + k*B_STEP, HI_PV), idesc_pv(k),
+             [sfa = SFP[stage] + sf_col_pv(k), sfb = SFV[stage] + sf_col_pv(k)], accumulate = accumulate or k != 0)
+    # instruction_selection, bf16 V: `@leader tcgen05.mma.cta_group::1.kind::f16 [tmem_acc], [tmem_a + 0x8k], smem_desc_b,
+    #   idesc, p|1` x8 in one asm block, idesc 0x08210490 (0x08110490 at DV=64), hi 0x40004040, B lo stepped
+    #   +0x80 per K=16 (2048 B = 16 MN-major rows), `setp.ne.b32 p, accumulate, 0` on k=0 only, THE_WAIT
+    #   (`.shared::cta`) between k=5 and k=6 (PV_SPLIT 6/8); extent: 8 per issue, 32 per export.
+    # instruction_selection, fp8 V: kind::f8f6f4, idesc 0x08210010 (DV=128) / 0x08110010 (DV=64), K=32, 4 per issue,
+    #   split 3/4 (THE_WAIT `.shared::cta` before k=3); the MN-major e4m3 V descriptor is hi 0x40004040 (SW128B) with
+    #   B step +0x100 (32 rows x 128 B) at DV=128, but hi 0x80004020 (SW64B: a 64-column e4m3 row is 64 B) with B step
+    #   +0x80 (32 rows x 64 B) at DV=64.
+    # instruction_selection, nvfp4 V: kind::mxf4nvf4.block_scale.scale_vec::4X [acc], [tmem_a + 0x8k], desc_b, idesc
+    #   0x08201680, [sfp + 4k], [sfv + 4k], p|1; K=64, 2 per issue, split 1/2; V K-major hi 0x80004020, B lo +0x2.
+    # instruction_selection, mxfp8 V (mode 4, inline asm bh:1409-1554): `@leader_thread tcgen05.mma.cta_group::1
+    #   .kind::mxf8f6f4.block_scale.scale_vec::1X [acc], [tmem_a + 0x8k], desc_b, idesc, [sfp + 0x0], [sfv + 0x0], p|1`
+    #   with `mov.b32 idesc, 0x08A00000 | k<<29 | k<<4` then `or.b32 idesc, idesc, sf_dyn` (the always-zero top bits of
+    #   the SF base), K=32, 4 per issue, THE_WAIT (`.shared::cta`) before k=3 (split 3/4); V K-major e4m3 hi 0x40004040,
+    #   B lo +0x2. Unlike the generic QK path the SF address operands are static `+0x0`.
+```
+
+```python
+# ===========================================================================
+# Softmax warpgroups 0..7 (:2727-3063, :3559-3883); thread = one S row (`tidx & 127`)
+# ===========================================================================
+def softmax_warpgroup(stage):
+    si_phase = 0; corr_phase = 1                                          # :2810-2811
+    if stage == 1: arrive(sfqk_load[0])                                   # :2815-2817 (one-time pre-arrive)
+    # instruction_selection: mbarrier.arrive.shared.b64 [mbar+296]; extent: scalar.
+    sched = scheduler(); tile = sched.initial()
+    while tile.valid:
+        n_min, n_max = block_range(m_block)
+        row_max = -inf; row_sum = 0                                        # softmax.reset :2887
+        wait(softmax_corr.empty[stage], corr_phase); corr_phase ^= 1       # :2924-2927  THE_WAIT
+        step(n_max - 1, first=True, mask_seqlen=True, mask_causal=is_causal)   # :2964-2974 (mask_fn(mask_seqlen=True))
+        if is_causal:                                                          # :2976-2993, bi:105-121
+            for n in range(n_max - 2, n_min_causal - 1, -1): step(n, mask_causal=True)
+            # the `:3007` loop below runs with the DEFAULT mask_fn (mask_causal=True, mask_seqlen=False) and
+            # `mask_is_noop=False`: identical body, only the bounds differ -- the export has three masked copies.
+            for n in range(min(n_max - 1, n_min_causal) - 1, n_min - 1, -1): step(n, mask_causal=True)
+        else:
+            for n in range(n_max - 2, n_min - 1, -1): step(n, unmasked=True)   # :3007-3014, mask_is_noop=True
+        store_shared(sScale, (tidx + stage*128) * 4, row_sum)              # :3034
+        # instruction_selection: st.shared.b32 [sScale + stage*512 + tidx*4]; extent: scalar.
+        arrive(softmax_corr.full[stage])                                   # :3039  arrive: mbarrier.arrive [mbar+144+8s]
+        sched.advance(); tile = sched.current()
+    arrive(tmem_dealloc)                                                   # :1918  arrive: mbarrier.arrive [mbar+272]
+
+def step(n, first=False, mask_seqlen=False, mask_causal=False, unmasked=False):
+    wait(S_full[stage], si_phase)                                          # :3623  THE_WAIT
+    s = reg_tile([128], "f32"); tile_max = reg_tile([4], "f32")
+    for j in range(4): copy_t2r_max(S[stage] + 32j, s[32j:32j+32], tile_max[j])      # bh:1806-1829
+    # instruction_selection: tcgen05.ld.red.sync.aligned.32x32b.x32.f32.max {32 regs}, max, [addr] x4 with addr
+    #   = base | 32j (`or.b32 ..., 32/64/96`); then tcgen05.wait::ld.sync.aligned; extent: 32 values + 1 max each.
+    hw_max = max(max(max(tile_max[0], tile_max[1]), tile_max[2]), tile_max[3])       # bh:1828
+    # instruction_selection: max.f32 x3 (2-source, blackwell_helpers.py:1828) emitted ONLY in the unmasked copy (the
+    #   non-causal steady step); in the first copy and in every causal copy the fold is dead and eliminated -- the 33rd
+    #   ld.red register is simply unused there (3 static in a non-causal export, 0 in a causal one); extent: scalar.
+    wait_tmem_ld(); arrive(sfqk_load[1 - stage])                            # :3646-3648
+    # instruction_selection: mbarrier.arrive.shared.b64 [mbar + 296 + (stage^1)*8]; extent: scalar.
+    if mask_seqlen or mask_causal:                                          # mk:373-500 (r2p)
+        seqlen_limit = S_K - max(n, 0) * 128                                    # mk:401-403
+        causal_limit = (tidx + (2*m_block + stage)*128) + (S_K - n*128 - S_Q) + 1   # mk:481-486 (row + causal_row_offset + 1)
+        limit = seqlen_limit            if mask_seqlen and not mask_causal  else \
+                causal_limit            if mask_causal and not mask_seqlen  else \
+                min(causal_limit, seqlen_limit)                                 # both: first causal step only (mk:487-488)
+        # instruction_selection: `min.s32` exists only in the first causal copy (`mask.py:488`, x1 in the causal export);
+        #   the diagonal/remaining causal copies compute `row + causal_row_offset + 1` with no min (`mask.py:486`).
+        for c in range(4):
+            bits = shift_right_u32(0xFFFFFFFF, max((c+1)*32 - limit, 0))
+            for i in range(32): s[32c+i] = select(bits & (1<<i), s[32c+i], -inf)
+        # instruction_selection: max.s32/shl/sub/max.s32 for the limit, `shr.u32` (inline asm) per chunk, then per
+        #   element `and.b32 / setp.(ne|eq).b32 / selp.f32 ..., 0fFF800000`; extent: 128 selects per masked step.
+    if unmasked:  new_max = max(hw_max, row_max)                             # sm:229-239
+    else:                                                                    # sm:242-259, ut:410-432
+        l0 = max(s[0], s[1]) if first else max3(row_max, s[0], s[1])         # ut:415-419: the previous row max folds
+        l = [l0, max(s[2],s[3]), max(s[4],s[5]), max(s[6],s[7])]              #   into the FIRST partial, never at the tail
+        for i in range(8, 128, 8): l[j] = max3(l[j], s[i+2j], s[i+2j+1])  for j in 0..3     # ut:426-430
+        new_max = max3(max(l[0], l[1]), l[2], l[3])                           # ut:431-432
+        # instruction_selection: max.f32 x66 per copy -- first copy 5 two-source (utils.py:418, 422-424, 431) + 61
+        #   three-source (427-430, 432); non-first masked copies 4 two-source (422-424, 431) + 62 three-source
+        #   (416, 427-430, 432); extent: 128 values.
+    safe = select(new_max != -inf, new_max, 0.0)                            # sm:217/245
+    # instruction_selection: setp.neu.f32 ..., 0fFF800000; selp.f32; extent: scalar.
+    if not first:
+        acc_scale_ = softmax_scale_log2 * (row_max - safe);  acc_scale = exp2(acc_scale_)      # sm:218-219
+        # instruction_selection: sub.f32; mul.f32 (no .rn); ex2.approx.ftz.f32; extent: scalar.
+        if rescale_threshold == 8.0 and acc_scale_ >= -8.0: new_max, safe, acc_scale = row_max, row_max, 1.0   # sm:220-224
+        # instruction_selection: setp.ge.f32 ..., 0fC1000000; selp.f32 x3; extent: scalar (absent in quant_pv modes).
+        store_shared(sScale, (tidx + stage*128)*4, acc_scale)                # :3683
+        # instruction_selection: st.shared.b32 [sScale + stage*512 + tidx*4] (`.loc 1 3683`); extent: scalar,
+        #   non-first copies only (1 per export, 2 in causal builds).
+    row_max = new_max
+    arrive(softmax_corr.full[stage])                                        # :3685  arrive: mbarrier.arrive [mbar+144+8s]
+    bias = max_offset - safe * softmax_scale_log2                            # sm:271-285
+    for i in range(0, 128, 2): (s[i], s[i+1]) = fma((s[i], s[i+1]), scale_log2, bias, lanes=2)
+    # instruction_selection: mul.f32; sub.f32 (from `mov.b32` of the max_offset constant); fma.rn.f32x2 x64; extent: 128 values.
+    p_words = reg_tile([P_COLS], "u32"); fill(p_words, 0)                   # :3699-3700 (fp8_pv_zero_fill_regs)
+    # instruction_selection: none -- the zero fill is folded into the full overwrite below (no `mov` survives).
+    # ---- P per mode ----------------------------------------------------------------------------------
+    if pv_format == bf16:                                                    # sm:303-346 apply_exp2_convert
+        for frag in range(4):
+            for i in range(32): s[32frag+i] = exp2(s[32frag+i])
+            for i in range(16): p_words[16frag+i] = cast_bf16x2(s[32frag+2i+1], s[32frag+2i])
+        # instruction_selection: ex2.approx.ftz.f32 x128; cvt.rn.bf16x2.f32 x64 (hi = odd element); extent: 128 values.
+    elif pv_format == fp8:                                                   # :3809-3821, bh:1596-1620
+        for i in range(128): s[i] = exp2(s[i])
+        for i in range(32): p_words[i] = {cast_e4m3x2(s[4i+1], s[4i]) | cast_e4m3x2(s[4i+3], s[4i+2]) << 16}
+        # instruction_selection: ex2.approx.ftz.f32 x128; cvt.rn.satfinite.e4m3x2.f32 x64 + mov.b32 {lo,hi} x32; extent: 128 values.
+    elif pv_format == nvfp4:                                                 # :3171-3295 _fused_log2_group_quant
+        acc = 0
+        for g in range(8):                                                   # 16-element groups, unrolled
+            m = fmax-tree over s[16g:16g+16]                                  # max.f32 x5 + max3 x5 (10 per group)
+            b = max(m, -100.0) + (-log2 6);  nb = -b                          # :3224
+            for i in range(0, 16, 2): (s[16g+i], s[16g+i+1]) = fma((..), (1.0, 1.0), (nb, nb), lanes=2)   # :3231-3236
+            for i in range(16): s[16g+i] = exp2(s[16g+i]);  sf[g] = exp2(b)  # :3237-3242
+            gs = packed add-tree over the 16 exps;  acc = fma(sf[g], gs, acc)  # :3245 (first: fma(sf0, gs0, +0.0))
+            p_words[2g], p_words[2g+1] = 8 x cast_e2m1x2 bytes                 # bh:1624-1666
+        row_sum = acc if first else fma(row_sum, acc_scale, acc)              # :3272-3275
+        sf_words = [cast_e4m3x2(sf[1], sf[0]) | cast_e4m3x2(sf[3], sf[2]) << 16, ... sf[4..7]]    # bh:1596
+        store_shared(sSFP, sSFP_off(stage, lane, warp, 0), sf_words[0]); store_shared(sSFP, sSFP_off(stage, lane, warp, 1), sf_words[1])   # :3757-3773
+        # instruction_selection, PER INLINED softmax_step COPY (two copies per non-causal export): group maxes
+        #   max.f32 x80 (10 per group, 2/3-source) + `max.f32 m, m, 0fC2C80000` x8 + `add.f32 b, m, 0fC0257007` x8
+        #   (`.loc 1 3224`), neg.f32 x8 (`.loc 1 3235`), fma.rn.f32x2 x64, ex2.approx.ftz.f32 x136 (128 + 8 sf),
+        #   group sums add.rn.f32x2 x56 + add.f32 x8 (`utils.py:466-473`), fma.rn.f32 x8 (`.loc 1 3245`) + x1 for row_sum
+        #   (`.loc 1 3275`, non-first copy), cvt.rn.satfinite.e2m1x2.f32 x64 (`.loc 1 447-450`), cvt.rn.satfinite.e4m3x2
+        #   .f32 x4, st.shared.b32 x2 at [sSFP + stage*1024 + lane*16 + (warp%4)*4 (+512)] (`.loc 1 3773`);
+        #   extent: 128 values / 8 groups. Export totals: ex2 273 = 2x136 + 1, neg.f32 16, fma.rn.f32 17.
+    elif pv_format == mxfp8:                                                 # same helper with 32-element groups
+        for g in range(4):
+            m = (tile_max[g] * scale_log2 + hw_bias) if unmasked else fmax-tree over s[32g:32g+32]   # :3213-3223
+            b = ceil(max(m, -100.0) + (-log2 448))                            # :3224-3228, bh:1833
+            fma / exp2 as above over 32 values; sf[g] = exp2(b); gs; acc = fma(sf[g], gs, acc)
+            p_words[8g:8g+8] = cast_e4m3x2 pairs                              # :3263-3269
+        row_sum as above;  sf_word = cast_ue8m0x2(sf[1], sf[0]) | cast_ue8m0x2(sf[3], sf[2]) << 16   # bh:1849-1873
+        store_shared(sSFP, sSFP_off(stage, lane, warp, 0), sf_word)
+        # instruction_selection, PER COPY: st.shared.b32 x1 at [sSFP + stage*512 + lane*16 + (warp%4)*4] (`.loc 1
+        #   3773`; 2 per mode-4 export = 1 per inlined copy), cvt.rpi.f32.f32 x4 (`.loc 1 442`), cvt.rn.satfinite.e4m3x2.f32 x64,
+        #   cvt.rz.satfinite.ue8m0x2.f32 x2, ex2 x132 (128 + 4 sf), fma.rn.f32 x4 (`.loc 1 3245` group chain) + x1
+        #   row_sum (non-first) + x4 (`.loc 1 3221`, hw group maxes -- NON-causal steady copy only; the first copy and
+        #   every causal copy use the 32-element software fmax tree instead); extent: 128 values / 4 groups.
+        #   Export totals (mode 4, non-causal): fma.rn.f32 13 = 8 + 4 + 1, cvt.rpi 8, ue8m0x2 4.
+    # ---- P to TMEM with the split handoff ---------------------------------------------------- :3861-3870
+    for c in range(P_SPLIT):     copy_r2t(P[stage] + c*P_REP, p_words[c*P_REP : (c+1)*P_REP])
+    wait_tmem_st(); arrive(P_full_O_rescaled[stage])
+    for c in range(P_SPLIT, P_CHUNKS): copy_r2t(P[stage] + c*P_REP, p_words[...])
+    wait_tmem_st(); arrive(P_full_2[stage])
+    # instruction_selection: tcgen05.st.sync.aligned.32x32b.x16.b32 x4 (bf16: 3 + 1) | .x8 x4 (fp8/mxfp8, d128 and
+    #   d64 alike: 3 + 1) | .x8 x2 (nvfp4: 1 + 1); each group followed by tcgen05.wait::st.sync.aligned and
+    #   mbarrier.arrive.shared.b64 (all 128 threads) on [mbar+96+8*stage] then [mbar+280+8*stage]; extent: P_REP
+    #   columns per instruction. The fp8 d64 export has zero `.x4`: `.loc 1 3862` .x8 x3, `.loc 1 3867` .x8 x1 per copy.
+    wait(softmax_corr.empty[stage], corr_phase)                              # :3874  THE_WAIT
+    if not quant_pv:                                                         # sm:261-266, ut:455-473
+        init = row_sum * acc_scale (not first)
+        l = [(s0,s1)+(init,0) , (s2,s3), (s4,s5), (s6,s7)]; l[j] += (s[i+2j], s[i+2j+1]) for i in 8..120 step 8
+        row_sum = (l0+l1+l2+l3).x + .y
+        # instruction_selection: mul.f32; add.rn.f32x2 x63 (+1); add.f32; extent: 128 values.
+    si_phase ^= 1; corr_phase ^= 1
+```
+
+```python
+# ===========================================================================
+# Correction warpgroup 8..11 (:3885-4360); thread = one O row
+# ===========================================================================
+def correction_warpgroup():
+    arrive(P_full_O_rescaled[0]); arrive(P_full_O_rescaled[1])               # :3926-3927 arrive: mbarrier.arrive [mbar+96],[+104]
+    sc_phase = 0; o_phase = 0; ce_phase = 1                                   # :3929-3931
+    sched = scheduler(); tile = sched.initial()
+    while tile.valid:
+        n_min, n_max = block_range(m_block)
+        wait(softmax_corr.full[0], sc_phase); arrive(softmax_corr.empty[0])   # :3969-3972 THE_WAIT; arrive: mbarrier.arrive [mbar+160]
+        wait(softmax_corr.full[1], sc_phase); sc_phase ^= 1
+        for i in range(n_max - n_min - 1):                                    # rolled, unroll=1   :3979
+            for stage in (0, 1):
+                wait(softmax_corr.full[stage], sc_phase)                      # THE_WAIT
+                scale = load_shared(sScale, (tidx + stage*128)*4)             # :3989
+                # instruction_selection: ld.shared.b32 [sScale + stage*512 + tidx*4]; extent: scalar.
+                if vote_any(scale < 1.0):                                     # :3990
+                    # instruction_selection: setp.lt.f32 ..., 0f3F800000; vote.sync.ballot.b32; setp.eq.b32; branch; extent: warp.
+                    for t in range(DV // 16):                                 # :4196-4225
+                        o = reg_tile([16], "f32"); copy_t2r(O[stage] + 16t, o)
+                        for j in range(0, 16, 2): (o[j], o[j+1]) = mul((o[j], o[j+1]), (scale, scale), lanes=2)
+                        copy_r2t(O[stage] + 16t, o)
+                    wait_tmem_st()
+                    # instruction_selection: tcgen05.ld.sync.aligned.32x32b.x16.b32 x8, mul.rn.f32x2 x8 each,
+                    #   tcgen05.st.sync.aligned.32x32b.x16.b32 x8, then one tcgen05.wait::st.sync.aligned; extent: DV columns.
+                arrive(P_full_O_rescaled[stage]); arrive(softmax_corr.empty[1 - stage])     # :3998-4001 arrive: mbarrier.arrive
+            sc_phase ^= 1
+        arrive(softmax_corr.empty[1])                                          # :4004  arrive: mbarrier.arrive [mbar+168]
+        for stage in (0, 1):                                                   # :4021-4076
+            wait(softmax_corr.full[stage], sc_phase)
+            row_sum = load_shared(sScale, (tidx + stage*128)*4)               # :4029
+            # instruction_selection: ld.shared.b32 [sScale + stage*512 + tidx*4] (`.loc 1 4029`); extent: scalar.
+            arrive(softmax_corr.empty[stage])                                  # :4034  arrive: mbarrier.arrive
+            d = select(row_sum != 0.0, row_sum, 1.0);  scale = rcp(d)         # :4047-4051 (v_descale = 1.0 folded)
+            # instruction_selection: setp.ne.f32 (one compare covers the `== 0 or NaN` source test); selp.f32;
+            #   rcp.approx.ftz.f32; extent: scalar.
+            wait(O_full[stage], o_phase); wait(corr_epi.empty[stage], ce_phase)          # :4052-4058
+            for t in range(DV // 16):                                          # :4293-4305
+                o = reg_tile([16], "f32"); copy_t2r(O[stage] + 16t, o)
+                for j in range(0, 16, 2): (o[j], o[j+1]) = mul((o[j], o[j+1]), (scale, scale), lanes=2)
+                h = [cast_bf16x2(o[2j+1], o[2j]) for j in range(8)]
+                store_shared(sO, sO_off(stage, tidx, 16t),     h[0:4])
+                store_shared(sO, sO_off(stage, tidx, 16t + 8), h[4:8])
+            # instruction_selection: tcgen05.ld...x16 x8; mul.rn.f32x2 x8 each; cvt.rn.bf16x2.f32 x8 each;
+            #   st.shared.v4.b32 x2 each (32 per export at d128, 16 at d64); extent: 16 columns per iteration.
+            fence("proxy.async.shared::cta")                                    # :4307-4310
+            # instruction_selection: fence.proxy.async.shared::cta; extent: scalar.
+            arrive(corr_epi.full[stage]); arrive(P_full_O_rescaled[stage])      # :4073-4076 arrive: mbarrier.arrive [mbar+176+8s], [mbar+96+8s]
+        o_phase ^= 1; sc_phase ^= 1; ce_phase ^= 1
+        sched.advance(); tile = sched.current()
+    arrive(tmem_dealloc)                                                       # :1962  arrive: mbarrier.arrive [mbar+272]
+
+# ===========================================================================
+# Epilogue warp 13 (:4405-4510)
+# ===========================================================================
+def epilogue_warp():
+    phase = 0; sched = scheduler(); tile = sched.initial()
+    while tile.valid:
+        for stage in (0, 1):
+            wait(corr_epi.full[stage], phase)                                   # THE_WAIT
+            for half in range(DV // 64):
+                copy_s2g(O, {64*half, (2*m_block + stage)*128, head, batch}, sO + stage*o_stage_bytes + half*16384)
+            bulk_commit_group()
+            # instruction_selection: cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint x(DV/64)
+            #   with column coordinate 0 / 64 and row coordinate (m_block<<8) | (stage*128), issued by ALL 32 lanes of
+            #   warp 13 (no elect.sync: `:4433-4446` is a plain cute.copy from the whole warp); cp.async.bulk.commit_group;
+            #   extent: one (64 cols x 128 rows) bf16 box per copy.
+        for stage in (0, 1):
+            bulk_wait_group_read(1 - stage); arrive(corr_epi.empty[stage])       # :4447-4448
+            # instruction_selection: cp.async.bulk.wait_group.read 1 then 0; mbarrier.arrive.shared.b64 [mbar+192+8s]
+            #   by all 32 lanes (the barrier is initialized with count 32); extent: scalar.
+        phase ^= 1
+        sched.advance(); tile = sched.current()
+
+# ===========================================================================
+# Schedulers (:1038-1078, ts:287-390, ts:393-634)
+# ===========================================================================
+# non-causal: StaticPersistentTileScheduler: linear = cta_id; block = linear % num_m; head = linear // num_m % H;
+#   batch = linear // (num_m * H); advance += gridDim.x; valid = linear < tiles.
+# causal: SingleTileLPTScheduler: one tile per CTA (advance -> invalid). l2_swizzle = 1 if 50 MiB < size_one_head
+#   else 2^floor(log2(50 MiB // size_one_head)) with size_one_head = S_K * (D + DV) * max(width//8, 1)  (:1071);
+#   bidhb, l2_mod = divmod(linear, l2_swizzle * num_m); block, residual = divmod(l2_mod, l2_swizzle | rem);
+#   batch, head = divmod(bidhb * l2_swizzle + residual, H); block = num_m - 1 - block (LPT).
+# instruction_selection: mul.hi.u32 / mul.lo.s32 / shr (FastDivmod) and cvt.u32.u16; extent: scalar bookkeeping.
+```
+
+## Logical GEMMs
+
+| name | (M, N, K) per instruction | A | B | D | K phases per issue | issues per KV block | owner |
+| --- | --- | --- | --- | --- | ---: | ---: | --- |
+| QK nvfp4 | (128, 128, 64) | sQ stage, E2M1 K-major SW64B (SW32B d64), scale SFQ tmem | sK slot, same | S[stage] f32 | D/64 | 2 (one per stage) | warp 12 |
+| QK mxfp8 | (128, 128, 32) | sQ stage, E4M3 K-major SW128B, scale SFQ, sf_id = k | sK slot | S[stage] | 4 | 2 | warp 12 |
+| PV bf16 | (128, DV, 16) | P[stage] TMEM bf16 (+8 cols per k) | sV slot, bf16 MN-major SW128B | O[stage] f32 | 8 | 2 | warp 12 |
+| PV fp8 | (128, DV, 32) | P TMEM e4m3 | sV e4m3 MN-major SW128B (SW64B d64) | O[stage] | 4 | 2 | warp 12 |
+| PV nvfp4 | (128, 128, 64) | P TMEM e2m1 + SFP tmem | sV E2M1 K-major SW64B + SFV tmem | O[stage] | 2 | 2 | warp 12 |
+| PV mxfp8 | (128, 128, 32) | P TMEM e4m3 + SFP (E8M0) at S[stage]+0..3, sf_id = k in idesc only | sV e4m3 K-major SW128B + SFV at S[stage]+4..7 | O[stage] | 4 | 2 | warp 12 |
+
+## TensorMap fields
+
+All maps are encoded on the host with 128-byte L2 promotion, no interleave, OOB
+zero fill; dims and coordinates are listed innermost first, matching the export's operand
+order `{col, row, head, batch}` for the 4-D maps (the head dimension is OUTSIDE the
+sequence dimension: the 128-row box moves along dim 1, dim 2 selects the head).
+
+| map | dtype | dims (inner -> outer) | box | swizzle |
+| --- | --- | --- | --- | --- |
+| Q, K (nvfp4) | u8 | (D/2, S, H or HKV, B) | (D/2, 128, 1, 1) | 64B (d128) / 32B (d64) |
+| Q, K (mxfp8) | u8 | (D, S, H or HKV, B) | (D, 128, 1, 1) | 128B |
+| V bf16 (MN-major) | bf16 | (DV, S_K, HKV, B) | (64, 128, 1, 1) x DV/64 issues | 128B |
+| V e4m3 (MN-major) | u8 | (DV, S_K, HKV, B) | (DV, 128, 1, 1) | 128B (d128) / 64B (d64) |
+| V nvfp4 (K-major) | u8 | (S_K/2, DV, HKV, B) | (64, 128, 1, 1); coords {n*64 B (the export issues n*128 in 4-bit elements), 0, kv_head, batch} | 64B |
+| V mxfp8 (K-major) | u8 | (S_K, DV, HKV, B) | (128, 128, 1, 1); coords {n*128, 0, kv_head, batch} | 128B |
+| SFQ / SFK (SF_TILE_K == 2: nvfp4 d128, modes 1-4) | u16 | (256, 2, S/128, H or HKV, B) | (256, 2, 1, 1, 1); coords {0, 0, block, head, batch} (nvfp4_bf16_d128 export `{%r, %r, block, head, batch}` with `%r = 0`) | none |
+| SFQ / SFK (SF_TILE_K == 1: mxfp8 d128 modes 5-6, nvfp4 d64 modes 1-2) | u16 | (256, S/128, 1, H or HKV, B) | (256, 1, 1, 1, 1); coords {0, block, 0, head, batch} (mxfp8_fp8_d128 / nvfp4_fp8_d64 exports `{0, block, 0, head, batch}`; the single-chunk dimension collapses to dim 2) | none |
+| SFV (nvfp4 PV, sf_vec 16) | u16 | (256, S_K/64, DV/128, HKV, B) | (256, 2, 1, 1, 1); coords {0, 2n, 0, kv_head, batch} (E3c `.loc 1 4589`: `{0, %r=n<<1, 0, kv_head, batch}`) | none |
+| SFV (mxfp8 PV, sf_vec 32) | u16 | (256, DV/128 (=1), S_K/128, HKV, B) | (256, 1, 1, 1, 1); coords {0, 0, n, kv_head, batch} (mode-4 export `.loc 1 4589`) | none |
+| O | bf16 | (DV, S_Q, H, B) | (64, 128, 1, 1) x DV/64 issues | 128B |
+
+## Storage alias lifetimes
+
+| storage | first meaning | second meaning | rule |
+| --- | --- | --- | --- |
+| KV ring slot | K_i (FP4 inside a wider V slot, or the slot itself) | V_i in the next slot | K and V alternate slots; K is released after QK of both stages, V after PV of stage 1 |
+| S[stage] columns 64.. | S accumulator (read by ld.red) | P for the PV of the same block | P is written only after the whole S row is in registers |
+| S[1-stage] columns 0..8*QK_KT | SFQ/SFK for stage's QK | S[1-stage] accumulator | the MMA warp copies the scales right before its QK and the other stage's QK overwrites them afterwards; ordered by `sfqk_load` |
+| S[stage] columns 0.. (quant_pv) | SFP/SFV for the PV | S accumulator of the next QK | ordered by P_full / S_full |
+
+## TIRx module and benchmark contract
+
+- `get_kernel(qk_format, pv_format, batch_size, seq_len_q, seq_len_kv, num_qo_heads, num_kv_heads, head_dim, is_causal)`
+  traces one `@K.kernel(warps=16, arch="sm_103a", min_blocks_per_sm=1, grid=...)`; `hardware_num_sms()` sizes
+  the persistent grid.
+- Inputs are quantized with flashinfer (`nvfp4_quantize` / `mxfp8_quantize`, `SfLayout.layout_128x4`) exactly as the
+  fork's `bench_fp4.py`; the scale bytes are the contiguous `[b][h][s/128][d/(4 sf_vec)][32][4][4]` storage.
+- `run_test` compares bit-for-bit against the fork kernel on identical bytes and against fp64 attention on the
+  dequantized inputs (library-anchored); `run_gpu` benchmarks with proton against the fork's compiled callable.
+
+## Instruction-selection summary
+
+| pattern | PTX family | per-export count (nvfp4_bf16_d128) |
+| --- | --- | ---: |
+| TMA loads Q/K/V | `cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint` | 8 |
+| TMA loads SFQ/SFK/(SFV) | same, `.5d` | 4 (6 with SFV) |
+| TMA store O | `cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint` + `commit_group` + `wait_group.read` | 4 + 2 + 2 |
+| scale SMEM -> TMEM | `tcgen05.cp.cta_group::1.32x128b.warpx4` | 16 (32 mode 3, 24 mode 4, 8 mxfp8 QK) |
+| QK | `tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X` / `kind::mxf8f6f4.block_scale.block32` | 8 / 16 |
+| PV | `kind::f16` / `kind::f8f6f4` / `kind::mxf4nvf4...4X` / `kind::mxf8f6f4.block_scale.scale_vec::1X` | 32 / 16 / 8 / 16 |
+| S load + row max | `tcgen05.ld.red.sync.aligned.32x32b.x32.f32.max`, `tcgen05.wait::ld` | 8 (12 causal), 2 |
+| P store | `tcgen05.st.sync.aligned.32x32b.x16/x8/x4.b32`, `tcgen05.wait::st` | 8 (+16 rescale), 6 |
+| O rescale / epilogue reads | `tcgen05.ld.sync.aligned.32x32b.x16.b32` | 32 |
+| completion signals | `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64` | 12 |
+| exp | `ex2.approx.ftz.f32` | 257 |
+| packed fp32 | `fma.rn.f32x2` / `add.rn.f32x2` / `mul.rn.f32x2` | 128 / 127 / 256 |
+| conversions | `cvt.rn.bf16x2.f32`; `cvt.rn.satfinite.e4m3x2.f32`; `cvt.rn.satfinite.e2m1x2.f32`; `cvt.rz.satfinite.ue8m0x2.f32`; `cvt.rpi.f32.f32` | 256; 0; 0; 0; 0 |
+| max / select / mask | `max.f32` (2/3-source), `selp.f32`, `shr.u32` | 70, 135, 66 |
+| waits | `mbarrier.try_wait.parity.shared.b64` (+ 4 `.shared::cta` inside PV) | 38 + 4 |
+| arrives | `mbarrier.arrive.shared.b64`, `mbarrier.arrive.expect_tx.shared.b64` | 28, 6 |
+| register budgets | `setmaxnreg.dec/inc.sync.aligned.u32` | 5 / 1 |
+
+The counts are audit evidence, not operands or issue-count hints in the sketch.

--- a/.agents/sketch/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.md
+++ b/.agents/sketch/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.md
@@ -1,0 +1,634 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ c5365737570a2a156d7cae0c4070fa3770ecc670),
+Copyright (c) 2026 by FlashInfer team.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashInfer Cake VSA blk128_compact SM100: coarse WASP pipeline sketch
+
+This is the non-executable, mechanically translatable sketch for
+[`tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py`](../../../../tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py).
+The authoritative source is `csrc/cake_vsa/cake_vsa_blk128_compact_sm_100a.cu`
+at FlashInfer commit `c5365737570a2a156d7cae0c4070fa3770ecc670` (file SHA256
+`e220b84c36930737d9da00676950a547402ba34e40eaa2f33061102bb6b4f7b6`, last
+changed by upstream `adc49a85`, "perf(cake_vsa): refresh Blackwell block-sparse
+WS kernel (#4804)"), launched by `csrc/cake_vsa/cake_vsa_blk128_compact_host.cpp`
+and dispatched by `flashinfer/cake_vsa.py`. The port targets `sm_100a` only.
+
+First-class layouts are forbidden. Every shared-memory object below is a byte
+range in one rank-one `u8` arena. Every alias, stage, descriptor word and TMEM
+fragment is selected by scalar integer arithmetic. "Tile" means a logical
+rectangle only; it is not a TIRx tile primitive or a layout-bearing value.
+
+## Scope and specialization boundary
+
+| axis | in-scope values | emitted-code consequence |
+| --- | --- | --- |
+| dtype / head dim / block | BF16, D=128, R=C=128 | fixed QK idesc `0x04200490`, PV idesc `0x04210490`, descriptor high word `0x40004040`, 16 KB / 8 KB TMA boxes |
+| heads | MHA (`num_q_heads == num_kv_heads`); `num_kv_heads` is an ABI argument the device never reads | CTA uses `kv_head = q_head` |
+| selected KV blocks per query block | 1..64 (compact list capacity); a zero-count row degrades to block 0 with count 1 | one rolled `union_index` loop per role |
+| `mb`, `nb`, `num_q_heads`, `softmax_scale_log2` | runtime scalars | grid `(mb, num_q_heads, 1)`; ballot loop over `nb` in 32-block steps |
+| `return_softmax_lse` | 0/1 runtime | predicate on the scalar LSE store |
+| `return_temperature_lse`, `lse_temperature_scale` | 0/1 and f32 runtime (upstream Python passes 0 and 1.0) | selects the temperature branch that re-reads S from TMEM and keeps a second running sum |
+| partial KV / Q tiles | source predicates present, never true (planner requires `M % 128 == N % 128 == 0`, grid x = `mb`) | `valid_cols`, `q_valid`, `instance_valid`, `row_valid` selects stay; the per-element `-inf` fill loops (source 683-717, 794-829) are compiler-dead: `valid_cols = 128*(nb - n_block)` clamps to exactly 0 or 128, so `0 < half_valid < 64` is unsatisfiable and the export has no `.loc` for those lines |
+
+Out of scope: fp16, GQA, D64/D96, blk64, ultrasparse BSR, longseq, causal or
+any other mask shape, clusters, PDL, persistent scheduling.
+
+## Writer line-info evidence
+
+Exports at `.porting/cake_vsa_blk128_compact_sm100/writer_exports/`:
+`source_sm_100a.lineinfo.ptx` (1051 `.loc`, `.version 9.2`, `.target sm_100a`),
+`source_sm_100a.ptx` (upstream flags, no line info), `source_sm_100a.cubin`,
+`source_sm_100a.lineinfo.cubin`, `source_sm_100a.sass`, `source_ptxas_v.txt`
+(128 registers, 0 spill bytes, 9 barriers), `keyops_by_loc.txt`,
+`ptx_opcode_hist.txt`, `ptx_scalar_glue.txt`, `sass_opcode_hist.txt`. Build:
+`nvcc -ptx|-cubin [-lineinfo] --std=c++17 --use_fast_math -arch=sm_100a`.
+
+Static emitted counts (raw PTX instruction lines, including the `@leader`-predicated
+`tcgen05.mma`/`tcgen05.commit` lines):
+32 `tcgen05.mma.cta_group::1.kind::f16`, 12 `tcgen05.ld...16x32bx2.x32`,
+4 `tcgen05.st...16x32bx2.x16`, 2 `tcgen05.st...16x32bx2.x64`, 8
+`tcgen05.commit`, 18 `cp.async.bulk.tensor.4d`, 19 `mbarrier.init`, 16
+`mbarrier.arrive`, 5 `mbarrier.arrive.expect_tx`, 27 `mbarrier.try_wait`
+loops, 18 `elect.sync`, 194 `ex2.approx.ftz.f32`, 96 `fma.rn.ftz.f32x2`, 128
+`mul.rn.ftz.f32x2`, 96 `add.f32x2`, 67 `max.f32`, 128 `cvt.rn.bf16x2.f32`, 16
+`st.global.v4.b32`, 4 `lg2.approx.ftz.f32`, 2 `rcp.approx.ftz.f32`, 11
+`shfl.sync.idx.b32`, 4 `shfl.sync.bfly.b32`, 1 `vote.sync.ballot.b32`, 2
+`vote.sync.any.pred`. SASS: 32 `UTCHMMA`, 24 `LDTM.16`, 12 `STTM.16`, 18
+`UTMALDG.4D`, 8 `UTCBAR`, 194 `MUFU.EX2`, 128 `FMUL2.FTZ`, 96 `FFMA2.FTZ`, 96
+`FADD2`, 34 `FMNMX3`/`FMNMX`, 128 `F2FP.BF16.F32.PACK_AB`, 16 `STG.E.128`.
+
+## Pipeline at a glance
+
+One CTA per `(query block of 128 rows, head)`; nothing is persistent.
+
+| warps | role-local program | publication / reuse edges |
+| --- | --- | --- |
+| 0..3, 4..7 | two softmax instances (64 query rows each): read the 64x128 f32 S tile from TMEM, row max with a `2^-8` rescale-skip decision, `ex2` probabilities, bf16 P written in place over the upper S columns, running sum/max | consume `s_full[i]`, `corr_done[i]`; produce `corr_sig[i]` (rescale factor and final stats in SMEM), `p_full[i]` |
+| 8..11 | correction + epilogue: rescale the TMEM O accumulator of either instance when a warp vote says any row needs it; finally normalize O, store bf16 rows and the LSE | consume `corr_sig[i]`, `o_full[i]`; produce `corr_done[i]`, `p_full[i]`, `tmem_dealloc` |
+| 12 | sole MMA issuer: `S_i = Q_i K^T` (8 issues) then `O_i += P_i V` (8 issues, A from TMEM) per selected block and instance | consume `q_full`, `kv_full`, `p_full[i]`; produce `s_full[i]`, `kv_empty`, `o_full[i]`; frees TMEM after `tmem_dealloc` |
+| 13, 14 | register-decreased idle warps | none |
+| 15 | load warp: Q TMA, ballot compaction of the block-mask row into the shared selected-block list, then the three-stage K/V TMA ring in order K0, K1, V0, V1 per selected block | produce `q_full`, `union_ready`, `kv_full`; consume `kv_empty` |
+
+## Primitive vocabulary
+
+Structural operations do not compute values:
+
+```python
+linear_smem_u8(bytes, alignment)   # the one rank-one arena
+byte(...)                          # integer byte offset into the arena
+reg_tile(...)                      # role-local register storage
+tmem_addr(lane_origin, column)     # integer TMEM address (lane<<16 | column)
+```
+
+Copies always state their storage direction:
+
+```python
+copy_g2s_tma(map, coords, dst_byte, completion)   # global -> shared (TMA)
+copy_g2r(src, dst)                                # global -> register
+copy_r2g(src, dst)                                # register -> global
+copy_s2r(byte, dst) / copy_r2s(src, byte)         # shared <-> register
+copy_t2r(tmem_addr, dst, shape) / copy_r2t(src, tmem_addr, shape)
+```
+
+Compute vocabulary: `fill, cast, add, sub, mul, fma, max, exp2, log2, rcp,
+select, shuffle_xor, shuffle_index, ballot, any, popc, gemm`. Packed forms carry
+`lanes=2` (one `f32x2` instruction with two ordered results). Schedule
+operations: `init_mbarrier, wait, arrive, arrive_expect_tx, tmem_commit,
+fence, named_barrier, sync_warp, sync_cta, elect, setmaxnreg, tmem_alloc,
+tmem_relinquish, tmem_dealloc, tmem_wait_ld, tmem_wait_st`.
+
+## Fixed storage and integer maps
+
+```python
+THREADS=512; WARPS=16; D=128; BLOCK=128; KV_STAGES=3; TMEM_COLS=512
+SMEM_BYTES=134784; MAX_COMPACT=64
+REG_SOFTMAX=192; REG_CORRECTION=80; REG_OTHER=48      # 8*192+4*80+4*48 = 2048
+launch(grid=(mb,num_q_heads,1), block=(512,1,1), min_blocks_per_sm=1,
+       dynamic_smem_bytes=SMEM_BYTES, target="sm_100a")
+# instruction_selection: `.reqntid`-free `__launch_bounds__(512,1)` entry with
+# 128 registers, `.extern .shared .align 1024`; extent: one specialization.
+
+ABI=(Qmap, Kmap, Vmap,                     # const __grid_constant__ CUtensorMap
+     out_bf16[M*Hq*128], lse_f32, temperature_lse_f32, block_mask_u8[Hq*mb*nb],
+     mb_i32, nb_i32, num_q_heads_i32, num_kv_heads_i32,
+     softmax_scale_log2_f32, lse_temperature_scale_f32,
+     return_softmax_lse_i32, return_temperature_lse_i32)
+# TensorMaps (host): bf16, rank 4, SWIZZLE_128B, no L2 promotion, no OOB fill.
+#   Qmap dims {64, M, Hq, 2}, byte strides {Hq*256, 256, 128}, box {64,64,1,2}
+#   Kmap/Vmap dims {64, N, 2, Hkv}, byte strides {Hkv*256, 128, 256}, box {64,64,1,1}
+# A Q coordinate (0, token, head, 0) moves 64 tokens x both dim halves = 16384 B;
+# a K/V coordinate (0, token, dim_half, head) moves 64 tokens x one half = 8192 B.
+
+arena = linear_smem_u8(SMEM_BYTES, alignment=1024)
+OFF = dict(
+  q_full=0, union_ready=8, kv_full=16, kv_empty=40, s_full=64, p_full=80,
+  corr_sig=96, corr_done=112, o_full=128, tmem_dealloc=144, tmem_mailbox=152,
+  q0=1024, q1=17408, kv=33792, scale=132096, union_count=134144, union_blocks=134152)
+def bar(name, index=0): return OFF[name] + 8*index          # 19 mbarriers
+INIT_COUNT = dict(q_full=1, union_ready=32, kv_full=1, kv_empty=1, s_full=1,
+                  p_full=256, corr_sig=128, corr_done=128, o_full=1, tmem_dealloc=128)
+
+# Q: two 64-row tiles; each tile is two 8192-byte dim halves of 64 rows x 128 B
+# with the TMA 128-byte swizzle, consumed only through MMA descriptors.
+def q_byte(tile, dim_half): return OFF.q0 + 16384*tile + 8192*dim_half       # tile 1 lands at OFF.q1 = 17408
+# K/V ring: stage = {tokens 0-63 half 0 @+0, tokens 64-127 half 0 @+8192,
+#                    tokens 0-63 half 1 @+16384, tokens 64-127 half 1 @+24576}
+def kv_byte(stage, token_half, dim_half): return OFF.kv + 32768*stage + 8192*token_half + 16384*dim_half
+def scale_byte(kind, instance, row):   # kind: 0 acc_scale, 1 row_sum, 2 row_max, 3 temperature_sum
+    return OFF.scale + 4*(128*kind + 64*instance + row)
+def union_count_byte(instance): return OFF.union_count + 4*instance
+def union_block_byte(instance, slot): return OFF.union_blocks + 4*(64*instance + slot)
+# instruction_selection: scalar `ld.shared.b32`/`st.shared.b32` (the two
+# union counts are read together as one `ld.shared.v2.b32`); extent: rank-one
+# byte offsets, never a multidimensional shared tensor.
+
+# UMMA shared descriptors are built as two 32-bit halves and packed with mov.b64.
+DESC_HI = 0x40004040            # SBO 1024 B, base-offset/version bit 46, 128 B swizzle
+def desc_lo(byte): return (smem_base_addr(byte) >> 4) & 0x3FFF
+QK_IDESC = 0x04200490           # bf16 x bf16 -> f32, M=64, N=128, K-major A and B
+PV_IDESC = 0x04210490           # same with MN-major B (V is [token, feature])
+# Q/K low-word walk over K=128 in eight K16 steps: +2,+2,+2 inside a 64-column
+# half, then +506 (Q: +8192 B) / +1018 (K: +16384 B) to the other half, then +2,+2,+2.
+QK_A_STEPS = (2,2,2,506,2,2,2); QK_B_STEPS = (2,2,2,1018,2,2,2)
+# V descriptor: low word |= 0x4000000 encodes LBO = 16384 B (dim-half stride);
+# +128 (2048 B = 16 tokens x 128 B) per K16 step.  P is read from TMEM at +8
+# columns per K16 (16 bf16 columns packed two per 32-bit column).
+PV_B_STEP = 128; PV_A_STEP = 8
+
+# TMEM: 512 columns, lane field in bits 31..16.
+S_COL=(0,256); P_COL=(64,320); O_COL=(128,384)          # per-instance column bases;
+# S spans 128 columns (S_COL..S_COL+128), P overwrites S_COL+64..+128, O spans O_COL..O_COL+128
+def tmem_addr(lane_origin, col): return taddr + col + (lane_origin << 16)
+# 16x32bx2 fragments: a warp covers 16 lanes x two 64-column halves; thread
+# (lane%16) owns row lane_origin/2 + lane%16 of the 64-row instance, thread
+# (lane/16) owns column half 0 or 1; x32 = 32 consecutive columns per thread.
+# Two x32 loads at col+0 and col+32 give one thread its 64 columns
+# [64*col_half, 64*col_half+64) of one 64x128 tile.
+```
+
+## Exact prologue and pipeline state
+
+```python
+tid = thread_id(); warp = shuffle_index(tid // 32, lane=0); lane = tid % 32
+# instruction_selection: `shfl.sync.idx.b32 ..., 0, 0x1f, 0xffffffff`; extent: one.
+smem_base = cvta_shared(arena)
+
+if warp == 0:
+    if elect():
+        # instruction_selection: `elect.sync _|p, 0xFFFFFFFF`; extent: warp 0.
+        for name in (q_full, union_ready, kv_full x3, kv_empty x3, s_full x2,
+                     p_full x2, corr_sig x2, corr_done x2, o_full x2, tmem_dealloc):
+            init_mbarrier(bar(name, i), INIT_COUNT[name])
+        # instruction_selection: 19 x `mbarrier.init.shared::cta.b64`; extent: one lane.
+        fence("mbarrier_init_release_cluster")
+        # instruction_selection: `fence.mbarrier_init.release.cluster`; inside the leader branch.
+sync_warp()
+# instruction_selection: `bar.warp.sync -1` executed by every warp.
+if warp == 0:
+    tmem_alloc(OFF.tmem_mailbox, columns=512); tmem_relinquish()
+    # instruction_selection: `tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [mailbox], 512`
+    # then `tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned`; extent: warp 0.
+sync_cta()
+# instruction_selection: `bar.sync 0`; extent: all 512 threads.
+fence("tcgen05_after_thread_sync")
+# instruction_selection: `tcgen05.fence::after_thread_sync`; extent: all threads.
+taddr = copy_s2r(OFF.tmem_mailbox, volatile=True)
+# instruction_selection: `ld.volatile.shared.b32`; extent: all threads.
+
+# Phase state (every wait is parity-based). Producer-side kv_empty starts at 1.
+PHASE = dict(union_ready=0, q_full=0, kv_full=0, kv_empty_producer=1,
+             s_full=[0,0], p_full=[0,0], corr_sig=[0,0], corr_done=[0,0],
+             o_full=[0,0], tmem_dealloc=0)
+# The KV ring cursor (stage 0..2, parity) advances once per K or V push;
+# the MMA warp and the load warp walk the identical K0,K1,V0,V1 sequence.
+```
+
+## Source-order role programs
+
+The branch order below is source-exact: `dec(12..15) -> softmax(0..7) ->
+correction(8..11) -> mma(12) -> idle(13,14) -> load(15)`. Every role recomputes
+its own `q_tile = blockIdx.x`, `q_head = blockIdx.y`, `kv_head = q_head`,
+`query_base = q_tile*128`, `q_valid = 128 if q_tile < mb else 0`,
+`kv_len = nb*128` scalars.
+
+```python
+if 12 <= warp <= 15:
+    setmaxnreg(decrease, REG_OTHER)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32 48`; extent: warps 12..15,
+    # emitted before any increase so the pool can grant the softmax request.
+
+# 1. Warps 0..7: two four-warp softmax instances.
+if warp <= 7:
+    setmaxnreg(increase, REG_SOFTMAX)
+    # instruction_selection: `setmaxnreg.inc.sync.aligned.u32 192`; extent: warps 0..7.
+    wait(bar(union_ready), PHASE.union_ready)
+    # instruction_selection: `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64` retry
+    # loop with suspend hint 0x989680; extent: all 256 softmax threads.
+    instance = shuffle_index(warp // 4, lane=0)
+    instance_row_offset = shuffle_index(instance*64, 0)
+    instance_token_offset = shuffle_index(instance*64, 0)
+    instance_tmem_offset = shuffle_index(instance*256, 0)
+    # instruction_selection: four `shfl.sync.idx.b32`; extent: warp-uniform broadcasts.
+    union_count = copy_s2r(union_count_byte(instance))
+    # instruction_selection: `ld.shared.b32`; extent: one scalar.
+    warp_in_instance = warp % 4; lane_origin = warp_in_instance*32
+    my_row = warp_in_instance*16 + lane % 16; col_half = lane // 16
+    instance_valid = clamp(q_valid - instance_token_offset, 0, 64)
+    row_valid = my_row < instance_valid
+    row_max = -inf; row_sum = 0.0; temperature_sum = 0.0
+    score_addr = tmem_addr(lane_origin, S_COL[instance])
+    p_addr = tmem_addr(lane_origin, P_COL[instance])
+
+    for union_index in serial_range(union_count):            # rolled (`#pragma unroll 1`)
+        n_block = copy_s2r(union_block_byte(instance, union_index))
+        # instruction_selection: `ld.shared.b32`; extent: one scalar.
+        wait(bar(s_full, instance), PHASE.s_full[instance]); PHASE.s_full[instance] ^= 1
+        # instruction_selection: parity retry wait, one of two static barrier
+        # addresses selected by `instance`; extent: 128 threads per instance.
+        valid_cols = clamp(kv_len - n_block*128, 0, 128) if row_valid else 0
+        s = reg_tile([64], "f32")
+        copy_t2r(score_addr, s[0:32], shape="16x32bx2.x32")
+        copy_t2r(score_addr + 32, s[32:64], shape="16x32bx2.x32")
+        # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32 {32}, [addr], 64`;
+        # extent: one 64-row x 128-column S tile, 64 f32 per thread.
+        half_valid = clamp(valid_cols - col_half*64, 0, 64)
+        # Source lines 683-717 (`-inf` fill of columns >= half_valid) are dead:
+        # half_valid is provably 0 or 64; the export has no `.loc` for them.
+        acc = (-inf, -inf)
+        for j in static_range(32):                       # two accumulators alternate
+            acc[j % 2] = max(acc[j % 2], max(s[2*j], s[2*j+1]))
+        tile_max = max(acc[0], acc[1])
+        # instruction_selection: 64 + 1 `max.f32` (no ftz), SASS fuses pairs into
+        # `FMNMX3`; extent: one 64-value fragment.
+        tile_max = select(half_valid <= 0, -inf, tile_max)
+        tile_max = max(tile_max, shuffle_xor(tile_max, 16))
+        # instruction_selection: `selp.f32`, `shfl.sync.bfly.b32 ..., 16, 31, -1`,
+        # `max.f32`; extent: one row across the two column halves.
+        new_max = max(tile_max, row_max)
+        safe_max = select(new_max == -inf, 0.0, new_max)
+        new_max_scaled = mul(safe_max, softmax_scale_log2)
+        acc_scale_log2 = fma(row_max, softmax_scale_log2, -new_max_scaled)
+        # instruction_selection: `max.f32`, `setp.eq.ftz.f32`+`selp.f32`, `mul.ftz.f32`,
+        # `fma.rn.ftz.f32`; extent: scalars per thread.
+        if acc_scale_log2 >= -8.0:
+            selected_max = row_max; safe_max = select(row_max == -inf, 0.0, row_max)
+            acc_scale = 1.0; temperature_acc_scale = 1.0
+            new_max_scaled = mul(safe_max, softmax_scale_log2)
+            # instruction_selection: `setp.ltu.ftz.f32` branch, `selp.f32`, `mul.ftz.f32`.
+        else:
+            selected_max = new_max
+            acc_scale = select(row_max > -inf, exp2(acc_scale_log2), 1.0)
+            temperature_acc_scale = select(row_max > -inf,
+                                           exp2(mul(acc_scale_log2, lse_temperature_scale)), 1.0)
+            # instruction_selection: two `ex2.approx.ftz.f32`, `mul.ftz.f32`,
+            # `setp.ne.ftz.f32` + two `selp.f32`; extent: rescale path only.
+        row_max = selected_max
+        if col_half == 0:
+            copy_r2s(acc_scale, scale_byte(0, instance, my_row))
+            # instruction_selection: branch-guarded `st.shared.b32`; extent: 64 rows per instance.
+        fence("proxy_async_shared_cta")
+        # instruction_selection: `fence.proxy.async.shared::cta`; extent: every softmax thread.
+        arrive(bar(corr_sig, instance))
+        # instruction_selection: `mbarrier.arrive.release.cta.shared::cta.b64`; extent:
+        # 128 arrivals per instance (barrier count 128).
+        score_bias = select(valid_cols > 0, -new_max_scaled, -inf)
+        # instruction_selection: `selp.f32`; extent: one scalar.
+        block_sum = 0.0; block_temperature_sum = 0.0
+        if return_temperature_lse != 0:
+            tau_scale = mul(softmax_scale_log2, lse_temperature_scale)
+            tau_bias = mul(score_bias, lse_temperature_scale)
+            for j in static_range(32):
+                s[2*j:2*j+2] = fma(s[2*j:2*j+2], (tau_scale,)*2, (tau_bias,)*2, lanes=2)
+            # instruction_selection: 32 `fma.rn.ftz.f32x2`; extent: 64 values.
+            for j in static_range(64): s[j] = exp2(s[j])
+            # instruction_selection: 64 `ex2.approx.ftz.f32`.
+            acc2 = (0.0, 0.0)
+            for j in static_range(32): acc2 = add(acc2, s[2*j:2*j+2], lanes=2)
+            half = add(acc2[0], acc2[1])
+            block_temperature_sum = add(half, shuffle_xor(half, 16))
+            # instruction_selection: 32 `add.f32x2` (no ftz), `add.ftz.f32`,
+            # `shfl.sync.bfly.b32 16`, `add.ftz.f32`; extent: one row.
+            copy_t2r(score_addr, s[0:32], shape="16x32bx2.x32")
+            copy_t2r(score_addr + 32, s[32:64], shape="16x32bx2.x32")
+            # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32`;
+            # S is re-read because the first copy was consumed by the temperature sum.
+            # Source lines 794-829 (`-inf` fill) are dead as above.
+        for j in static_range(32):
+            s[2*j:2*j+2] = fma(s[2*j:2*j+2], (softmax_scale_log2,)*2, (score_bias,)*2, lanes=2)
+        # instruction_selection: 32 `fma.rn.ftz.f32x2`; extent: 64 values.
+        for j in static_range(64): s[j] = exp2(s[j])
+        # instruction_selection: 64 `ex2.approx.ftz.f32`.
+        acc2 = (0.0, 0.0)
+        for j in static_range(32): acc2 = add(acc2, s[2*j:2*j+2], lanes=2)
+        half = add(acc2[0], acc2[1]); block_sum = add(half, shuffle_xor(half, 16))
+        # instruction_selection: 32 `add.f32x2`, `add.ftz.f32`, `shfl.sync.bfly.b32 16`,
+        # `add.ftz.f32`; extent: one row sum.
+        packed_p = reg_tile([32], "b32")
+        for j in static_range(32): packed_p[j] = cast(pack(s[2*j], s[2*j+1]), "bf16x2")
+        # instruction_selection: 32 `cvt.rn.bf16x2.f32`; extent: 64 probabilities.
+        copy_r2t(packed_p[0:16], p_addr, shape="16x32bx2.x16")
+        copy_r2t(packed_p[16:32], p_addr + 16, shape="16x32bx2.x16")
+        # instruction_selection: two `tcgen05.st.sync.aligned.16x32bx2.x16.b32 [addr], 32, {16}`;
+        # extent: P columns P_COL..P_COL+64 of this instance, written in place over S.
+        # (The temperature and plain branches each emit their own copy of the
+        # fma/exp2/sum/cvt/st sequence: 3 x 32 fma, 3 x 64 ex2, 4 x16 stores total.)
+        tmem_wait_st()
+        # instruction_selection: `tcgen05.wait::st.sync.aligned`.
+        arrive(bar(p_full, instance))
+        # instruction_selection: `mbarrier.arrive.release.cta.shared::cta.b64`; 128 of the
+        # 256 expected arrivals (the other 128 come from the correction warps).
+        wait(bar(corr_done, instance), PHASE.corr_done[instance]); PHASE.corr_done[instance] ^= 1
+        # instruction_selection: parity retry wait; extent: 128 threads.
+        row_sum = fma(row_sum, acc_scale, block_sum)
+        if return_temperature_lse != 0:
+            temperature_sum = fma(temperature_sum, temperature_acc_scale, block_temperature_sum)
+        # instruction_selection: `fma.rn.ftz.f32` (x2, second predicated); extent: scalars.
+
+    if col_half == 0:
+        copy_r2s(row_sum, scale_byte(1, instance, my_row))
+        copy_r2s(row_max, scale_byte(2, instance, my_row))
+        copy_r2s(temperature_sum, scale_byte(3, instance, my_row))
+        # instruction_selection: three branch-guarded `st.shared.b32`; extent: 64 rows.
+    fence("proxy_async_shared_cta")
+    arrive(bar(corr_sig, instance))
+    # instruction_selection: `fence.proxy.async.shared::cta` then
+    # `mbarrier.arrive.release.cta.shared::cta.b64`; the final corr_sig generation.
+
+# 2. Warps 8..11: correction and epilogue.
+if 8 <= warp <= 11:
+    setmaxnreg(decrease, REG_CORRECTION)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32 80`; extent: warps 8..11.
+    wait(bar(union_ready), PHASE.union_ready)
+    # instruction_selection: parity retry wait; extent: 128 threads.
+    count0, count1 = copy_s2r(union_count_byte(0), width=2)
+    max_union_count = max(count0, count1)
+    # instruction_selection: `ld.shared.v2.b32` + `max.s32`; extent: two scalars.
+    warp_in_role = warp - 8; lane_origin = warp_in_role*32
+    my_row = warp_in_role*16 + lane % 16; col_half = lane // 16
+    row_addr = lane_origin << 16
+    arrive(bar(p_full, 0)); arrive(bar(p_full, 1))
+    # instruction_selection: two `mbarrier.arrive.release.cta.shared::cta.b64`; the
+    # correction half of the first p_full generation needs no O rescale.
+    wait(bar(corr_sig, 0), PHASE.corr_sig[0]); PHASE.corr_sig[0] ^= 1; arrive(bar(corr_done, 0))
+    wait(bar(corr_sig, 1), PHASE.corr_sig[1]); PHASE.corr_sig[1] ^= 1; arrive(bar(corr_done, 1))
+    # instruction_selection: parity wait then ordinary arrive, per instance; block 0
+    # never rescales.
+    for union_index in serial_range(1, max_union_count):     # rolled
+        for instance in static_range(2):
+            count = copy_s2r(union_count_byte(instance))
+            # instruction_selection: `ld.shared.b32`; re-read every iteration.
+            if count > union_index:
+                wait(bar(corr_sig, instance), PHASE.corr_sig[instance]); PHASE.corr_sig[instance] ^= 1
+                # instruction_selection: parity retry wait; extent: 128 threads.
+                acc_scale = copy_s2r(scale_byte(0, instance, my_row))
+                # instruction_selection: `ld.shared.b32`; extent: one row scale.
+                if any(acc_scale < 1.0):
+                    # instruction_selection: `setp.lt.ftz.f32` + `vote.sync.any.pred`; one warp vote.
+                    o = reg_tile([64], "f32")
+                    copy_t2r(tmem_addr(lane_origin, O_COL[instance]), o[0:32], shape="16x32bx2.x32")
+                    copy_t2r(tmem_addr(lane_origin, O_COL[instance]) + 32, o[32:64], shape="16x32bx2.x32")
+                    # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32`.
+                    for j in static_range(32): o[2*j:2*j+2] = mul(o[2*j:2*j+2], (acc_scale,)*2, lanes=2)
+                    # instruction_selection: 32 `mul.rn.ftz.f32x2`; extent: 64 values.
+                    copy_r2t(o, tmem_addr(lane_origin, O_COL[instance]), shape="16x32bx2.x64")
+                    # instruction_selection: one `tcgen05.st.sync.aligned.16x32bx2.x64.b32 [addr], 64, {64}`.
+                    tmem_wait_st()
+                    # instruction_selection: `tcgen05.wait::st.sync.aligned`.
+                arrive(bar(p_full, instance)); arrive(bar(corr_done, instance))
+                # instruction_selection: two `mbarrier.arrive.release.cta.shared::cta.b64`.
+    wait(bar(o_full, 0), PHASE.o_full[0]); wait(bar(o_full, 1), PHASE.o_full[1])
+    wait(bar(corr_sig, 0), PHASE.corr_sig[0]); wait(bar(corr_sig, 1), PHASE.corr_sig[1])
+    # instruction_selection: four parity retry waits; extent: both O accumulators and
+    # both final statistics generations.
+    fence("tcgen05_after_thread_sync")
+    # instruction_selection: `tcgen05.fence::after_thread_sync`.
+    for instance in static_range(2):
+        final_sum = copy_s2r(scale_byte(1, instance, my_row))
+        final_max = copy_s2r(scale_byte(2, instance, my_row))
+        final_temperature_sum = copy_s2r(scale_byte(3, instance, my_row))
+        # instruction_selection: three `ld.shared.b32`.
+        inv_sum = select(final_sum > 0 and final_sum == final_sum, rcp(final_sum), 0.0)
+        # instruction_selection: `rcp.approx.ftz.f32`, `setp.gt.ftz.f32` x2, `selp.f32`.
+        instance_valid = clamp(q_valid - 64*instance, 0, 64)
+        query = query_base + 64*instance + my_row
+        output_row = (query*num_q_heads + q_head)*128
+        o = reg_tile([64], "f32")
+        copy_t2r(tmem_addr(lane_origin, O_COL[instance]), o[0:32], shape="16x32bx2.x32")
+        copy_t2r(tmem_addr(lane_origin, O_COL[instance]) + 32, o[32:64], shape="16x32bx2.x32")
+        # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32`.
+        if my_row < instance_valid:
+            for chunk in static_range(8):
+                for j in static_range(4):
+                    o[8*chunk+2*j : 8*chunk+2*j+2] = mul(o[8*chunk+2*j : 8*chunk+2*j+2], (inv_sum,)*2, lanes=2)
+                words = [cast(pack(o[8*chunk+2*j], o[8*chunk+2*j+1]), "bf16x2") for j in static_range(4)]
+                copy_r2g(words, out[output_row + 64*col_half + 8*chunk : +8])
+                # instruction_selection: four `mul.rn.ftz.f32x2`, four `cvt.rn.bf16x2.f32`,
+                # one `st.global.v4.b32`; extent: 8 chunks x 2 instances = 16 stores/thread.
+            if col_half == 0:
+                stat_idx = query*num_q_heads + q_head
+                if return_softmax_lse != 0:
+                    lse_value = select(final_sum > 0,
+                                       fma(mul(final_max, softmax_scale_log2), LN2, mul(log2(final_sum), LN2)),
+                                       -inf)
+                    copy_r2g(lse_value, lse[stat_idx])
+                    # instruction_selection: `lg2.approx.ftz.f32`, `mul.ftz.f32` x2,
+                    # `fma.rn.ftz.f32` with the ln2 immediate, `setp.gt.ftz.f32`, `selp.f32`,
+                    # `st.global.b32`; extent: one scalar per live row.
+                if return_temperature_lse != 0:
+                    t_value = select(final_temperature_sum > 0,
+                                     fma(lse_temperature_scale,
+                                         mul(mul(final_max, softmax_scale_log2), LN2),
+                                         mul(log2(final_temperature_sum), LN2)),
+                                     -inf)
+                    copy_r2g(t_value, temperature_lse[stat_idx])
+                    # instruction_selection: `lg2.approx.ftz.f32`, `mul.ftz.f32` x3
+                    # (final_max*scale, *LN2 immediate, log2*LN2 immediate), one
+                    # `fma.rn.ftz.f32` whose multiplier is `lse_temperature_scale`,
+                    # `setp.leu.ftz.f32` branching over an unconditional `mov.b32 -inf`,
+                    # `st.global.b32`; extent: one scalar per live row.
+    tmem_wait_ld()
+    fence("tcgen05_before_thread_sync")
+    arrive(bar(tmem_dealloc))
+    # instruction_selection: `tcgen05.wait::ld.sync.aligned`, `tcgen05.fence::before_thread_sync`,
+    # `mbarrier.arrive.release.cta.shared::cta.b64`; extent: 128 arrivals.
+
+# 3. Warp 12: MMA issuer and TMEM owner.
+if warp == 12:
+    wait(bar(union_ready), PHASE.union_ready)
+    count0, count1 = copy_s2r(union_count_byte(0), width=2); max_union_count = max(count0, count1)
+    # instruction_selection: parity wait, `ld.shared.v2.b32`, `max.s32`.
+    kv = ring(stages=3, stage=0, parity=0)
+    wait(bar(q_full), PHASE.q_full)
+    # instruction_selection: parity retry wait; extent: one Q generation.
+    first_pv = [True, True]
+    for union_index in serial_range(max_union_count):        # rolled
+        count = [None, None]
+        for instance in static_range(2):                     # S_i = Q_i K^T
+            count[instance] = copy_s2r(union_count_byte(instance))
+            # instruction_selection: `ld.shared.b32`; one count read per instance per
+            # iteration, reused by the PV guard and the last-block test below.
+            if count[instance] > union_index:
+                # instruction_selection: `setp` + branch on the count just read.
+                k_stage = kv.stage; kv.advance()
+                wait(bar(kv_full, k_stage), kv.parity_at(k_stage))
+                # instruction_selection: parity retry wait; extent: one K stage.
+                a_lo = shuffle_index(desc_lo(q_byte(instance, 0)), 0)
+                b_lo = shuffle_index(desc_lo(kv_byte(k_stage, 0, 0)), 0)
+                # instruction_selection: two `shfl.sync.idx.b32` uniform broadcasts.
+                leader = elect()
+                for k16 in static_range(8):
+                    gemm(tmem_addr(0, S_COL[instance]), desc64(a_lo, DESC_HI), desc64(b_lo, DESC_HI),
+                         QK_IDESC, accumulate=(k16 != 0), predicate=leader)
+                    a_lo += QK_A_STEPS[k16]; b_lo += QK_B_STEPS[k16]
+                # instruction_selection: one `elect.sync`, `setp.ne.b32` x2, `mov.b32` immediates,
+                # eight `mov.b64 {lo,hi}` pairs and eight `@leader tcgen05.mma.cta_group::1.kind::f16
+                # [d], da, db, id, p` with `add.u32` low-word steps; extent: K=128 in eight K16 issues.
+                tmem_commit(bar(s_full, instance), elect=True)
+                tmem_commit(bar(kv_empty, k_stage), elect=True)
+                # instruction_selection: two elected
+                # `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`.
+        for instance in static_range(2):                     # O_i += P_i V
+            if count[instance] > union_index:                # no second shared read
+                v_stage = kv.stage; kv.advance()
+                wait(bar(kv_full, v_stage), kv.parity_at(v_stage))
+                wait(bar(p_full, instance), PHASE.p_full[instance]); PHASE.p_full[instance] ^= 1
+                # instruction_selection: two parity retry waits; extent: one V stage, one P.
+                b_lo = shuffle_index(desc_lo(kv_byte(v_stage, 0, 0)) | 0x4000000, 0)
+                # instruction_selection: `shfl.sync.idx.b32`; LBO bit set for the MN-major V.
+                ta = tmem_addr(0, P_COL[instance]); leader = elect()
+                for k16 in static_range(8):
+                    gemm(tmem_addr(0, O_COL[instance]), tmem_operand(ta), desc64(b_lo, DESC_HI),
+                         PV_IDESC, accumulate=(k16 != 0 or not first_pv[instance]), predicate=leader)
+                    ta += PV_A_STEP; b_lo += PV_B_STEP
+                # instruction_selection: one `elect.sync`, eight `@leader tcgen05.mma.cta_group::1.kind::f16
+                # [d], [ta], db, id, p` with `add.u32 ta, ta, 8` and `add.u32 blo, blo, 128`;
+                # the first issue of the instance's first block passes enable_input_d = 0.
+                first_pv[instance] = False
+                if union_index + 1 == count[instance]:
+                    tmem_commit(bar(o_full, instance), elect=True)
+                    # instruction_selection: elected `tcgen05.commit...mbarrier::arrive::one`; last block only.
+                tmem_commit(bar(kv_empty, v_stage), elect=True)
+                # instruction_selection: elected `tcgen05.commit...mbarrier::arrive::one`; V release.
+    wait(bar(tmem_dealloc), PHASE.tmem_dealloc)
+    taddr_again = copy_s2r(OFF.tmem_mailbox, volatile=True)
+    tmem_dealloc(taddr_again, columns=512)
+    # instruction_selection: parity retry wait, `ld.volatile.shared.b32`,
+    # `tcgen05.dealloc.cta_group::1.sync.aligned.b32 addr, 512`; extent: warp 12.
+
+# 4. Warps 13, 14: idle after the register decrease.
+if 13 <= warp <= 14:
+    pass
+
+# 5. Warp 15: Q load, mask compaction, K/V ring producer.
+if warp == 15:
+    if elect():
+        arrive_expect_tx(bar(q_full), 32768)
+        copy_g2s_tma(Qmap, (0, query_base, q_head, 0), q_byte(0, 0), bar(q_full))
+        copy_g2s_tma(Qmap, (0, query_base + 64, q_head, 0), q_byte(1, 0), bar(q_full))
+        # instruction_selection: `elect.sync`, `mbarrier.arrive.expect_tx.release.cta.shared::cta.b64`,
+        # two `cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes`;
+        # extent: 2 x 16384 bytes (both dim halves of 64 rows per issue).
+    q_block = query_base // 128; mask_base = (q_head*mb + q_block)*nb; selected_count = 0
+    for block_base in serial_range(0, nb, 32):                # rolled
+        n_block = block_base + lane
+        selected = (copy_g2r(block_mask[mask_base + n_block]) != 0) if n_block < nb else 0
+        # instruction_selection: branch-guarded `ld.global.nc.b8` + `setp.ne.b16`; extent: one byte per lane.
+        vote = ballot(selected != 0)
+        slot = selected_count + popc(vote & ((1 << lane) - 1))
+        # instruction_selection: `vote.sync.ballot.b32`, `popc.b32` x2, `shl.b32`/`add.s32`.
+        if selected:
+            copy_r2s(n_block, union_block_byte(0, slot)); copy_r2s(n_block, union_block_byte(1, slot))
+            # instruction_selection: two branch-guarded `st.shared.b32`; both instances get the list.
+        selected_count += popc(vote)
+    if selected_count == 0:
+        if lane == 0:
+            copy_r2s(0, union_block_byte(0, 0)); copy_r2s(0, union_block_byte(1, 0))
+            # instruction_selection: two `st.shared.b32 [addr], 0`; extent: lane 0.
+        selected_count = 1
+    if lane < 2:
+        copy_r2s(selected_count, union_count_byte(lane))
+        # instruction_selection: branch-guarded `st.shared.b32`; extent: lanes 0 and 1.
+    named_barrier(8, threads=32)
+    fence("proxy_async_shared_cta")
+    arrive(bar(union_ready))
+    # instruction_selection: `barrier.sync 8, 32`, `fence.proxy.async.shared::cta`,
+    # `mbarrier.arrive.release.cta.shared::cta.b64` by all 32 lanes (count 32).
+    load = ring(stages=3, stage=0, parity=1)
+    count0, count1 = copy_s2r(union_count_byte(0), width=2); max_union_count = max(count0, count1)
+    # instruction_selection: `ld.shared.v2.b32`, `max.s32`.
+    for union_index in serial_range(max_union_count):        # rolled
+        for map in (Kmap, Vmap):                             # K for both instances, then V
+            for instance in static_range(2):
+                if copy_s2r(union_count_byte(instance)) > union_index:
+                    n_block = copy_s2r(union_block_byte(instance, union_index))
+                    # instruction_selection: two `ld.shared.b32`.
+                    token0 = n_block*128; token1 = token0 + 64
+                    wait(bar(kv_empty, load.stage), load.parity)
+                    # instruction_selection: parity retry wait by all 32 lanes; producer parity starts at 1.
+                    if elect():
+                        arrive_expect_tx(bar(kv_full, load.stage), 32768)
+                        copy_g2s_tma(map, (0, token0, 0, kv_head), kv_byte(load.stage, 0, 0), bar(kv_full, load.stage))
+                        copy_g2s_tma(map, (0, token1, 0, kv_head), kv_byte(load.stage, 1, 0), bar(kv_full, load.stage))
+                        copy_g2s_tma(map, (0, token0, 1, kv_head), kv_byte(load.stage, 0, 1), bar(kv_full, load.stage))
+                        copy_g2s_tma(map, (0, token1, 1, kv_head), kv_byte(load.stage, 1, 1), bar(kv_full, load.stage))
+                        # instruction_selection: `elect.sync`, `mbarrier.arrive.expect_tx...` 32768,
+                        # four `cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes`
+                        # of 8192 bytes; extent: one 128-token K or V tile per push, 16 static sites.
+                    load.advance()
+```
+
+## Bidirectional source / sketch / PTX map
+
+| semantic edge | source lines | sketch section | exported `.loc` / opcode evidence |
+| --- | --- | --- | --- |
+| helpers: elect, mbarrier init/wait/arrive/expect_tx, commit, TMA, warp-uniform, approx math | 47-260, 445-483 | primitive vocabulary | `.loc 56/63/107/204/211/218/466/481/243/250/257` inlined at every call site |
+| f32x2 helpers (fma/mul in place, block sum), max accumulators | 278-372 | softmax/correction/epilogue bodies | `.loc 287/289` (64 `max.f32`), `364` (96 `fma.rn.ftz.f32x2`), `370` (128 `mul.rn.ftz.f32x2`), `354` (96 `add.f32x2`) |
+| dead helpers (cluster waits, tokens, `mma_ss/ts_step`, `tmem_ld_x32`, `warp_reduce_*`, `ex2_emulation`, `softmax_frag_exp2_cast`, unused f32x2 wrappers, `make_smem_desc`, `tcgen05_commit`) | 67-135, 138-193, 222-238, 262-275, 294-343, 373-440, 450-456, 470-475 | omitted | no `.loc` |
+| ABI and smem carve-up | 487-515 | fixed storage | `cvta.to.global` x7, `.extern .shared .align 1024` |
+| mbarrier init, warp sync, TMEM alloc, CTA sync, TMEM base | 520-587 | exact prologue | `.loc 521-553` (19 inits + fence), `557` `bar.warp.sync`, `563/564` alloc/relinquish, `567` `bar.sync 0`, `568` fence, `581` `ld.volatile.shared` |
+| register redistribution | 591-597, 922 | role entries | `.loc 592` dec 48, `597` inc 192, `922` dec 80 |
+| softmax scalars, union_ready, uniform broadcasts | 599-642 | role 1 head | `.loc 614` wait, `616-619` `shfl.sync.idx`, `620` `ld.shared` |
+| softmax per-block: wait, S load, (dead mask), max tree, rescale decision, acc_scale publish | 644-762 | role 1 loop | `.loc 645/647/650/670/675/720-734/739-750/754/756/758/760`; no `.loc` for 683-717 |
+| temperature branch (fma, exp2, sum, S re-read, fma, exp2, sum, cvt, P store) | 766-859 | role 1 temperature branch | `.loc 771/774/777-782/788/793/834/837/840-845/849/855/859`; no `.loc` for 794-829 |
+| plain branch (fma, exp2, sum, cvt, P store) | 860-891 | role 1 plain branch | `.loc 865/868/871-876/880/886/890` |
+| P publish, corr_done, running sums, final stats | 892-918 | role 1 tail | `.loc 892/894/895/898/899/902/903/908-916` |
+| correction prologue and rescale loop | 921-1026 | role 2 loop | `.loc 939/941/952-961/964-969/976/981/985/989/990/992/993/995-1024` |
+| epilogue: waits, stats, normalize, store, LSE | 1027-1112 | role 2 epilogue | `.loc 1028-1037/1043-1047/1065/1070/1080/1087-1091/1098/1099/1103/1104/1109-1111` |
+| MMA warp: waits, QK chains, PV chains, dealloc | 1115-1394 | role 3 | `.loc 1118/1120/1128/1136/1142-1144/1198-1200/1202-1210/1264-1266/1273-1276/1321-1326/1333-1336/1381-1386/1390-1393` |
+| idle warps | 1397-1399 | role 4 | none |
+| load warp: Q TMA, ballot compaction, union publish, K/V ring | 1401-1507 | role 5 | `.loc 1417-1420/1426-1457/1459/1469-1484/1489-1504` |
+
+Reading in reverse, every TMA, TMEM load/store, MMA, commit, mbarrier, named
+barrier, warp vote, shuffle, transcendental, packed f32x2, conversion, vector
+global store and register-budget instruction in the export maps to a concrete
+occurrence above. Address arithmetic maps to the integer functions of "Fixed
+storage and integer maps", never to a layout.
+
+## TIRx, correctness and performance contract
+
+The public module exports `KERNEL_META`, `CONFIGS`, `BENCH_CONFIGS`,
+`get_kernel`, `prepare_data`, `run_test`, `prepare_bench`, `run_gpu`, and
+`run_bench`. Device code imports only `tirx_kernels.kern as K`; low-level
+instruction families use `K.ptx[...]` / `K.ptx.*`. There is no inline CUDA
+function call, tile primitive, first-class layout or multidimensional SMEM
+allocation. The kernel is compiled once, shape-generic, through nvcc 13.2
+(`compile_kernel(..., cuda_compile_mode="nvcc")`) so TIRx and the upstream
+`nvcc -cubin` build share PTX ISA 9.2.
+
+The frozen correctness matrix has 9 rows: the upstream test shape, one selected
+block without LSE, all 64 blocks, an nb=40 ballot tail with variable per-row
+counts, N=16384 with 16 heads, an amplified-Q rescale case, a single CTA, an
+empty block row, and the temperature-LSE branch. TIRx and the pinned upstream
+kernel share immutable inputs and independent outputs; `out` and `lse` must be
+bitwise identical between them, a second TIRx launch must reproduce the first
+bit for bit, no-LSE sentinels stay untouched, NaN is forbidden, and both are
+checked against one FP32 dense oracle with tolerances frozen from measurement.
+
+Performance truth is exclusively `python -m tirx_kernels.bench_suite` over the
+frozen 6-row benchmark matrix with the pinned FlashInfer reference. Each row
+must have five finite positive Proton samples for both implementations and
+strict `mean(flashinfer)/mean(tirx) > 0.99`.

--- a/.agents/sketch/flashinfer/cake_vsa/cake_vsa_longseq_sm100.md
+++ b/.agents/sketch/flashinfer/cake_vsa/cake_vsa_longseq_sm100.md
@@ -1,0 +1,472 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ c5365737570a2a156d7cae0c4070fa3770ecc670),
+Copyright (c) 2026 by FlashInfer team.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashInfer Cake VSA longseq SM100: coarse WASP pipeline sketch
+
+This is the non-executable, mechanically translatable execution sketch for
+[`tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py`](../../../../tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py).
+The authoritative source is `csrc/cake_vsa/cake_vsa_longseq_sm_100a.cu` at
+FlashInfer commit `c5365737570a2a156d7cae0c4070fa3770ecc670`, file SHA-256
+`647951f777c17fa4e74e892843ce5ba8ff25d4abf1b0e68b19a264e25532c71d`,
+launched by `csrc/cake_vsa/cake_vsa_longseq_host.cpp`. The specialization is
+SM100a only: BF16, D=128, R=C=128, MHA with eight heads, `N >= 16384`, and one
+uniform selected-block count in `[1,192]`. Other dtypes, dimensions, GQA,
+clusters, persistent scheduling, and the compact/ultrasparse profiles are out
+of scope.
+
+The writer export is
+`.porting/cake_vsa_longseq_sm100/writer_exports/source_sm_100a.lineinfo.ptx`:
+PTX 9.2, target `sm_100a`, 1046 `.loc` records. The paired cubin uses 128
+registers, zero spill bytes, nine hardware barriers. Instruction counts below
+are static PTX instruction lines, including predicated lines: 48 `tcgen05.mma`,
+12 `tcgen05.commit`, 18 four-dimensional TMA loads, 23 barrier initializations,
+30 parity-wait loops, 12 TMEM loads, six TMEM stores, 194 `ex2`, 96 packed FMA,
+96 packed add, 128 packed multiply, and 20 global stores.
+
+Every shared object is an interval in one rank-one byte arena. Every logical
+coordinate, stage, swizzle, alias, descriptor, and TMEM reference is represented
+by scalar integer arithmetic. No first-class layout or tile primitive exists.
+
+## Pipeline at a glance
+
+| warps | role-local program | publication and reuse edges |
+| --- | --- | --- |
+| 0–7 | two four-warp, 64-row instances read S from TMEM, update row max/sums, form BF16 P, and publish rescale/final statistics | consume `union_ready`, `s_full[i]`, `corr_done[i]`; produce `corr_sig[i]`, `p_full[i]` |
+| 8–11 | rescale each instance's TMEM O when required, then load/scale/store output and optional statistics | consume `union_ready`, `corr_sig[i]`, `o_full[i]`; produce `corr_done[i]`, half of `p_full[i]`, `tmem_dealloc` |
+| 12 | sole QK/PV MMA issuer; interleaves independent three-stage K and two-stage V rings | consume `q_full`, `k_full[*]`, `v_full[*]`, `p_full[i]`, `tmem_dealloc`; produce `s_full[i]`, `k_empty[*]`, `v_empty[*]`, `o_full[i]` |
+| 13 | loads Q, ballot-compacts the mask, and streams K | produce `q_full`, `union_ready`, `k_full[*]`; consume `k_empty[*]` |
+| 14 | waits for the compact list and streams V independently | consume `union_ready`, `v_empty[*]`; produce `v_full[*]` |
+| 15 | register-decreased idle warp | none |
+
+## Primitive vocabulary
+
+```python
+linear_smem_u8(bytes, alignment)
+byte(base, scalar_offset)
+reg_tile(count, dtype)
+tmem_addr(lane_origin, column)
+
+copy_g2s_tma(tensor_map, coordinates, shared_byte, completion_barrier)
+copy_g2r(global_byte, register)
+copy_s2r(shared_byte, register)
+copy_r2s(register, shared_byte)
+copy_t2r(tmem_address, registers, instruction_shape)
+copy_r2t(registers, tmem_address, instruction_shape)
+copy_r2g(registers, global_byte)
+
+fill, cast, add, sub, mul, fma, max, exp2, log2, rcp, select
+shuffle_xor, shuffle_index, ballot, any, popc, gemm
+init_mbarrier, wait, arrive, arrive_expect_tx, commit, fence
+named_barrier, sync_warp, sync_cta, elect, setmaxnreg
+tmem_alloc, tmem_relinquish, tmem_dealloc, tmem_wait_ld, tmem_wait_st
+```
+
+Each occurrence below denotes one instruction, one fixed tile of a single
+instruction family, or one explicit loop of that family.
+
+## Fixed resources and scalar maps
+
+```python
+THREADS=512; WARPS=16; BLOCK=128; D=128; K_STAGES=3; V_STAGES=2
+SMEM_BYTES=201344; MAX_SELECTED=192; TMEM_COLS=512
+REG_SOFTMAX=192; REG_CORRECTION=80; REG_OTHER=48
+launch(grid=(mb,num_q_heads,1), block=(512,1,1), min_blocks_per_sm=1,
+       dynamic_smem_bytes=201344, target="sm_100a")
+# instruction_selection: `__launch_bounds__(512,1)`, `.extern .shared .align 1024`;
+# extent: one runtime-shape specialization.
+
+ABI=(Qmap,Kmap,Vmap,out_bf16,lse_f32,temperature_lse_f32,block_mask_u8,
+     mb_i32,nb_i32,selected_blocks_i32,num_q_heads_i32,num_kv_heads_i32,
+     softmax_scale_log2_f32,lse_temperature_scale_f32,
+     return_softmax_lse_i32,return_temperature_lse_i32)
+# Q map: bf16 rank 4, dims {64,M,Hq,2}, byte strides {Hq*256,256,128},
+# box {64,64,1,2}; K/V maps: dims {64,N,2,Hkv}, strides
+# {Hkv*256,128,256}, box {64,64,1,1}; all use SWIZZLE_128B.
+
+arena = linear_smem_u8(201344, alignment=1024)
+OFF=dict(q_full=0,union_ready=8,k_full=16,k_empty=40,v_full=64,v_empty=80,
+         s_full=96,p_full=112,corr_sig=128,corr_done=144,o_full=160,
+         tmem_dealloc=176,tmem_mailbox=184,q0=1024,q1=17408,k=33792,
+         v=132096,scale=197632,union_count=199680,union_blocks=199688)
+def bar(name,i=0): return OFF[name] + 8*i
+INIT_COUNT=dict(q_full=1,union_ready=32,k_full=1,k_empty=1,v_full=1,v_empty=1,
+                s_full=1,p_full=256,corr_sig=128,corr_done=128,o_full=1,
+                tmem_dealloc=128)
+def q_byte(instance,dim_half): return OFF.q0 + 16384*instance + 8192*dim_half
+def k_byte(stage,token_half,dim_half):
+    return OFF.k + 32768*stage + 8192*token_half + 16384*dim_half
+def v_byte(stage,token_half,dim_half):
+    return OFF.v + 32768*stage + 8192*token_half + 16384*dim_half
+def scale_byte(kind,instance,row): return OFF.scale + 4*(128*kind+64*instance+row)
+def union_count_byte(instance): return OFF.union_count + 4*instance
+def union_block_byte(instance,slot): return OFF.union_blocks + 4*(192*instance+slot)
+# instruction_selection: scalar `ld.shared.b32` / `st.shared.b32`; extent:
+# explicit rank-one byte addresses only.
+
+DESC_HI=0x40004040
+QK_IDESC=0x04200490; PV_IDESC=0x04210490
+QK_A_STEPS=(2,2,2,506,2,2,2); QK_B_STEPS=(2,2,2,1018,2,2,2)
+PV_A_STEP=8; PV_B_STEP=128; V_LBO_BIT=0x4000000
+S_COL=(0,256); P_COL=(64,320); O_COL=(128,384)
+def desc_lo(shared_byte): return (shared_address(shared_byte)>>4) & 0x3fff
+def tmem_addr(lane_origin,column): return tmem_base + (lane_origin<<16) + column
+```
+
+## Complete operation sketch
+
+### Prologue
+
+```python
+q_tile,q_head = cta_id(); warp=shuffle_index(thread_id()//32,0); lane=thread_id()%32
+# instruction_selection: `%ctaid.x/y`, `%tid.x`, one `shfl.sync.idx.b32`;
+# extent: scalar special-register reads and one warp-uniform broadcast.
+
+if warp == 0 and elect():
+    for name in (q_full,union_ready,k_full*3,k_empty*3,v_full*2,v_empty*2,
+                 s_full*2,p_full*2,corr_sig*2,corr_done*2,o_full*2,tmem_dealloc):
+        init_mbarrier(bar(name),INIT_COUNT[name])
+    # instruction_selection: `elect.sync`, 23 `mbarrier.init.shared::cta.b64`;
+    # extent: elected lane of warp 0.
+    fence("mbarrier_init_release_cluster")
+    # instruction_selection: `fence.mbarrier_init.release.cluster`; extent: one.
+sync_warp()
+# instruction_selection: `bar.warp.sync -1`; extent: every warp.
+if warp == 0:
+    tmem_alloc(OFF.tmem_mailbox,512); tmem_relinquish()
+    # instruction_selection: `tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32`
+    # then `tcgen05.relinquish_alloc_permit...`; extent: warp 0.
+sync_cta(); fence("tcgen05_after_thread_sync")
+# instruction_selection: `bar.sync 0`, `tcgen05.fence::after_thread_sync`.
+tmem_base=copy_s2r(OFF.tmem_mailbox,volatile=True)
+# instruction_selection: `ld.volatile.shared.b32`; extent: all threads.
+
+if 12 <= warp <= 15: setmaxnreg(decrease,48)
+# instruction_selection: `setmaxnreg.dec.sync.aligned.u32 48`; extent: warps 12–15.
+```
+
+Every parity wait is the source retry loop around
+`mbarrier.try_wait.parity.acquire.cta.shared::cta.b64` with timeout `0x989680`.
+Producer empty phases start at one; other phases start at zero and flip after
+each completed wait.
+
+### Warps 0–7: two 64-row probability/statistics instances
+
+```python
+if warp <= 7:
+    setmaxnreg(increase,192)
+    # instruction_selection: `setmaxnreg.inc.sync.aligned.u32 192`; extent: eight warps.
+    wait(bar(union_ready),phase_union_ready)
+    # instruction_selection: parity retry loop; extent: 256 threads.
+    instance=shuffle_index(warp//4,0); lane_origin=(warp%4)*32
+    my_row=(warp%4)*16 + lane%16; col_half=lane//16
+    # instruction_selection: source's four `shfl.sync.idx.b32` broadcasts;
+    # extent: instance/row/token/TMEM offsets.
+    row_max=-inf; row_sum=0.0; temperature_sum=0.0
+    for block_slot in serial_range(selected_blocks):
+        n_block=copy_s2r(union_block_byte(instance,block_slot))
+        # instruction_selection: `ld.shared.b32`; extent: one selected index.
+        wait(bar(s_full,instance),phase_s[instance]); phase_s[instance]^=1
+        # instruction_selection: parity retry loop; extent: 128 threads per instance.
+        s=reg_tile(64,"f32")
+        copy_t2r(tmem_addr(lane_origin,S_COL[instance]),s[0:32],"16x32bx2.x32")
+        copy_t2r(tmem_addr(lane_origin,S_COL[instance]+32),s[32:64],"16x32bx2.x32")
+        # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32`;
+        # extent: 64 FP32 values per thread.
+        acc=(-inf,-inf)
+        for j in static_range(32): acc[j%2]=max(acc[j%2],max(s[2*j],s[2*j+1]))
+        tile_max=max(max(acc[0],acc[1]),shuffle_xor(max(acc[0],acc[1]),16))
+        # instruction_selection: 67 static `max.f32` plus `shfl.sync.bfly.b32`;
+        # extent: one 128-column row split between lane halves.
+        new_max=max(tile_max,row_max); safe_max=select(new_max == -inf,0.0,new_max)
+        scaled_max=mul(safe_max,softmax_scale_log2)
+        delta=fma(row_max,softmax_scale_log2,-scaled_max)
+        # instruction_selection: `max.f32`, `selp.f32`, `mul.ftz.f32`,
+        # `fma.rn.ftz.f32`; extent: row scalars.
+        if delta >= -8.0:
+            acc_scale=1.0; temperature_acc_scale=1.0; selected_max=row_max
+            safe_max=select(row_max == -inf,0.0,row_max)
+            scaled_max=mul(safe_max,softmax_scale_log2)
+        else:
+            acc_scale=select(row_max>-inf,exp2(delta),1.0)
+            temperature_acc_scale=select(row_max>-inf,exp2(mul(delta,lse_temperature_scale)),1.0)
+            selected_max=new_max
+        # instruction_selection: `setp.ltu.ftz.f32` branch, `ex2.approx.ftz.f32`,
+        # `mul.ftz.f32`, and `selp.f32`; extent: one rescale decision.
+        row_max=selected_max
+        if col_half == 0: copy_r2s(acc_scale,scale_byte(0,instance,my_row))
+        # instruction_selection: predicated `st.shared.b32`; extent: one row scale.
+        fence("proxy_async_shared_cta"); arrive(bar(corr_sig,instance))
+        # instruction_selection: `fence.proxy.async.shared::cta` then
+        # `mbarrier.arrive.release.cta.shared::cta.b64`; extent: 128 arrivals.
+        bias=select(True,-scaled_max,-inf)
+        if return_temperature_lse != 0:
+            for j in static_range(32):
+                s[2*j:2*j+2]=fma(s[2*j:2*j+2],(softmax_scale_log2*lse_temperature_scale,)*2,
+                                   (bias*lse_temperature_scale,)*2,lanes=2)
+            for j in static_range(64): s[j]=exp2(s[j])
+            # instruction_selection: 32 `fma.rn.ftz.f32x2`, 64
+            # `ex2.approx.ftz.f32`; extent: the optional temperature fragment.
+            pair_acc=(0.0,0.0)
+            for j in static_range(32): pair_acc=add(pair_acc,s[2*j:2*j+2],lanes=2)
+            half=add(pair_acc[0],pair_acc[1])
+            temperature_block_sum=add(half,shuffle_xor(half,16))
+            # instruction_selection: 32 `add.f32x2`, two scalar `add.ftz.f32`,
+            # one `shfl.sync.bfly.b32`; extent: one row.
+            copy_t2r(tmem_addr(lane_origin,S_COL[instance]),s[0:32],"16x32bx2.x32")
+            copy_t2r(tmem_addr(lane_origin,S_COL[instance]+32),s[32:64],"16x32bx2.x32")
+            # instruction_selection: two `tcgen05.ld...x32`; extent: re-read S.
+        for j in static_range(32):
+            s[2*j:2*j+2]=fma(s[2*j:2*j+2],(softmax_scale_log2,)*2,(bias,)*2,lanes=2)
+        for j in static_range(64): s[j]=exp2(s[j])
+        pair_acc=(0.0,0.0)
+        for j in static_range(32): pair_acc=add(pair_acc,s[2*j:2*j+2],lanes=2)
+        half=add(pair_acc[0],pair_acc[1])
+        block_sum=add(half,shuffle_xor(half,16))
+        # instruction_selection: 32 packed FMA, 64 `ex2`, 32 packed add, two
+        # scalar add and one shuffle; extent: one probability row.
+        packed=[cast((s[2*j],s[2*j+1]),"bf16x2") for j in static_range(32)]
+        copy_r2t(packed[0:16],tmem_addr(lane_origin,P_COL[instance]),"16x32bx2.x16")
+        copy_r2t(packed[16:32],tmem_addr(lane_origin,P_COL[instance]+16),"16x32bx2.x16")
+        # instruction_selection: 32 `cvt.rn.bf16x2.f32` and two
+        # `tcgen05.st.sync.aligned.16x32bx2.x16.b32`; extent: 64 probabilities.
+        tmem_wait_st(); arrive(bar(p_full,instance))
+        wait(bar(corr_done,instance),phase_corr_done[instance]); phase_corr_done[instance]^=1
+        # instruction_selection: TMEM store wait, mbarrier arrive, parity retry wait.
+        row_sum=fma(row_sum,acc_scale,block_sum)
+        if return_temperature_lse: temperature_sum=fma(temperature_sum,temperature_acc_scale,
+                                                        temperature_block_sum)
+        # instruction_selection: `fma.rn.ftz.f32`; extent: one or two running sums.
+    if col_half == 0:
+        copy_r2s(row_sum,scale_byte(1,instance,my_row))
+        copy_r2s(row_max,scale_byte(2,instance,my_row))
+        copy_r2s(temperature_sum,scale_byte(3,instance,my_row))
+    # instruction_selection: three predicated `st.shared.b32`; extent: final row state.
+    fence("proxy_async_shared_cta"); arrive(bar(corr_sig,instance))
+    # instruction_selection: proxy fence and mbarrier arrive; extent: final generation.
+```
+
+### Warps 8–11: correction and output
+
+```python
+if 8 <= warp <= 11:
+    setmaxnreg(decrease,80)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32 80`; extent: four warps.
+    wait(bar(union_ready),phase_union_ready)
+    warp_in_role=warp-8; lane_origin=warp_in_role*32
+    logical_row_origin=warp_in_role*16
+    my_row=logical_row_origin+lane%16; col_half=lane//16
+    arrive(bar(p_full,0)); arrive(bar(p_full,1))
+    for instance in static_range(2):
+        wait(bar(corr_sig,instance),phase_corr_sig[instance]); phase_corr_sig[instance]^=1
+        arrive(bar(corr_done,instance))
+    # instruction_selection: parity waits and mbarrier arrives; first block never rescales O.
+    for block_slot in serial_range(1,selected_blocks):
+        for instance in static_range(2):
+            wait(bar(corr_sig,instance),phase_corr_sig[instance]); phase_corr_sig[instance]^=1
+            acc_scale=copy_s2r(scale_byte(0,instance,my_row))
+            # instruction_selection: parity wait and `ld.shared.b32`; extent: one row.
+            if any(acc_scale < 1.0):
+                # instruction_selection: `setp.lt.ftz.f32`, `vote.sync.any.pred`; one warp vote.
+                o=reg_tile(64,"f32")
+                copy_t2r(tmem_addr(lane_origin,O_COL[instance]),o[0:32],"16x32bx2.x32")
+                copy_t2r(tmem_addr(lane_origin,O_COL[instance]+32),o[32:64],"16x32bx2.x32")
+                for j in static_range(32):
+                    o[2*j:2*j+2]=mul(o[2*j:2*j+2],(acc_scale,)*2,lanes=2)
+                copy_r2t(o,tmem_addr(lane_origin,O_COL[instance]),"16x32bx2.x64")
+                # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32`,
+                # 32 `mul.rn.ftz.f32x2`, one
+                # `tcgen05.st.sync.aligned.16x32bx2.x64.b32`; extent: 64 registers.
+                tmem_wait_st()
+                # instruction_selection: `tcgen05.wait::st.sync.aligned`; extent: one.
+            arrive(bar(p_full,instance)); arrive(bar(corr_done,instance))
+            # instruction_selection: two mbarrier arrives; extent: one instance/block.
+    wait(bar(o_full,0),phase_o[0]); wait(bar(o_full,1),phase_o[1])
+    wait(bar(corr_sig,0),phase_corr_sig[0]); wait(bar(corr_sig,1),phase_corr_sig[1])
+    fence("tcgen05_after_thread_sync")
+    # instruction_selection: four parity waits and `tcgen05.fence::after_thread_sync`.
+    for instance in static_range(2):
+        final_sum=copy_s2r(scale_byte(1,instance,my_row))
+        final_max=copy_s2r(scale_byte(2,instance,my_row))
+        final_temperature_sum=copy_s2r(scale_byte(3,instance,my_row))
+        inv_sum=select(final_sum>0.0,rcp(final_sum),0.0)
+        # instruction_selection: three unconditional `ld.shared.b32`,
+        # `rcp.approx.ftz.f32`, `selp.f32`; extent: one instance row.
+        o=reg_tile(64,"f32")
+        copy_t2r(tmem_addr(lane_origin,O_COL[instance]),o[0:32],"16x32bx2.x32")
+        copy_t2r(tmem_addr(lane_origin,O_COL[instance]+32),o[32:64],"16x32bx2.x32")
+        # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32`;
+        # extent: 64 columns in the lane-selected half.
+        for chunk in static_range(8):
+            for j in static_range(4):
+                o[8*chunk+2*j:8*chunk+2*j+2]=mul(
+                    o[8*chunk+2*j:8*chunk+2*j+2],(inv_sum,)*2,lanes=2)
+            words=[cast((o[8*chunk+2*j],o[8*chunk+2*j+1]),"bf16x2")
+                   for j in static_range(4)]
+            copy_r2g(words,out_row+col_half*64+8*chunk)
+        # instruction_selection: 32 packed FTZ multiplies, 32 packed BF16
+        # conversions, eight `st.global.v4.b32`; extent: one 64-column lane half.
+        if col_half == 0:
+            if return_softmax_lse:
+                lse_core=fma(mul(final_max,softmax_scale_log2),ln2,
+                             mul(log2(final_sum),ln2))
+                softmax_lse=select(final_sum>0.0,lse_core,-inf)
+                copy_r2g(softmax_lse,lse_index)
+                # instruction_selection: `lg2.approx.ftz.f32`, ordered mul/FMA,
+                # positive-sum `selp.f32`, and one `st.global.b32`.
+            if return_temperature_lse:
+                temperature_core=fma(
+                    lse_temperature_scale,
+                    mul(mul(final_max,softmax_scale_log2),ln2),
+                    mul(log2(final_temperature_sum),ln2))
+                temperature_value=select(final_temperature_sum>0.0,temperature_core,-inf)
+                copy_r2g(temperature_value,temperature_lse_index)
+                # instruction_selection: `lg2.approx.ftz.f32`, source-ordered nested
+                # mul/FMA, positive-sum `selp.f32`, and one `st.global.b32`.
+    tmem_wait_ld(); fence("tcgen05_before_thread_sync"); arrive(bar(tmem_dealloc))
+    # instruction_selection: `tcgen05.wait::ld.sync.aligned`,
+    # `tcgen05.fence::before_thread_sync`, mbarrier arrive; extent: 128 threads.
+```
+
+### Warp 12: MMA issuer
+
+```python
+if warp == 12:
+    wait(bar(union_ready),phase_union_ready); wait(bar(q_full),phase_q_full)
+    # instruction_selection: two parity retry loops; extent: warp 12.
+    k_ring=(stage=0,phase=0); v_ring=(stage=0,phase=0); first_pv=(True,True)
+    for instance in static_range(2):
+        wait(bar(k_full,k_ring.stage),k_ring.phase)
+        for k16 in static_range(8):
+            gemm(tmem_addr(0,S_COL[instance]),q_descriptor(instance,k16),
+                 k_descriptor(k_ring.stage,k16),QK_IDESC,accumulate=(k16!=0))
+        # instruction_selection: parity wait, `elect.sync`, eight predicated
+        # `tcgen05.mma.cta_group::1.kind::f16`; extent: one 64x128x128 QK tile.
+        commit(bar(s_full,instance)); commit(bar(k_empty,k_ring.stage)); k_ring.advance()
+        # instruction_selection: two elected `tcgen05.commit...mbarrier::arrive::one`.
+    for block_slot in serial_range(selected_blocks):
+        for instance in static_range(2):
+            wait(bar(v_full,v_ring.stage),v_ring.phase)
+            wait(bar(p_full,instance),phase_p[instance]); phase_p[instance]^=1
+            for k16 in static_range(8):
+                gemm(tmem_addr(0,O_COL[instance]),tmem_addr(0,P_COL[instance]+8*k16),
+                     v_descriptor(v_ring.stage,k16),PV_IDESC,
+                     accumulate=(k16!=0 or not first_pv[instance]))
+            # instruction_selection: two parity waits, elect, eight predicated
+            # `tcgen05.mma...kind::f16`; extent: one 64x128x128 PV tile.
+            first_pv[instance]=False
+            if block_slot+1 == selected_blocks: commit(bar(o_full,instance))
+            commit(bar(v_empty,v_ring.stage)); v_ring.advance()
+            # instruction_selection: elected tcgen05 commit(s); output commit only on last block.
+            if block_slot+1 < selected_blocks:
+                wait(bar(k_full,k_ring.stage),k_ring.phase)
+                for k16 in static_range(8):
+                    gemm(tmem_addr(0,S_COL[instance]),q_descriptor(instance,k16),
+                         k_descriptor(k_ring.stage,k16),QK_IDESC,accumulate=(k16!=0))
+                commit(bar(s_full,instance)); commit(bar(k_empty,k_ring.stage)); k_ring.advance()
+                # instruction_selection: parity wait, eight QK `tcgen05.mma`, two commits;
+                # extent: prefetch the next score tile between PV instances.
+    wait(bar(tmem_dealloc),phase_tmem_dealloc)
+    tmem_dealloc(copy_s2r(OFF.tmem_mailbox,volatile=True),512)
+    # instruction_selection: parity wait, `ld.volatile.shared.b32`,
+    # `tcgen05.dealloc.cta_group::1.sync.aligned.b32`; extent: warp 12.
+```
+
+### Warp 13: Q, mask, and K producer
+
+```python
+if warp == 13:
+    if elect():
+        arrive_expect_tx(bar(q_full),32768)
+        copy_g2s_tma(Qmap,(0,query_base,q_head,0),q_byte(0,0),bar(q_full))
+        copy_g2s_tma(Qmap,(0,query_base+64,q_head,0),q_byte(1,0),bar(q_full))
+    # instruction_selection: elect, one expect-tx, two
+    # `cp.async.bulk.tensor.4d.shared::cta.global...`; extent: two 16 KiB Q halves.
+    selected_count=0
+    for block_base in serial_range(0,nb,32):
+        selected=copy_g2r(block_mask[mask_base+block_base+lane]) != 0 if block_base+lane<nb else False
+        bits=ballot(selected); lower=popc(bits & ((1<<lane)-1)); count=popc(bits)
+        # instruction_selection: predicated `ld.global.nc.b8`, `vote.sync.ballot.b32`,
+        # two `popc.b32`; extent: one 32-column mask chunk.
+        if selected:
+            copy_r2s(block_base+lane,union_block_byte(0,selected_count+lower))
+            copy_r2s(block_base+lane,union_block_byte(1,selected_count+lower))
+        # instruction_selection: two predicated `st.shared.b32`; extent: one selected lane.
+        selected_count+=count
+    if lane<2: copy_r2s(selected_count,union_count_byte(lane))
+    named_barrier(8,32); fence("proxy_async_shared_cta"); arrive(bar(union_ready))
+    # instruction_selection: `barrier.sync 8,32`, proxy fence, mbarrier arrive.
+    k_ring=(stage=0,phase=1)
+    for block_slot in serial_range(selected_blocks):
+        for instance in static_range(2):
+            n_block=copy_s2r(union_block_byte(instance,block_slot))
+            wait(bar(k_empty,k_ring.stage),k_ring.phase)
+            if elect():
+                arrive_expect_tx(bar(k_full,k_ring.stage),32768)
+                for token_half,dim_half in static_product(2,2):
+                    copy_g2s_tma(Kmap,(0,n_block*128+64*token_half,dim_half,q_head),
+                                 k_byte(k_ring.stage,token_half,dim_half),bar(k_full,k_ring.stage))
+            # instruction_selection: shared index load, parity wait, elect, expect-tx,
+            # four 8 KiB four-dimensional TMA loads; extent: one K tile.
+            k_ring.advance()
+```
+
+### Warp 14 and warp 15
+
+```python
+if warp == 14:
+    wait(bar(union_ready),phase_union_ready)
+    # instruction_selection: parity retry loop; extent: warp 14.
+    v_ring=(stage=0,phase=1)
+    for block_slot in serial_range(selected_blocks):
+        for instance in static_range(2):
+            n_block=copy_s2r(union_block_byte(instance,block_slot))
+            wait(bar(v_empty,v_ring.stage),v_ring.phase)
+            if elect():
+                arrive_expect_tx(bar(v_full,v_ring.stage),32768)
+                for token_half,dim_half in static_product(2,2):
+                    copy_g2s_tma(Vmap,(0,n_block*128+64*token_half,dim_half,q_head),
+                                 v_byte(v_ring.stage,token_half,dim_half),bar(v_full,v_ring.stage))
+            # instruction_selection: shared index load, parity wait, elect, expect-tx,
+            # four 8 KiB four-dimensional TMA loads; extent: one V tile.
+            v_ring.advance()
+if warp == 15: pass
+```
+
+## Bidirectional source/sketch/PTX map
+
+| source region | sketch region | line-info PTX evidence |
+| --- | --- | --- |
+| helpers 44–481 | primitive vocabulary | helper `.loc` records for elect, waits, TMA, TMEM, packed arithmetic, and approximate math |
+| ABI/storage/init 489–596 | fixed resources and prologue | 23 `mbarrier.init`, alloc/relinquish, warp/CTA sync, dynamic shared declaration |
+| probability/statistics 598–933 | warps 0–7 | `.loc` 624/657/660/905/909 waits; 12 TMEM x32 loads; 194 ex2; packed FMA/add; four TMEM x16 stores |
+| correction/output 935–1118 | warps 8–11 | `.loc` 949–1030 waits/rescale stores; 1043 fence; 1049–1110 shared loads, TMEM loads, 16 vector output stores and four statistic stores |
+| MMA 1120–1529 | warp 12 | `.loc` 1198/1264/1325/1394/1451/1519 six static eight-issue chains and 12 static commits |
+| Q/mask/K 1531–1609 | warp 13 | `.loc` 1549–1588 Q TMA, mask load/ballot/shared stores/publication; 1595 K list loads and K pipeline waits/TMA |
+| V 1611–1659 | warp 14 | `.loc` 1617/1639/1641 V publication wait, list loads, V pipeline waits/TMA |
+| idle 1661–1663 | warp 15 | no emitted operation |
+
+Reading the mapping in reverse, every TMA, TMEM load/store, MMA, tcgen commit,
+mbarrier operation, named barrier, vote, shuffle, transcendental, packed FP32
+operation, conversion, global store, and register-budget instruction in the
+writer export has an occurrence above.
+
+## TIRx and validation contract
+
+The implementation imports only `tirx_kernels.kern as K`, uses a single
+rank-one shared allocation and scalar offsets, compiles with nvcc for PTX 9.2,
+and contains no tile primitive, first-class layout, `K.cuda.func_call`, verifier
+exception, or edit under `tirx_kernels/kern/`.
+
+Correctness compares independent outputs from this exact TIRx implementation
+and FlashInfer's direct `longseq/sm_100a` module bit-for-bit for BF16 output and
+enabled FP32 statistics, repeats TIRx deterministically, checks disabled-output
+sentinels, exercises selected counts 1/8/16/32/65/128/192 plus both statistic
+branches and an amplified-Q rescale case, and applies a separate strict FP32
+oracle. Performance truth is exclusively the six-row `bench_suite` matrix with
+the pinned FlashInfer reference and requires every mean ratio to be strictly
+greater than 0.99.

--- a/.agents/sketch/flashinfer/cake_vsa/cake_vsa_longseq_sm103.md
+++ b/.agents/sketch/flashinfer/cake_vsa/cake_vsa_longseq_sm103.md
@@ -1,0 +1,497 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ cc6e8794c49bf66172627bdb9742fcb17d18b839),
+Copyright (c) 2026 by FlashInfer team.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashInfer Cake VSA longseq SM103: coarse WASP pipeline sketch
+
+This is the non-executable, mechanically translatable sketch for
+[`tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py`](../../../../tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py).
+The authoritative source is
+`csrc/cake_vsa/cake_vsa_longseq_sm_103a.cu` at FlashInfer commit
+`cc6e8794c49bf66172627bdb9742fcb17d18b839` (SHA256
+`647951f777c17fa4e74e892843ce5ba8ff25d4abf1b0e68b19a264e25532c71d`),
+launched by `csrc/cake_vsa/cake_vsa_longseq_host.cpp` and dispatched by
+`flashinfer/cake_vsa.py`. The port targets `sm_103a` only.
+
+First-class layouts are forbidden. Every shared-memory object below is a byte
+range in one rank-one `u8` arena. Every stage, alias, swizzle, descriptor word,
+and TMEM fragment is selected by scalar integer arithmetic. “Tile” means a
+logical rectangle only; it is not a TIRx tile primitive or layout-bearing value.
+
+## Scope and specialization boundary
+
+| axis | in-scope values | emitted-code consequence |
+| --- | --- | --- |
+| dtype / head dim / block | BF16, D=128, R=C=128 | QK idesc `0x04200490`, PV idesc `0x04210490`, descriptor high word `0x40004040` |
+| heads | MHA, `num_q_heads == num_kv_heads == 8` | CTA uses `kv_head=q_head`; grid Y is eight |
+| selected blocks | fixed uniform count `1..192` per mask row | rolled loops bounded by runtime `selected_blocks`; two 192-entry shared lists |
+| scheduling | one CTA per `(query block, head)` | grid `(mb,8,1)`, no persistent scheduler or cluster |
+| sequence | `M,N` multiples of 128, `N>=16384` | mask scan covers `nb=N/128` in 32-bit ballot groups |
+| LSE | two independent runtime flags in the direct ABI | optional natural-log LSE and temperature-LSE scalar stores |
+| partial tiles | source keeps Q/K bounds but the public domain is exact-block aligned | predicates remain source-shaped; no padding route is added |
+
+The public wrapper passes both LSE flags as zero and selects this profile after
+the ultrasparse branch. Correctness may call the direct ABI to exercise the
+source's two LSE branches. Out of scope: FP16, GQA, other head dimensions or
+block sizes, variable top-k, more than 192 blocks, clusters, persistent
+scheduling, and the compact/ultrasparse device kernels.
+
+## Writer line-info evidence
+
+Artifacts are under `.porting/cake_vsa_longseq_sm103/writer_exports/`:
+`source_sm_103a.lineinfo.ptx` (2100 `.loc`, `.version 9.3`, `.target sm_103a`),
+plain PTX, line-info and plain cubins, SASS, ptxas output, key-op locations, and
+PTX/SASS histograms. Build flags are `nvcc -ptx|-cubin [-lineinfo]
+--std=c++17 --use_fast_math -arch=sm_103a` using CUDA 13.3 V13.3.73.
+The native cubin uses 128 registers, nine hardware barriers, zero stack frame,
+and zero spill loads/stores.
+
+Static PTX instruction-line counts include predicated instruction lines: 48
+`tcgen05.mma.cta_group::1.kind::f16`, 12 TMEM x32 loads, four TMEM x16 stores,
+two TMEM x64 stores, 12 `tcgen05.commit`, 18 TMA 4-D loads, 23 mbarrier
+initializations, five arrive-expect-tx sites, 30 try-wait sites, 24 elect sites,
+194 `ex2.approx.ftz.f32`, two `rcp.approx.ftz.f32`, four
+`lg2.approx.ftz.f32`, 16 vector output stores, and three setmaxnreg sites.
+The SASS contains 48 `UTCHMMA`, 24 `LDTM.16`, 12 `STTM.16`, 18 `UTMALDG.4D`,
+12 `UTCBAR`, 192 `MUFU.EX2`, and 16 `STG.E.128`.
+
+## Pipeline at a glance
+
+| warps | role-local program | publication / reuse edges |
+| --- | --- | --- |
+| 0..3, 4..7 | two 64-row online-softmax instances: load S from TMEM, select running max with the `2^-8` skip rule, form BF16 P, maintain sums | consume `union_ready`, `s_full[i]`, `corr_done[i]`; produce `corr_sig[i]`, `p_full[i]` |
+| 8..11 | prime the P/correction handshake, correct the two TMEM O accumulators when any row rescales, then normalize/store output and optional statistics | consume `union_ready`, `corr_sig[i]`, `o_full[i]`; produce `corr_done[i]`, `p_full[i]`, `tmem_dealloc` |
+| 12 | sole MMA issuer, alternating instance-0/1 QK and PV work through separate K/V rings | consume `union_ready`, `q_full`, `k_full`, `v_full`, `p_full`; produce `s_full`, `k_empty`, `v_empty`, `o_full` |
+| 13 | load Q, ballot-compact the mask into both union lists, then stream K through three stages | produce `q_full`, `union_ready`, `k_full`; consume `k_empty` |
+| 14 | stream V through two stages after the union list is published | consume `union_ready`, `v_empty`; produce `v_full` |
+| 15 | register-decreased idle warp | none |
+
+## Primitive vocabulary
+
+```python
+linear_smem_u8(bytes, alignment)            # the only shared allocation
+byte(base, scalar_offset)                   # scalar byte addressing
+reg_fragment(count, dtype)                  # ordinary register scalars
+tmem_addr(lane_origin, column)              # taddr + (lane_origin<<16) + column
+
+copy_g2s_tma(map, coords, dst, completion)  # global -> shared
+copy_g2r(src, dst) / copy_r2g(src, dst)     # global <-> register
+copy_s2r(src, dst) / copy_r2s(src, dst)     # shared <-> register
+copy_t2r(src, dst, shape) / copy_r2t(src, dst, shape)  # TMEM <-> register
+
+gemm, fill, cast, add, sub, mul, fma, max, exp2, log2, rcp, select
+shuffle_xor, shuffle_index, ballot, any, popc
+init_mbarrier, wait, arrive, arrive_expect_tx, commit_mma
+fence, sync_warp, sync_cta, named_barrier, elect
+setmaxnreg, tmem_alloc, tmem_relinquish, tmem_dealloc, tmem_wait_ld, tmem_wait_st
+```
+
+## Complete sketch
+
+### Fixed storage, descriptors, and scalar maps
+
+```python
+THREADS=512; WARPS=16; D=128; BLOCK=128; K_STAGES=3; V_STAGES=2
+SMEM_BYTES=201344; TMEM_COLS=512; MAX_SELECTED=192
+REG_SOFTMAX=192; REG_CORRECTION=80; REG_OTHER=48
+launch(grid=(mb,num_q_heads,1), block=(512,1,1), min_blocks_per_sm=1,
+       dynamic_smem_bytes=SMEM_BYTES, target="sm_103a")
+# instruction_selection: `.maxntid 512`, `.minnctapersm 1`,
+# `.extern .shared .align 1024`; extent: one runtime-shape specialization.
+
+ABI=(Qmap,Kmap,Vmap,out_bf16,lse_f32,temperature_lse_f32,block_mask_u8,
+     mb_i32,nb_i32,selected_blocks_i32,num_q_heads_i32,num_kv_heads_i32,
+     softmax_scale_log2_f32,lse_temperature_scale_f32,
+     return_softmax_lse_i32,return_temperature_lse_i32)
+
+# bf16 TensorMaps, rank four, SWIZZLE_128B, no L2 promotion or OOB fill.
+# Q dims {64,M,Hq,2}, strides bytes {Hq*256,256,128}, box {64,64,1,2}.
+# K/V dims {64,N,2,Hkv}, strides bytes {Hkv*256,128,256}, box {64,64,1,1}.
+
+arena = linear_smem_u8(201344, alignment=1024)
+OFF=dict(q_full=0,union_ready=8,k_full=16,k_empty=40,v_full=64,v_empty=80,
+         s_full=96,p_full=112,corr_sig=128,corr_done=144,o_full=160,
+         tmem_dealloc=176,tmem_mailbox=184,q0=1024,q1=17408,k=33792,
+         v=132096,scale=197632,union_count=199680,union_blocks=199688)
+def bar(name,i=0): return OFF[name]+8*i
+INIT=dict(q_full=1,union_ready=32,k_full=1,k_empty=1,v_full=1,v_empty=1,
+          s_full=1,p_full=256,corr_sig=128,corr_done=128,o_full=1,
+          tmem_dealloc=128)
+
+def q_byte(instance,dim_half): return OFF.q0+instance*16384+dim_half*8192
+def k_byte(stage,token_half,dim_half):
+    return OFF.k+stage*32768+token_half*8192+dim_half*16384
+def v_byte(stage,token_half,dim_half):
+    return OFF.v+stage*32768+token_half*8192+dim_half*16384
+def scale_byte(kind,instance,row):
+    return OFF.scale+4*(128*kind+64*instance+row)
+def union_block_byte(instance,slot): return OFF.union_blocks+4*(192*instance+slot)
+def mask_index(head,q_tile,n_block): return (head*mb+q_tile)*nb+n_block
+def query_index(q_tile,instance,row): return q_tile*128+instance*64+row
+def output_index(query,head,column): return (query*num_q_heads+head)*128+column
+def statistic_index(query,head): return query*num_q_heads+head
+
+DESC_HI=0x40004040
+QK_IDESC=0x04200490; PV_IDESC=0x04210490
+QK_A_STEPS=(2,2,2,506,2,2,2)
+QK_B_STEPS=(2,2,2,1018,2,2,2)
+PV_A_STEP=8; PV_B_STEP=128
+S_COL=(0,256); P_COL=(64,320); O_COL=(128,384)
+def tmem_addr(lane_origin,col): return taddr+(lane_origin<<16)+col
+```
+
+Each 32-KB K/V stage comprises four 8-KB TMA boxes: token half 0/1 crossed
+with feature half 0/1. Two TMEM x32 loads give each lane 64 FP32 elements of a
+64x128 logical tile. P overwrites columns 64..127 of each S region; O occupies
+the adjacent 128 columns.
+
+### Prologue
+
+```python
+q_tile,q_head=cta_id(); warp=warp_id(); lane=lane_id(); smem=cvta_shared(arena)
+if warp == 0:
+    if elect():
+        for offset,count in source_order_23_barriers:
+            init_mbarrier(smem+offset,count)
+            # instruction_selection: `mbarrier.init.shared::cta.b64`; extent: 23, one lane.
+        fence("mbarrier_init_release_cluster")
+        # instruction_selection: `fence.mbarrier_init.release.cluster`; extent: one lane.
+sync_warp()
+# instruction_selection: `bar.warp.sync -1`; extent: all warps.
+if warp == 0:
+    tmem_alloc(smem+OFF.tmem_mailbox,512); tmem_relinquish()
+    # instruction_selection: `tcgen05.alloc...b32 [mailbox],512` then
+    # `tcgen05.relinquish_alloc_permit...`; extent: warp 0.
+sync_cta(); fence("tcgen05_after_thread_sync")
+# instruction_selection: `bar.sync 0`, `tcgen05.fence::after_thread_sync`; extent: CTA.
+taddr=copy_s2r(OFF.tmem_mailbox,volatile=True)
+# instruction_selection: `ld.volatile.shared.b32`; extent: all threads.
+
+if 12 <= warp <= 15:
+    setmaxnreg(decrease,48)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32 48`; extent: warps 12..15.
+```
+
+### Warps 0..7: online softmax
+
+```python
+if warp <= 7:
+    setmaxnreg(increase,192)
+    # instruction_selection: `setmaxnreg.inc.sync.aligned.u32 192`; extent: warps 0..7.
+    wait(bar(union_ready),phase_union_ready=0)
+    # instruction_selection: parity `mbarrier.try_wait...cta.shared::cta.b64` retry loop.
+    instance=shuffle_index(warp//4,0); row_base=shuffle_index(instance*64,0)
+    tmem_base=shuffle_index(instance*256,0)
+    # instruction_selection: `shfl.sync.idx.b32`; extent: source warp-uniform broadcasts.
+    warp_in_instance=warp%4; lane_origin=warp_in_instance*32
+    my_row=warp_in_instance*16+lane%16; col_half=lane//16
+    row_valid = my_row < clamp(128-instance*64,0,64)
+    row_max=-inf; row_sum=0.0; temperature_sum=0.0
+
+    for u in serial_range(selected_blocks):
+        n_block=copy_s2r(union_block_byte(instance,u))
+        # instruction_selection: `ld.shared.b32`; extent: one list entry.
+        wait(bar(s_full,instance),phase_s[instance]); phase_s[instance]^=1
+        # instruction_selection: parity mbarrier retry loop; extent: 128 threads/instance.
+        scores=reg_fragment(64,f32)
+        copy_t2r(tmem_addr(lane_origin,S_COL[instance]),scores[0:32],"16x32bx2.x32")
+        copy_t2r(tmem_addr(lane_origin,S_COL[instance])+32,scores[32:64],"16x32bx2.x32")
+        # instruction_selection: two `tcgen05.ld.sync.aligned.16x32bx2.x32.b32 ... ,64`.
+        valid_cols=clamp(nb*128-n_block*128,0,128) if row_valid else 0
+        half_valid=clamp(valid_cols-col_half*64,0,64)
+        if 0 < half_valid < 64:
+            fill(scores[half_valid:64],-inf)
+            # instruction_selection: predicated `mov.b32` fill selected by scalar masks.
+        tile_max=max(scores)
+        # instruction_selection: local `max.f32` tree; extent: one lane's 64 values.
+        tile_max=select(half_valid<=0,-inf,tile_max)
+        # instruction_selection: predicate and `selp.f32`; extent: one scalar.
+        tile_max=max(tile_max,shuffle_xor(tile_max,16))
+        # instruction_selection: `shfl.sync.bfly.b32` then `max.f32`; extent: two column halves.
+        new_max=max(tile_max,row_max); safe_max=select(new_max==-inf,0,new_max)
+        new_max_scaled=mul(safe_max,softmax_scale_log2)
+        acc_log2=fma(row_max,softmax_scale_log2,-new_max_scaled)
+        # instruction_selection: `max.f32`, `selp.f32`, `mul.ftz.f32`, `fma.rn.ftz.f32`.
+        if acc_log2 >= -8.0:
+            selected_max=row_max; acc_scale=1.0; temperature_acc_scale=1.0
+            new_max_scaled=mul(select(row_max==-inf,0,row_max),softmax_scale_log2)
+        else:
+            selected_max=new_max; acc_scale=select(row_max>-inf,exp2(acc_log2),1.0)
+            temperature_acc_scale=select(row_max>-inf,exp2(acc_log2*lse_temperature_scale),1.0)
+            # instruction_selection: `ex2.approx.ftz.f32`; extent: two scalar rescale values.
+        row_max=selected_max
+        if col_half == 0: copy_r2s(acc_scale,scale_byte(0,instance,my_row))
+        # instruction_selection: `st.shared.b32`; extent: one value per logical row.
+        fence("proxy_async_shared_cta"); arrive(bar(corr_sig,instance))
+        # instruction_selection: `fence.proxy.async.shared::cta`, `mbarrier.arrive.release...`.
+
+        score_bias=select(valid_cols>0,-new_max_scaled,-inf)
+        if return_temperature_lse:
+            temp_scores=fma(scores,softmax_scale_log2*lse_temperature_scale,
+                            score_bias*lse_temperature_scale,lanes=2)
+            temp_probs=exp2(temp_scores)
+            # instruction_selection: 32 `fma.rn.ftz.f32x2`, 64 `ex2.approx.ftz.f32`.
+            temp_half=add_tree(temp_probs[0:32],temp_probs[32:64],lanes=2)
+            block_temperature_sum=add(temp_half,shuffle_xor(temp_half,16))
+            # instruction_selection: `add.f32x2` tree and `shfl.sync.bfly.b32`.
+            copy_t2r(S_again, scores, "2x16x32bx2.x32")
+            # instruction_selection: two more x32 TMEM loads; extent: source re-read branch.
+            if 0 < half_valid < 64:
+                fill(scores[half_valid:64],-inf)
+                # instruction_selection: the source-repeated predicated `mov.b32` fill.
+        probs=exp2(fma(scores,softmax_scale_log2,score_bias,lanes=2))
+        # instruction_selection: 32 `fma.rn.ftz.f32x2`, 64 `ex2.approx.ftz.f32`.
+        prob_half=add_tree(probs[0:32],probs[32:64],lanes=2)
+        block_sum=add(prob_half,shuffle_xor(prob_half,16))
+        # instruction_selection: `add.f32x2` tree and `shfl.sync.bfly.b32`.
+        copy_r2t(cast_bf16x2(probs[0:32]),P_COL[instance],"16x32bx2.x16")
+        copy_r2t(cast_bf16x2(probs[32:64]),P_COL[instance]+32,"16x32bx2.x16")
+        # instruction_selection: `cvt.rn.bf16x2.f32` then two
+        # `tcgen05.st.sync.aligned.16x32bx2.x16.b32`; extent: one P tile.
+        tmem_wait_st(); arrive(bar(p_full,instance))
+        wait(bar(corr_done,instance),phase_corr_done[instance]); phase_corr_done[instance]^=1
+        # instruction_selection: `tcgen05.wait::st.sync.aligned`, mbarrier arrival,
+        # then parity mbarrier retry loop in source order.
+        row_sum=fma(row_sum,acc_scale,block_sum)
+        # instruction_selection: scalar `fma.rn.ftz.f32`.
+        if return_temperature_lse:
+            temperature_sum=fma(temperature_sum,temperature_acc_scale,block_temperature_sum)
+            # instruction_selection: conditional scalar `fma.rn.ftz.f32` and select.
+
+    if col_half == 0:
+        copy_r2s(row_sum,scale_byte(1,instance,my_row))
+        copy_r2s(row_max,scale_byte(2,instance,my_row))
+        copy_r2s(temperature_sum,scale_byte(3,instance,my_row))
+        # instruction_selection: three `st.shared.b32`; extent: one lane per logical row.
+    fence("proxy_async_shared_cta"); arrive(bar(corr_sig,instance))
+    # instruction_selection: `fence.proxy.async.shared::cta` then final
+    # `mbarrier.arrive.release.cta.shared::cta.b64`; extent: 128 threads/instance.
+```
+
+### Warps 8..11: correction and epilogue
+
+```python
+if 8 <= warp <= 11:
+    setmaxnreg(decrease,80)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32 80`; extent: warps 8..11.
+    my_row=(warp-8)*16+lane%16; col_half=lane//16; row_addr=(warp-8)*32<<16
+    wait(bar(union_ready),phase_union_ready=0)
+    # instruction_selection: parity mbarrier retry loop.
+    arrive(bar(p_full,0)); arrive(bar(p_full,1))
+    # instruction_selection: two `mbarrier.arrive.release.cta.shared::cta.b64`.
+    wait(bar(corr_sig,0),phase_corr_sig[0]); phase_corr_sig[0]^=1
+    arrive(bar(corr_done,0))
+    wait(bar(corr_sig,1),phase_corr_sig[1]); phase_corr_sig[1]^=1
+    arrive(bar(corr_done,1))
+    # instruction_selection: two source-ordered parity waits and two corr_done arrivals.
+    for u in serial_range(1,selected_blocks):
+        for instance in static_range(2):
+            wait(bar(corr_sig,instance),phase_corr_sig[instance]); phase_corr_sig[instance]^=1
+            # instruction_selection: parity mbarrier retry loop.
+            acc_scale=copy_s2r(scale_byte(0,instance,my_row))
+            # instruction_selection: `ld.shared.b32`.
+            if any(acc_scale < 1.0):
+                # instruction_selection: `vote.sync.any.pred`; extent: one warp.
+                accum=copy_t2r(tmem_addr(row_addr,O_COL[instance]),64,"2x16x32bx2.x32")
+                # instruction_selection: two x32 TMEM loads.
+                accum=mul(accum,acc_scale,lanes=2)
+                # instruction_selection: 32 `mul.rn.ftz.f32x2`.
+                copy_r2t(accum,tmem_addr(row_addr,O_COL[instance]),"16x32bx2.x64")
+                # instruction_selection: one `tcgen05.st.sync.aligned.16x32bx2.x64.b32`.
+                tmem_wait_st()
+                # instruction_selection: `tcgen05.wait::st.sync.aligned`.
+            arrive(bar(p_full,instance)); arrive(bar(corr_done,instance))
+            # instruction_selection: two mbarrier arrivals.
+
+    wait(bar(o_full,0),phase_o[0]); wait(bar(o_full,1),phase_o[1])
+    wait(bar(corr_sig,0),phase_corr_sig[0]); wait(bar(corr_sig,1),phase_corr_sig[1])
+    # instruction_selection: four parity mbarrier retry waits.
+    fence("tcgen05_after_thread_sync")
+    # instruction_selection: `tcgen05.fence::after_thread_sync`.
+    for instance in static_range(2):
+        final_sum=copy_s2r(scale_byte(1,instance,my_row))
+        final_max=copy_s2r(scale_byte(2,instance,my_row))
+        final_temperature_sum=copy_s2r(scale_byte(3,instance,my_row))
+        # instruction_selection: scalar shared loads.
+        inv_sum=select(final_sum>0 and final_sum==final_sum,rcp(final_sum),0)
+        # instruction_selection: `rcp.approx.ftz.f32`, predicates and `selp.f32`.
+        accum=copy_t2r(tmem_addr(row_addr,O_COL[instance]),64,"2x16x32bx2.x32")
+        # instruction_selection: two x32 TMEM loads.
+        query=query_index(q_tile,instance,my_row)
+        row_valid=my_row < clamp(128-instance*64,0,64)
+        if row_valid:
+            for chunk in static_range(8):
+                normalized=mul(accum[chunk*8:chunk*8+8],inv_sum,lanes=2)
+                packed=cast_bf16x2(normalized)
+                # instruction_selection: four `mul.rn.ftz.f32x2` followed by four
+                # `cvt.rn.bf16x2.f32`; extent: one eight-element output chunk.
+                column=col_half*64+chunk*8
+                copy_r2g(packed[0:4],out_bf16[output_index(query,q_head,column)])
+                # instruction_selection: one `st.global.v4.b32`; extent: four packed words.
+            if col_half == 0 and return_softmax_lse:
+                scaled_max=mul(final_max,softmax_scale_log2)
+                log_term=mul(log2(final_sum),ln2)
+                lse_value=select(final_sum>0,fma(scaled_max,ln2,log_term),-inf)
+                copy_r2g(lse_value,lse_f32[statistic_index(query,q_head)])
+                # instruction_selection: `lg2.approx.ftz.f32`, two scalar `mul.ftz.f32`,
+                # `fma.rn.ftz.f32`, predicate/select, and `st.global.b32`.
+            if col_half == 0 and return_temperature_lse:
+                scaled_max=mul(final_max,softmax_scale_log2)
+                scaled_max_ln2=mul(scaled_max,ln2)
+                log_term=mul(log2(final_temperature_sum),ln2)
+                tlse_value=select(final_temperature_sum>0,
+                    fma(lse_temperature_scale,scaled_max_ln2,log_term),-inf)
+                copy_r2g(tlse_value,temperature_lse_f32[statistic_index(query,q_head)])
+                # instruction_selection: `lg2.approx.ftz.f32`, three scalar `mul.ftz.f32`,
+                # `fma.rn.ftz.f32`, predicate/select, and `st.global.b32`.
+    tmem_wait_ld(); fence("tcgen05_before_thread_sync"); arrive(bar(tmem_dealloc))
+    # instruction_selection: `tcgen05.wait::ld.sync.aligned`,
+    # `tcgen05.fence::before_thread_sync`, one mbarrier arrival per thread.
+```
+
+### Warp 12: QK/PV MMA pipeline
+
+```python
+if warp == 12:
+    wait(bar(union_ready),0); wait(bar(q_full),0)
+    # instruction_selection: parity mbarrier retry waits.
+    k_stage=0; k_phase=0; v_stage=0; v_phase=0; first_pv=[True,True]
+    for instance in static_range(2):
+        current_k_stage=k_stage; current_k_phase=k_phase
+        advance(k_stage,k_phase,3)
+        wait(bar(k_full,current_k_stage),current_k_phase)
+        # instruction_selection: parity mbarrier retry wait.
+        gemm(S[instance],Q[instance],K[current_k_stage],QK_IDESC,enable_d=False,steps=8)
+        # instruction_selection: eight elected `tcgen05.mma.cta_group::1.kind::f16`;
+        # descriptor low-word steps are Q `(2,2,2,506,2,2,2)` and
+        # K `(2,2,2,1018,2,2,2)`.
+        commit_mma(bar(s_full,instance)); commit_mma(bar(k_empty,current_k_stage))
+        # instruction_selection: elected `tcgen05.commit...mbarrier::arrive::one` twice.
+
+    for u in serial_range(selected_blocks):
+        for instance in static_range(2):
+            current_v_stage=v_stage; current_v_phase=v_phase
+            advance(v_stage,v_phase,2)
+            wait(bar(v_full,current_v_stage),current_v_phase)
+            wait(bar(p_full,instance),phase_p[instance]); phase_p[instance]^=1
+            # instruction_selection: two parity mbarrier retry waits.
+            gemm(O[instance],P[instance],V[current_v_stage],PV_IDESC,
+                 enable_d=not first_pv[instance],steps=8)
+            # instruction_selection: eight elected `tcgen05.mma.cta_group::1.kind::f16`;
+            # TMEM A advances +8 columns and V descriptor advances +128 low words.
+            first_pv[instance]=False
+            if u+1 == selected_blocks: commit_mma(bar(o_full,instance))
+            commit_mma(bar(v_empty,current_v_stage))
+            # instruction_selection: elected tcgen05 commits to O/V barriers.
+            if u+1 < selected_blocks:
+                current_k_stage=k_stage; current_k_phase=k_phase
+                advance(k_stage,k_phase,3)
+                wait(bar(k_full,current_k_stage),current_k_phase)
+                gemm(S[instance],Q[instance],K[current_k_stage],QK_IDESC,enable_d=False,steps=8)
+                commit_mma(bar(s_full,instance)); commit_mma(bar(k_empty,current_k_stage))
+                # instruction_selection: pre-advance, parity wait, eight elected QK MMAs, two commits.
+    wait(bar(tmem_dealloc),0); tmem_dealloc(taddr,512)
+    # instruction_selection: parity wait and
+    # `tcgen05.dealloc.cta_group::1.sync.aligned.b32 ...,512`.
+```
+
+### Warp 13: Q, compaction, and K producer
+
+```python
+if warp == 13:
+    if elect():
+        arrive_expect_tx(bar(q_full),32768)
+        copy_g2s_tma(Qmap,(0,q_tile*128,q_head,0),OFF.q0,bar(q_full))
+        copy_g2s_tma(Qmap,(0,q_tile*128+64,q_head,0),OFF.q1,bar(q_full))
+        # instruction_selection: one arrive-expect-tx and two
+        # `cp.async.bulk.tensor.4d...complete_tx::bytes` operations.
+    selected_count=0
+    for block_base in serial_range(0,nb,32):
+        n_block=block_base+lane
+        selected=(n_block<nb and copy_g2r(block_mask[mask_index(q_head,q_tile,n_block)])!=0)
+        # instruction_selection: predicated `ld.global.nc.b8`.
+        votes=ballot(selected); slot=selected_count+popc(votes & ((1<<lane)-1))
+        # instruction_selection: `vote.sync.ballot.b32` and `popc.b32`.
+        if selected:
+            copy_r2s(n_block,union_block_byte(0,slot));
+            copy_r2s(n_block,union_block_byte(1,slot))
+            # instruction_selection: two `st.shared.b32`.
+        selected_count += popc(votes)
+    if selected_count == 0:
+        if lane == 0:
+            copy_r2s(0,union_block_byte(0,0)); copy_r2s(0,union_block_byte(1,0))
+        selected_count=1
+    if lane < 2: copy_r2s(selected_count,OFF.union_count+lane*4)
+    # instruction_selection: scalar shared stores; public domain count equals selected_blocks.
+    named_barrier(id=8,count=32); fence("proxy_async_shared_cta"); arrive(bar(union_ready))
+    # instruction_selection: `barrier.sync 8,32`, proxy fence, mbarrier arrival.
+    k_stage=0; k_empty_phase=1
+    for u in serial_range(selected_blocks):
+        for instance in static_range(2):
+            n_block=copy_s2r(union_block_byte(instance,u))
+            wait(bar(k_empty,k_stage),k_empty_phase)
+            # instruction_selection: shared load and parity mbarrier retry wait.
+            if elect():
+                arrive_expect_tx(bar(k_full,k_stage),32768)
+                for token_half,dim_half in static_product((0,1),(0,1)):
+                    copy_g2s_tma(Kmap,(0,n_block*128+token_half*64,dim_half,q_head),
+                                 k_byte(k_stage,token_half,dim_half),bar(k_full,k_stage))
+                # instruction_selection: one arrive-expect-tx plus four TMA 4-D loads.
+            advance(k_stage,k_empty_phase,3)
+```
+
+### Warp 14: V producer; warp 15 idle
+
+```python
+if warp == 14:
+    wait(bar(union_ready),0)
+    # instruction_selection: parity mbarrier retry wait.
+    v_stage=0; v_empty_phase=1
+    for u in serial_range(selected_blocks):
+        for instance in static_range(2):
+            n_block=copy_s2r(union_block_byte(instance,u))
+            wait(bar(v_empty,v_stage),v_empty_phase)
+            # instruction_selection: shared load and parity mbarrier retry wait.
+            if elect():
+                arrive_expect_tx(bar(v_full,v_stage),32768)
+                for token_half,dim_half in static_product((0,1),(0,1)):
+                    copy_g2s_tma(Vmap,(0,n_block*128+token_half*64,dim_half,q_head),
+                                 v_byte(v_stage,token_half,dim_half),bar(v_full,v_stage))
+                # instruction_selection: one arrive-expect-tx plus four TMA 4-D loads.
+            advance(v_stage,v_empty_phase,2)
+if warp == 15:
+    pass
+```
+
+The role conditions are independent sibling guards in source order. They must
+not become an `if/elif` chain, and the separate K and V producers/rings must not
+be fused even though both consume the same compact list.
+
+## TIRx module and benchmark contract
+
+- The module imports only `tirx_kernels.kern as K` as its device language and
+  exposes the repository-standard metadata, config, preparation, test, and
+  benchmark entry points.
+- Correctness uses the exact pinned FlashInfer cubin as the primary reference,
+  requires bitwise source/TIRx equality, deterministic repeats, and adds a
+  chunked sparse FP64 oracle and guard checks.
+- Benchmark setup, compilation, data generation, and validation occur outside
+  the no-argument source/TIRx launch closures. The curated sweep uses Proton
+  through `tvm.tirx.bench.bench`; `bench_suite` is the only performance gate.
+- Both binaries must declare PTX 9.3 targeting `sm_103a` before a comparison is
+  valid. Every required source-time/TIRx-time ratio must be strictly above 0.99.
+
+## Instruction-selection summary
+
+The source performance structure is selected by the 16-warp role split,
+independent register scopes, the one linear 201344-byte arena, exact 128-byte
+TMA descriptors, separate three-stage K and two-stage V pipelines, two
+64x128-score/64x128-output TMEM instances, eight-instruction QK/PV MMA chains,
+packed FP32x2 softmax arithmetic, approximate base-2 math, and 128-bit output
+stores. These choices are source requirements rather than optional tuning
+ideas; later performance work may alter lowering controls only while preserving
+this execution skeleton.

--- a/.agents/sketch/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.md
+++ b/.agents/sketch/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.md
@@ -1,0 +1,673 @@
+<!--
+This file is a design sketch for a TIRx port of code from FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ c5365737570a2a156d7cae0c4070fa3770ecc670),
+Copyright (c) 2026 by FlashInfer team.
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashInfer Cake VSA ultrasparse_bsr SM100: coarse WASP pipeline sketch
+
+This is the non-executable, mechanically translatable sketch for
+[`tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py`](../../../../tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py).
+The authoritative source is `csrc/cake_vsa/cake_vsa_ultrasparse_bsr_sm_100a.cu`
+at FlashInfer commit `c5365737570a2a156d7cae0c4070fa3770ecc670` (file SHA256
+`e850a27705a8ccde640b5417bea5e2e3bbc4efcda8a7e578845bd5e0b0c32a73`, 1524 lines,
+last changed by upstream `adc49a85`, "perf(cake_vsa): refresh Blackwell
+block-sparse WS kernel (#4804)"), launched by
+`csrc/cake_vsa/cake_vsa_ultrasparse_bsr_host.cpp` and dispatched by
+`flashinfer/cake_vsa.py` (`run_cake_vsa` lines 935-957). The port targets
+`sm_100a` only.
+
+First-class layouts are forbidden. Every shared-memory object below is a byte
+range in one rank-one `u8` arena. Every alias, stage, descriptor word and TMEM
+fragment is selected by scalar integer arithmetic. "Tile" means a logical
+rectangle only; it is not a TIRx tile primitive or a layout-bearing value.
+
+## Scope and specialization boundary
+
+| axis | in-scope values | emitted-code consequence |
+| --- | --- | --- |
+| dtype / head dim / block | BF16, D=128, R=C=128 | fixed QK idesc `0x08200490` (M=128, N=128), PV idesc `0x08210490`, descriptor high word `0x40004040`, 32 KB Q box, 8 KB K/V boxes |
+| heads | MHA, `num_q_heads == num_kv_heads == 8` (dispatch predicate); `num_kv_heads` is an ABI argument the device never reads | CTA uses `kv_head = q_head` |
+| selected KV blocks per query block | exactly six, shared by all heads (`bsr_indices[mb][6]`, host-checked `selected_blocks == 6`) | three fully unrolled block pairs; instance `i` consumes slots `5-i`, `3-i`, `1-i` |
+| scheduling | persistent: `grid_x = min(total_tiles, sm_count)`, `total_tiles = mb*num_q_heads` (host-checked) | rolled tile loop `tile_idx = %ctaid.x; += %nctaid.x`; unsigned `rem.u32`/`div.u32` by `mb` |
+| `mb`, `nb`, `num_q_heads`, `softmax_scale_log2` | runtime scalars (`mb >= 625` by dispatch) | `q_tile = tile_idx % mb`, `q_head = tile_idx / mb`; `kv_len = nb*128` feeds one predicate |
+| `return_softmax_lse`, `return_temperature_lse` | 0/1 runtime (upstream Python passes 0, 0; the device implements both stores) | two predicated scalar stores of the same `final_lse` |
+| `selected_blocks`, `lse_temperature_scale` | ABI arguments never read by the device | none |
+| partial tiles | `q_valid = 128 if q_tile < mb else 0`, `row_valid = my_row < q_valid`, `valid_cols = clamp(128*(nb - n_block), 0, 128)`: predicates present, never false/short in the dispatch domain | the export lowers the source's per-lane mask loops (706-775) to one predicate `!(row_valid && n_block < nb)` guarding a whole-fragment `-inf` fill (128 `mov.b32`); `q_valid`/`my_row < q_valid` selects survive as `setp`/`selp` |
+
+Out of scope: fp16, GQA, D64/D96, blk64, blk128_compact, longseq, causal or
+any other mask shape, clusters, PDL, non-persistent launch, temperature scaling
+(the device reuses `final_lse`).
+
+## Writer line-info evidence
+
+Exports at `.porting/cake_vsa_ultrasparse_bsr_sm100/writer_exports/`:
+`source_sm_100a.lineinfo.ptx` (2168 `.loc`, `.version 9.2`, `.target sm_100a`),
+`source_sm_100a.ptx` (upstream flags, no line info), `source_sm_100a.cubin`,
+`source_sm_100a.lineinfo.cubin`, `source_sm_100a.sass`,
+`source_sm_100a.lineinfo.sass`, `source_ptxas_v.txt` (128 registers at entry, 9
+barriers, 96 bytes stack frame, 164 bytes spill stores, 220 bytes spill loads),
+`keyops_by_loc.txt`, `ptx_opcode_hist.txt`, `sass_opcode_hist.txt`,
+`source.sha256`. Build: `nvcc -ptx|-cubin [-lineinfo] --std=c++17
+--use_fast_math -arch=sm_100a`.
+
+Static emitted counts (raw PTX instruction lines, including the `@leader`-predicated
+`tcgen05.mma`/`tcgen05.commit` lines): 96 `tcgen05.mma.cta_group::1.kind::f16`
+(12 chains x 8), 12 `tcgen05.ld...32x32b.x32`, 32 `tcgen05.ld...32x32b.x16`, 32
+`tcgen05.ld...32x32b.x8`, 44 `tcgen05.st...32x32b.x16`, 20 `tcgen05.commit`, 7
+`tcgen05.wait::st`, 1 `tcgen05.wait::ld`, 49 `cp.async.bulk.tensor.4d` (1 Q + 12
+pushes x 4), 20 `mbarrier.init`, 29 `mbarrier.arrive`, 13
+`mbarrier.arrive.expect_tx`, 58 `mbarrier.try_wait` loops, 46 `elect.sync`, 22
+`shfl.sync.idx.b32`, 4 `vote.sync.any.pred`, 1 `barrier.sync 8, 32`, 3
+`setmaxnreg`, 388 `ex2.approx.ftz.f32` (384 probabilities + 2 rescales + 2
+combine scales), 192 `fma.rn.ftz.f32x2`, 448 `mul.rn.ftz.f32x2`, 192 `add.f32x2`,
+391 `max.f32`, 132 `add.ftz.f32`, 13 `mul.ftz.f32`, 7 `fma.rn.ftz.f32`, 2
+`sub.ftz.f32`, 6 `neg.ftz.f32`, 16 `selp.f32`, 256 `cvt.rn.bf16x2.f32`, 16
+`st.global.v4.b32`, 2 `st.global.b32`, 1 `ld.global.nc.b32`, 23 `ld.shared.b32`,
+6 `st.shared.b32`, 2 `ld.volatile.shared.b32`, 5 `fence.proxy.async.shared::cta`,
+1 `lg2.approx.ftz.f32`, 1 `rcp.approx.ftz.f32`, 1 `rem.u32`, 2 `div.u32`, 1
+`mov.u32 %nctaid.x`. SASS: 96 `UTCHMMA`, 76 `LDTM`, 44 `STTM`, 49
+`UTMALDG.4D`, 20 `UTCBAR`, 388 `MUFU.EX2`, 1 `MUFU.LG2`, 448 `FMUL2.FTZ`, 192
+`FFMA2.FTZ`, 192 `FADD2`, 137 `FADD.FTZ`, 195 `FMNMX3`, 256
+`F2FP.BF16.F32.PACK_AB`, 16 `STG.E.128`, 2 `STG.E`, 1 `LDG.E`, 16 `FSEL`, 16
+`ELECT`, plus register-pressure traffic (48 `LDL`, 34 `STL`, 23 `MOV.SPILL`, 23
+`R2UR.FILL`).
+
+## Pipeline at a glance
+
+One persistent CTA per SM (grid `min(mb*8, sm_count)`); every role walks the same
+`tile_idx` sequence and processes one `(query block of 128 rows, head)` per
+iteration. Six KV blocks per tile are handled as three pairs; the two softmax
+instances each own all 128 query rows and take one block of each pair.
+
+| warps | role-local program | publication / reuse edges |
+| --- | --- | --- |
+| 0..3, 4..7 | two softmax instances (instance `i = warp/4`, blocks `5-i, 3-i, 1-i`): read the 128x128 f32 S tile from TMEM (128 columns per thread), row max with a `2^-8` rescale-skip decision, `ex2` probabilities, bf16 P written in place over the upper 64 S columns, running sum/max | consume `union_ready`, `s_full[i]`, `corr_done[i]`; produce `corr_sig[i]` (rescale factor, then final stats in SMEM), `p_full[i]` |
+| 8..11 | correction + epilogue: rescale the TMEM O accumulator of an instance when a warp vote says any row needs it; finally merge both instances (combine scales, one reciprocal), store bf16 rows and the LSE | consume `union_ready`, `corr_sig[i]`, `o_full[i]`; produce `corr_done[i]`, `p_full[i]`, `q_empty`, `tile_done` |
+| 12 | sole MMA issuer: `S_i = Q K^T` (8 issues, M=128) then `O_i += P_i V` (8 issues, A from TMEM) per block; order S5 S4 / PV5 S3 PV4 S2 / PV3 S1 PV2 S0 / PV1 PV0 | consume `union_ready`, `q_full`, `kv_full`, `p_full[i]`, `tile_done`; produce `s_full[i]`, `kv_empty`, `o_full[i]`; frees TMEM after the loop |
+| 13, 14 | register-decreased idle warps | none |
+| 15 | load warp: per tile wait for the epilogue, Q TMA (32 KB), copy the six BSR indices into SMEM, then the three-stage K/V TMA ring in the order K5 K4 V5 K3 V4 K2 V3 K1 V2 K0 V1 V0 | consume `q_empty`, `kv_empty`; produce `q_full`, `union_ready`, `kv_full` |
+
+## Primitive vocabulary
+
+Structural operations do not compute values:
+
+```python
+linear_smem_u8(bytes, alignment)   # the one rank-one arena
+byte(...)                          # integer byte offset into the arena
+reg_tile(...)                      # role-local register storage
+tmem_addr(lane_origin, column)     # integer TMEM address (lane<<16 | column)
+```
+
+Copies always state their storage direction:
+
+```python
+copy_g2s_tma(map, coords, dst_byte, completion)   # global -> shared (TMA)
+copy_g2r(src, dst)                                # global -> register
+copy_r2g(src, dst)                                # register -> global
+copy_s2r(byte, dst) / copy_r2s(src, byte)         # shared <-> register
+copy_t2r(tmem_addr, dst, shape) / copy_r2t(src, tmem_addr, shape)
+```
+
+Compute vocabulary: `fill, cast, add, sub, mul, fma, max, exp2, log2, rcp,
+select, shuffle_index, any, gemm, udiv, umod`. `ring(stages, stage, parity)` is a
+`(stage, parity)` cursor: `stage, parity = r.stage, r.parity; r.advance()` captures
+the wait operands before the advance (`advance`: `stage += 1`; at `stages` it wraps
+to 0 and flips `parity`). In this kernel every ring wait has a trace-time-constant
+stage and parity because 12 pushes per tile are exactly four ring turns. Packed forms carry `lanes=2` (one
+`f32x2` instruction with two ordered results). Schedule operations:
+`init_mbarrier, wait, arrive, arrive_expect_tx, tmem_commit, fence,
+named_barrier, sync_warp, sync_cta, elect, setmaxnreg, tmem_alloc,
+tmem_relinquish, tmem_dealloc, tmem_wait_ld, tmem_wait_st`.
+
+## Fixed storage and integer maps
+
+```python
+THREADS=512; WARPS=16; D=128; BLOCK=128; KV_STAGES=3; TMEM_COLS=512
+SMEM_BYTES=135424; SELECTED=6; PAIRS=3
+REG_SOFTMAX=192; REG_CORRECTION=80; REG_OTHER=48      # 8*192+4*80+4*48 = 2048
+launch(grid=(min(total_tiles, sm_count),1,1), block=(512,1,1), min_blocks_per_sm=1,
+       dynamic_smem_bytes=SMEM_BYTES, target="sm_100a")
+# instruction_selection: `.reqntid`-free `__launch_bounds__(512,1)` entry with
+# 128 registers, `.extern .shared .align 1024`; the grid extent is the host's
+# min(total_tiles, multi_processor_count) (152 on GB200); extent: one specialization.
+
+ABI=(Qmap, Kmap, Vmap,                     # const __grid_constant__ CUtensorMap
+     out_bf16[M*Hq*128], lse_f32, temperature_lse_f32, bsr_indices_i32[mb*6],
+     mb_i32, nb_i32, selected_blocks_i32, total_tiles_i32, num_q_heads_i32,
+     num_kv_heads_i32, softmax_scale_log2_f32, lse_temperature_scale_f32,
+     return_softmax_lse_i32, return_temperature_lse_i32)
+# TensorMaps (host): bf16, rank 4, SWIZZLE_128B, no L2 promotion, no OOB fill.
+#   Qmap dims {64, M, Hq, 2}, byte strides {Hq*256, 256, 128}, box {64,128,1,2}
+#   Kmap/Vmap dims {64, N, 2, Hkv}, byte strides {Hkv*256, 128, 256}, box {64,64,1,1}
+# A Q coordinate (0, token, head, 0) moves 128 tokens x both dim halves = 32768 B
+# laid out as [dim_half][128 rows][128 B]; a K/V coordinate (0, token, dim_half,
+# head) moves 64 tokens x one half = 8192 B.
+
+arena = linear_smem_u8(SMEM_BYTES, alignment=1024)
+OFF = dict(
+  q_full=0, q_empty=8, union_ready=16, kv_full=24, kv_empty=48, s_full=72, p_full=88,
+  corr_sig=104, corr_done=120, o_full=136, tile_done=152, tmem_mailbox=160,
+  q=1024, kv=33792, scale=132096, union_count=135168, union_blocks=135172)
+def bar(name, index=0): return OFF[name] + 8*index          # 20 mbarriers in [0,160)
+INIT_COUNT = dict(q_full=1, q_empty=128, union_ready=32, kv_full=1, kv_empty=1, s_full=1,
+                  p_full=256, corr_sig=128, corr_done=128, o_full=1, tile_done=128)
+# union_count (135168) is declared by the source and never accessed.
+
+# Q: one 128-row tile; two 16384-byte dim halves of 128 rows x 128 B with the TMA
+# 128-byte swizzle, consumed only through MMA descriptors.
+def q_byte(dim_half): return OFF.q + 16384*dim_half
+# K/V ring: stage = {tokens 0-63 half 0 @+0, tokens 64-127 half 0 @+8192,
+#                    tokens 0-63 half 1 @+16384, tokens 64-127 half 1 @+24576}
+def kv_byte(stage, token_half, dim_half): return OFF.kv + 32768*stage + 8192*token_half + 16384*dim_half
+def scale_byte(kind, instance, row):   # kind: 0 acc_scale, 1 row_sum, 2 row_max
+    return OFF.scale + 4*(256*kind + 128*instance + row)
+def union_block_byte(slot): return OFF.union_blocks + 4*slot        # slots 0..5 used
+# instruction_selection: scalar `ld.shared.b32`/`st.shared.b32`; extent: rank-one
+# byte offsets, never a multidimensional shared tensor.
+
+# UMMA shared descriptors are built as two 32-bit halves and packed with mov.b64.
+DESC_HI = 0x40004040            # SBO 1024 B, base-offset/version bit 46, 128 B swizzle
+def desc_lo(byte): return (smem_base_addr(byte) >> 4) & 0x3FFF
+QK_IDESC = 0x08200490           # bf16 x bf16 -> f32, M=128, N=128, K-major A and B
+PV_IDESC = 0x08210490           # same with MN-major B (V is [token, feature])
+# Q/K low-word walk over K=128 in eight K16 steps: +2,+2,+2 inside a 64-column
+# half, then +1018 (+16384 B) to the other half, then +2,+2,+2 (identical for A and B
+# because the Q tile and the K tile share the [dim_half][128 rows] shape).
+QK_STEPS = (2,2,2,1018,2,2,2)
+# V descriptor: low word |= 0x4000000 encodes LBO = 16384 B (dim-half stride);
+# +128 (2048 B = 16 tokens x 128 B) per K16 step.  P is read from TMEM at +8
+# columns per K16 (16 bf16 columns packed two per 32-bit column).
+PV_B_STEP = 128; PV_A_STEP = 8
+
+# TMEM: 512 columns, lane field in bits 31..16.
+S_COL=(0,128); P_COL=(64,192); O_COL=(256,384)          # per-instance column bases;
+# S spans 128 columns, P overwrites S_COL+64..+128, O spans 128 columns
+def tmem_addr(lane_origin, col): return taddr + col + (lane_origin << 16)
+# 32x32b fragments: a warp covers 32 lanes = 32 rows; thread `lane` owns row
+# lane_origin + lane and every column it loads.  Four x32 loads at col+0, +32,
+# +64, +96 give one thread the full 128-column S row; x16/x8 loads read 16/8
+# consecutive columns of the row.
+```
+
+## Exact prologue and pipeline state
+
+```python
+tid = thread_id(); warp = shuffle_index(tid // 32, lane=0); lane = tid % 32
+# instruction_selection: `shr.u32`, `shfl.sync.idx.b32 ..., 0, 0x1f, 0xffffffff`, `and.b32`; extent: one.
+smem_base = cvta_shared(arena)
+bid = cta_id_x(); num_bids = grid_dim_x()
+# instruction_selection: `mov.u32 %r, %ctaid.x` and `mov.u32 %r, %nctaid.x`; extent: one each.
+
+if warp == 0:
+    if elect():
+        # instruction_selection: `elect.sync _|p, 0xFFFFFFFF`; extent: warp 0.
+        for name in (q_full, q_empty, union_ready, kv_full x3, kv_empty x3, s_full x2,
+                     p_full x2, corr_sig x2, corr_done x2, o_full x2, tile_done):
+            init_mbarrier(bar(name, i), INIT_COUNT[name])
+        # instruction_selection: 20 x `mbarrier.init.shared::cta.b64`; extent: one lane.
+        fence("mbarrier_init_release_cluster")
+        # instruction_selection: `fence.mbarrier_init.release.cluster`; inside the leader branch.
+sync_warp()
+# instruction_selection: `bar.warp.sync -1` executed by every warp.
+if warp == 0:
+    tmem_alloc(OFF.tmem_mailbox, columns=512); tmem_relinquish()
+    # instruction_selection: `tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [mailbox], 512`
+    # then `tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned`; extent: warp 0.
+sync_cta()
+# instruction_selection: `bar.sync 0`; extent: all 512 threads.
+fence("tcgen05_after_thread_sync")
+# instruction_selection: `tcgen05.fence::after_thread_sync`; extent: all threads.
+taddr = copy_s2r(OFF.tmem_mailbox, volatile=True)
+# instruction_selection: `ld.volatile.shared.b32`; extent: all threads.
+
+# Phase state (every wait is parity-based); the scalars below live across tiles.
+# Consumer parities start at 0; the producer-side q_empty and kv_empty start at 1.
+PHASE = dict(union_ready=0, q_full=0, q_empty_producer=1, kv_empty_producer=1,
+             s_full=[0,0], p_full=[0,0], corr_sig=[0,0], corr_done=[0,0],
+             o_full=[0,0], tile_done=0)
+# The KV ring cursor (stage 0..2, parity) advances once per K or V push, 12 pushes
+# per tile = four full turns, so every tile starts at (stage 0, parity 0) in the MMA
+# warp and (stage 0, parity 1) in the load warp.  No ring state crosses tiles and
+# the export folds all 12 kv_full waits (MMA) and 12 kv_empty waits (load) to
+# immediate stage addresses (+24/+32/+40 resp. +48/+56/+64) and immediate parities:
+# MMA 0,0,0,1,1,1,0,0,0,1,1,1; load 1,1,1,0,0,0,1,1,1,0,0,0.  The only load-warp
+# parity register that lives across tiles is q_empty's.
+```
+
+## Source-order role programs
+
+The branch order below is source-exact: `dec(12..15) -> softmax(0..7) ->
+correction(8..11) -> mma(12) -> idle(13,14) -> load(15)`. Every role runs the
+rolled tile loop `for tile_idx in serial_range(bid, total_tiles, step=num_bids)`
+(`#pragma unroll 1`; entry guard `setp.ge.u32`, back edge `add.s32`+`setp.lt.u32`)
+and recomputes `q_tile = umod(tile_idx, mb)`, `q_head = udiv(tile_idx, mb)`,
+`kv_head = q_head`, `query_base = q_tile*128`, `q_valid = 128 if q_tile < mb else 0`,
+`kv_len = nb*128`. The softmax warps only materialise `q_tile` (`rem.u32`); the
+correction and load warps materialise `q_head` (`div.u32`) and derive `q_tile` as
+`tile_idx - q_head*mb` (`mul.lo.s32`, `sub.s32`); the MMA warp needs neither.
+
+```python
+if 12 <= warp <= 15:
+    setmaxnreg(decrease, REG_OTHER)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32 48`; extent: warps 12..15,
+    # emitted before any increase so the pool can grant the softmax request.
+
+# 1. Warps 0..7: two four-warp softmax instances.
+if warp <= 7:
+    setmaxnreg(increase, REG_SOFTMAX)
+    # instruction_selection: `setmaxnreg.inc.sync.aligned.u32 192`; extent: warps 0..7.
+    for tile_idx in serial_range(bid, total_tiles, step=num_bids):       # rolled
+        q_tile = umod(tile_idx, mb); q_valid = select(q_tile < mb, 128, 0)
+        # instruction_selection: `rem.u32`, `setp.lt.s32` + `selp.b32`; extent: scalars.
+        wait(bar(union_ready), PHASE.union_ready); PHASE.union_ready ^= 1
+        # instruction_selection: `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64` retry
+        # loop with suspend hint 0x989680, `xor.b32`; extent: all 256 softmax threads.
+        instance = shuffle_index(warp // 4, lane=0)
+        instance_tmem_offset = shuffle_index(instance*128, 0)
+        instance_row_offset = shuffle_index(instance*128, 0)
+        # instruction_selection: three `shfl.sync.idx.b32`; extent: warp-uniform broadcasts.
+        warp_in_instance = warp % 4; lane_origin = warp_in_instance*32
+        my_row = lane_origin + lane; row_addr = lane_origin << 16
+        row_valid = my_row < q_valid
+        # instruction_selection: `shl.b32`, `setp.lt.s32`; extent: scalars.
+        row_max = -inf; row_sum = 0.0
+        score_addr = tmem_addr(lane_origin, S_COL[instance])
+        p_addr = tmem_addr(lane_origin, P_COL[instance])
+
+        for pair in static_range(3):                                   # `#pragma unroll`
+            n_block = copy_s2r(union_block_byte(5 - instance - 2*pair))
+            # instruction_selection: `ld.shared.b32` at `union_blocks + 4*(5-2*pair) - 4*instance`;
+            # extent: one scalar per pair.
+            if instance == 0: wait(bar(s_full, 0), PHASE.s_full[0]); PHASE.s_full[0] ^= 1
+            else:             wait(bar(s_full, 1), PHASE.s_full[1]); PHASE.s_full[1] ^= 1
+            # instruction_selection: branch on `instance`, parity retry wait on one of two
+            # static barrier addresses, `xor.b32`; extent: 128 threads per instance.
+            valid_cols = clamp(kv_len - n_block*128, 0, 128) if row_valid else 0
+            s = reg_tile([128], "f32")
+            for quarter in static_range(4):
+                copy_t2r(score_addr + 32*quarter, s[32*quarter : 32*quarter+32], shape="32x32b.x32")
+            # instruction_selection: four `tcgen05.ld.sync.aligned.32x32b.x32.b32 {32}, [addr]`;
+            # extent: one 128-row x 128-column S tile, 128 f32 per thread.
+            if not (row_valid and n_block < nb):                         # valid_cols < 128
+                for j in static_range(128): s[j] = -inf
+            # instruction_selection: `setp.gt.s32 nb, n_block` + `and.pred` with row_valid,
+            # branch over one `mov.b32 0fFF800000` immediate plus 128 register `mov.b32`
+            # copies of it; the source's per-32-column mask
+            # arithmetic (706-775) is folded: valid_cols is provably 0 or 128, so every
+            # lane mask is 0 and the fill covers the whole fragment; never taken in-domain.
+            acc = (-inf, -inf)
+            for quarter in static_range(4):
+                for j in static_range(16):                       # two accumulators alternate
+                    acc[j % 2] = max(acc[j % 2], max(s[32*quarter+2*j], s[32*quarter+2*j+1]))
+            tile_max = max(acc[0], acc[1])
+            # instruction_selection: 128 + 1 `max.f32` (no ftz), SASS fuses pairs into
+            # `FMNMX3`; extent: one 128-value fragment, no cross-lane shuffle.
+            new_max = max(tile_max, row_max)
+            safe_max = select(new_max == -inf, 0.0, new_max)
+            new_max_scaled = mul(safe_max, softmax_scale_log2)
+            acc_scale_log2 = fma(row_max, softmax_scale_log2, -new_max_scaled)
+            # instruction_selection: `max.f32`, `setp.eq.ftz.f32`+`selp.f32`, `mul.ftz.f32`,
+            # `neg.ftz.f32` + `fma.rn.ftz.f32` (pair 0 folds row_max to the `0fFF800000`
+            # immediate); extent: scalars per thread.
+            if acc_scale_log2 >= -8.0:
+                selected_max = row_max; safe_max = select(row_max == -inf, 0.0, row_max)
+                acc_scale = 1.0
+                new_max_scaled = mul(safe_max, softmax_scale_log2)
+                # instruction_selection (pairs 1, 2): `setp.ltu.ftz.f32 .., 0fC1000000` + `@p bra`;
+                # this arm: `setp.eq.ftz.f32`+`selp.f32`, `mul.ftz.f32`, `mov.b32 acc_scale, 0f3F800000`.
+            else:
+                selected_max = new_max
+                acc_scale = select(row_max > -inf, exp2(acc_scale_log2), 1.0)
+                # instruction_selection (pairs 1, 2): `ex2.approx.ftz.f32`, `setp.ne.ftz.f32` +
+                # `selp.f32`, `mov.b32 row_max, new_max`.
+            # Pair 0 (row_max is the -inf immediate): no branch.  `setp.ltu.ftz.f32` then two
+            # `selp.f32`: new_max_scaled = p ? safe_max*scale : (softmax_scale_log2 * 0.0, one
+            # `mul.ftz.f32` hoisted out of the tile loop) and row_max = p ? new_max : -inf;
+            # acc_scale is the immediate 1.0 (`st.shared.b32 [..], 1065353216` below); the
+            # 793/795/798/799 instructions do not exist for pair 0.
+            row_max = selected_max
+            copy_r2s(acc_scale, scale_byte(0, instance, my_row))
+            # instruction_selection: `st.shared.b32`; extent: 128 rows per instance.
+            fence("proxy_async_shared_cta")
+            # instruction_selection: `fence.proxy.async.shared::cta`; extent: every softmax thread.
+            if instance == 0: arrive(bar(corr_sig, 0))
+            else:             arrive(bar(corr_sig, 1))
+            # instruction_selection: `mbarrier.arrive.release.cta.shared::cta.b64` on one of two
+            # static addresses; extent: 128 arrivals per instance (barrier count 128).
+            for j in static_range(64):
+                s[2*j:2*j+2] = fma(s[2*j:2*j+2], (softmax_scale_log2,)*2, (-new_max_scaled,)*2, lanes=2)
+            # instruction_selection: `neg.ftz.f32` + `mov.b64` packs, 64 `fma.rn.ftz.f32x2`;
+            # extent: 128 values.
+            packed_p = reg_tile([64], "b32")
+            for quarter in static_range(4):
+                for j in static_range(32): s[32*quarter+j] = exp2(s[32*quarter+j])
+                for j in static_range(16):
+                    packed_p[16*quarter+j] = cast(pack(s[32*quarter+2*j], s[32*quarter+2*j+1]), "bf16x2")
+                copy_r2t(packed_p[16*quarter : 16*quarter+16], p_addr + 16*quarter, shape="32x32b.x16")
+            # instruction_selection: per quarter 32 `ex2.approx.ftz.f32`, 16 `cvt.rn.bf16x2.f32`,
+            # one `tcgen05.st.sync.aligned.32x32b.x16.b32 [addr], {16}`; extent: P columns
+            # P_COL..P_COL+64 of this instance, written in place over the upper S half.
+            tmem_wait_st()
+            # instruction_selection: `tcgen05.wait::st.sync.aligned`.
+            if instance == 0:
+                arrive(bar(p_full, 0)); wait(bar(corr_done, 0), PHASE.corr_done[0]); PHASE.corr_done[0] ^= 1
+            else:
+                arrive(bar(p_full, 1)); wait(bar(corr_done, 1), PHASE.corr_done[1]); PHASE.corr_done[1] ^= 1
+            # instruction_selection: `mbarrier.arrive.release.cta.shared::cta.b64` (128 of the 256
+            # expected arrivals; the other 128 come from the correction warps), parity retry
+            # wait, `xor.b32`; extent: 128 threads per instance.
+            acc2 = (0.0, 0.0)
+            for j in static_range(64): acc2 = add(acc2, s[2*j:2*j+2], lanes=2)
+            block_sum = add(acc2[0], acc2[1])
+            # instruction_selection: 64 `add.f32x2` (no ftz) into one accumulator, `add.ftz.f32`;
+            # extent: one row sum, computed after the corr_done wait as in the source.
+            row_sum = fma(row_sum, acc_scale, block_sum)
+            # instruction_selection: `fma.rn.ftz.f32` (pairs 1, 2); pair 0 folds `0*acc_scale +
+            # block_sum` to `add.ftz.f32 block_sum, 0f00000000`.
+
+        copy_r2s(row_sum, scale_byte(1, instance, my_row))
+        copy_r2s(row_max, scale_byte(2, instance, my_row))
+        # instruction_selection: two `st.shared.b32`; extent: 128 rows per instance.
+        fence("proxy_async_shared_cta")
+        if instance == 0: arrive(bar(corr_sig, 0))
+        else:             arrive(bar(corr_sig, 1))
+        # instruction_selection: `fence.proxy.async.shared::cta` then
+        # `mbarrier.arrive.release.cta.shared::cta.b64`; the final corr_sig generation of the tile.
+
+# 2. Warps 8..11: correction and epilogue.
+if 8 <= warp <= 11:
+    setmaxnreg(decrease, REG_CORRECTION)
+    # instruction_selection: `setmaxnreg.dec.sync.aligned.u32 80`; extent: warps 8..11.
+    for tile_idx in serial_range(bid, total_tiles, step=num_bids):       # rolled
+        q_head = udiv(tile_idx, mb); q_tile = tile_idx - q_head*mb
+        query_base = q_tile*128; q_valid = select(q_tile < mb, 128, 0)
+        # instruction_selection: `div.u32`, `mul.lo.s32`, `sub.s32`, `shl.b32`, `setp.lt.s32`+`selp.b32`.
+        wait(bar(union_ready), PHASE.union_ready); PHASE.union_ready ^= 1
+        # instruction_selection: parity retry wait, `xor.b32`; extent: 128 threads.
+        warp_in_role = warp - 8; lane_origin = warp_in_role*32
+        my_row = lane_origin + lane; row_addr = lane_origin << 16
+        arrive(bar(p_full, 0)); arrive(bar(p_full, 1))
+        # instruction_selection: two `mbarrier.arrive.release.cta.shared::cta.b64`; the
+        # correction half of the first p_full generation needs no O rescale.
+        wait(bar(corr_sig, 0), PHASE.corr_sig[0]); PHASE.corr_sig[0] ^= 1; arrive(bar(corr_done, 0))
+        wait(bar(corr_sig, 1), PHASE.corr_sig[1]); PHASE.corr_sig[1] ^= 1; arrive(bar(corr_done, 1))
+        # instruction_selection: parity wait then ordinary arrive, per instance; pair 0
+        # never rescales.
+        for pair in static_range(1, 3):                                # `#pragma unroll`
+            for instance in static_range(2):
+                wait(bar(corr_sig, instance), PHASE.corr_sig[instance]); PHASE.corr_sig[instance] ^= 1
+                # instruction_selection: parity retry wait; extent: 128 threads.
+                acc_scale = copy_s2r(scale_byte(0, instance, my_row))
+                # instruction_selection: `ld.shared.b32`; extent: one row scale.
+                if any(acc_scale < 1.0):
+                    # instruction_selection: `setp.lt.ftz.f32` + `vote.sync.any.pred`; one warp vote.
+                    for chunk in static_range(8):
+                        o = reg_tile([16], "f32")
+                        copy_t2r(tmem_addr(lane_origin, O_COL[instance]) + 16*chunk, o, shape="32x32b.x16")
+                        for j in static_range(8): o[2*j:2*j+2] = mul(o[2*j:2*j+2], (acc_scale,)*2, lanes=2)
+                        copy_r2t(o, tmem_addr(lane_origin, O_COL[instance]) + 16*chunk, shape="32x32b.x16")
+                    # instruction_selection: per chunk one `tcgen05.ld.sync.aligned.32x32b.x16.b32`,
+                    # eight `mul.rn.ftz.f32x2`, one `tcgen05.st.sync.aligned.32x32b.x16.b32`;
+                    # extent: 8 chunks = 128 O columns of one instance.
+                    tmem_wait_st()
+                    # instruction_selection: `tcgen05.wait::st.sync.aligned`.
+                arrive(bar(p_full, instance)); arrive(bar(corr_done, instance))
+                # instruction_selection: two `mbarrier.arrive.release.cta.shared::cta.b64`.
+        wait(bar(o_full, 0), PHASE.o_full[0]); PHASE.o_full[0] ^= 1
+        wait(bar(o_full, 1), PHASE.o_full[1]); PHASE.o_full[1] ^= 1
+        wait(bar(corr_sig, 0), PHASE.corr_sig[0]); PHASE.corr_sig[0] ^= 1
+        wait(bar(corr_sig, 1), PHASE.corr_sig[1]); PHASE.corr_sig[1] ^= 1
+        # instruction_selection: four parity retry waits; extent: both O accumulators and
+        # both final statistics generations.
+        fence("tcgen05_after_thread_sync")
+        # instruction_selection: `tcgen05.fence::after_thread_sync`.
+        final_sum0 = copy_s2r(scale_byte(1, 0, my_row)); final_sum1 = copy_s2r(scale_byte(1, 1, my_row))
+        final_max0 = copy_s2r(scale_byte(2, 0, my_row)); final_max1 = copy_s2r(scale_byte(2, 1, my_row))
+        # instruction_selection: four `ld.shared.b32`.
+        valid0 = final_sum0 > 0.0; valid1 = final_sum1 > 0.0
+        max0 = select(valid0, final_max0, -inf); max1 = select(valid1, final_max1, -inf)
+        # instruction_selection: two `setp.gt.ftz.f32` (the `sum == sum` NaN test is folded),
+        # two `selp.f32`.
+        final_max = max(max0, max1); safe_max = select(final_max == -inf, 0.0, final_max)
+        # instruction_selection: `max.f32`, `setp.eq.ftz.f32` + `selp.f32`.
+        combine_scale0 = select(valid0, exp2(mul(sub(max0, safe_max), softmax_scale_log2)), 0.0)
+        combine_scale1 = select(valid1, exp2(mul(sub(max1, safe_max), softmax_scale_log2)), 0.0)
+        # instruction_selection: per instance `sub.ftz.f32`, `mul.ftz.f32`, `ex2.approx.ftz.f32`,
+        # `selp.f32`; extent: scalars.
+        final_sum = fma(final_sum0, combine_scale0, mul(final_sum1, combine_scale1))
+        # instruction_selection: `mul.ftz.f32` (sum1*cs1) then `fma.rn.ftz.f32` fusing sum0*cs0.
+        inv_sum = select(final_sum > 0.0, rcp(final_sum), 0.0)
+        # instruction_selection: `rcp.approx.ftz.f32`, `setp.gt.ftz.f32`, `selp.f32`.
+        output_scale0 = mul(combine_scale0, inv_sum); output_scale1 = mul(combine_scale1, inv_sum)
+        # instruction_selection: two `mul.ftz.f32`, then `mov.b64` packs of each scale pair.
+        query = query_base + my_row; output_row = (query*num_q_heads + q_head)*128
+        # instruction_selection: `add.s32`, `mad.lo.s32`, `shl.b32 7`.
+        if my_row < q_valid:
+            # instruction_selection: `setp.ge.s32` branch over the whole store block.
+            for chunk in static_range(16):
+                o0 = reg_tile([8], "f32"); o1 = reg_tile([8], "f32")
+                copy_t2r(tmem_addr(lane_origin, O_COL[0]) + 8*chunk, o0, shape="32x32b.x8")
+                copy_t2r(tmem_addr(lane_origin, O_COL[1]) + 8*chunk, o1, shape="32x32b.x8")
+                # instruction_selection: two `tcgen05.ld.sync.aligned.32x32b.x8.b32`.
+                for j in static_range(4): o0[2*j:2*j+2] = mul(o0[2*j:2*j+2], (output_scale0,)*2, lanes=2)
+                for j in static_range(4): o1[2*j:2*j+2] = mul(o1[2*j:2*j+2], (output_scale1,)*2, lanes=2)
+                for j in static_range(8): o0[j] = add(o0[j], o1[j])
+                for j in static_range(4): o0[2*j:2*j+2] = mul(o0[2*j:2*j+2], (1.0,)*2, lanes=2)
+                # instruction_selection: 4 + 4 `mul.rn.ftz.f32x2`, 8 scalar `add.ftz.f32`, then
+                # 4 `mul.rn.ftz.f32x2` by the packed 1.0 (kept: the ftz multiply flushes
+                # denormals and is inline asm in the source); extent: 8 columns.
+                words = [cast(pack(o0[2*j], o0[2*j+1]), "bf16x2") for j in static_range(4)]
+                copy_r2g(words, out[output_row + 8*chunk : +8])
+                # instruction_selection: four `cvt.rn.bf16x2.f32`, one `st.global.v4.b32` at
+                # `[base + 16*chunk]` (one `mul.wide.s32` + `add.s64` base per row);
+                # extent: 16 stores per thread = one 128-column output row.
+            stat_idx = query*num_q_heads + q_head
+            final_lse = select(final_sum > 0.0,
+                               fma(mul(final_max, softmax_scale_log2), LN2, mul(log2(final_sum), LN2)),
+                               -inf)
+            # instruction_selection: `lg2.approx.ftz.f32` (asm volatile: emitted regardless of
+            # the flags), `mul.ftz.f32` x2, `fma.rn.ftz.f32` with the ln2 immediate,
+            # `setp.gt.ftz.f32`, `selp.f32`; extent: one scalar per live row.
+            if return_softmax_lse != 0:     copy_r2g(final_lse, lse[stat_idx])
+            if return_temperature_lse != 0: copy_r2g(final_lse, temperature_lse[stat_idx])
+            # instruction_selection: two `setp.eq.b32`-guarded `st.global.b32` (each with
+            # `mul.wide.s32` + `add.s64`); the same value goes to both tensors.
+        tmem_wait_ld()
+        fence("tcgen05_before_thread_sync")
+        arrive(bar(q_empty)); arrive(bar(tile_done))
+        # instruction_selection: `tcgen05.wait::ld.sync.aligned`, `tcgen05.fence::before_thread_sync`,
+        # two `mbarrier.arrive.release.cta.shared::cta.b64`; extent: 128 arrivals each.
+
+# 3. Warp 12: MMA issuer and TMEM owner.
+if warp == 12:
+    for tile_idx in serial_range(bid, total_tiles, step=num_bids):       # rolled
+        wait(bar(union_ready), PHASE.union_ready); PHASE.union_ready ^= 1
+        # instruction_selection: parity retry wait, `xor.b32`; extent: warp 12.
+        kv = ring(stages=3, stage=0, parity=0)                           # per tile; every stage/parity below is a trace-time constant
+        wait(bar(q_full), PHASE.q_full); PHASE.q_full ^= 1
+        # instruction_selection: parity retry wait, `xor.b32`; extent: one Q generation.
+        first_pv = [True, True]
+
+        def qk_chain(instance, k_stage):                                 # S_instance = Q K^T
+            a_lo = shuffle_index(desc_lo(q_byte(0)), 0)
+            b_lo = shuffle_index(desc_lo(kv_byte(k_stage, 0, 0)), 0)
+            # instruction_selection: two `shfl.sync.idx.b32` uniform broadcasts.
+            leader = elect()
+            for k16 in static_range(8):
+                gemm(tmem_addr(0, S_COL[instance]), desc64(a_lo, DESC_HI), desc64(b_lo, DESC_HI),
+                     QK_IDESC, accumulate=(k16 != 0), predicate=leader)
+                a_lo += QK_STEPS[k16]; b_lo += QK_STEPS[k16]
+            # instruction_selection: one `elect.sync`, `setp.ne.b32` x2, `mov.b32` immediates
+            # (0x40004040, 136316048), eight `mov.b64 {lo,hi}` pairs and eight
+            # `@leader tcgen05.mma.cta_group::1.kind::f16 [d], da, db, id, p` with `add.u32`
+            # low-word steps; extent: K=128 in eight K16 issues, M=128 x N=128.
+            tmem_commit(bar(s_full, instance), elect=True)
+            tmem_commit(bar(kv_empty, k_stage), elect=True)
+            # instruction_selection: two elected
+            # `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`.
+
+        def pv_chain(instance, v_stage, last_pair):                      # O_instance += P_instance V
+            wait(bar(p_full, instance), PHASE.p_full[instance]); PHASE.p_full[instance] ^= 1
+            # instruction_selection: parity retry wait, `xor.b32`; extent: one P generation.
+            b_lo = shuffle_index(desc_lo(kv_byte(v_stage, 0, 0)) | 0x4000000, 0)
+            # instruction_selection: `shfl.sync.idx.b32`; LBO bit set for the MN-major V.
+            ta = tmem_addr(0, P_COL[instance]); leader = elect()
+            for k16 in static_range(8):
+                gemm(tmem_addr(0, O_COL[instance]), tmem_operand(ta), desc64(b_lo, DESC_HI),
+                     PV_IDESC, accumulate=(k16 != 0 or not first_pv[instance]), predicate=leader)
+                ta += PV_A_STEP; b_lo += PV_B_STEP
+            # instruction_selection: one `elect.sync`, `setp.ne.b32` x2 (p0 from first_pv),
+            # `mov.b32` immediates (0x40004040, 136381584), eight `@leader tcgen05.mma.cta_group::1.kind::f16
+            # [d], [ta], db, id, p` with `add.u32 ta, ta, 8` and `add.u32 blo, blo, 128`;
+            # the first issue of the instance's first block in the tile passes enable_input_d = 0.
+            first_pv[instance] = False
+            if last_pair:
+                tmem_commit(bar(o_full, instance), elect=True)
+                # instruction_selection: elected `tcgen05.commit...mbarrier::arrive::one`; pair 2 only.
+            tmem_commit(bar(kv_empty, v_stage), elect=True)
+            # instruction_selection: elected `tcgen05.commit...mbarrier::arrive::one`; V release.
+
+        for instance in static_range(2):                                 # S5, S4
+            k_stage, k_parity = kv.stage, kv.parity; kv.advance()
+            wait(bar(kv_full, k_stage), k_parity)
+            # instruction_selection: parity retry wait with immediate stage address and
+            # immediate parity (sites 1-2 of the 12: +24/0, +32/0); extent: one K stage.
+            qk_chain(instance, k_stage)
+        for pair in static_range(3):
+            for instance in static_range(2):
+                v_stage, v_parity = kv.stage, kv.parity; kv.advance()
+                wait(bar(kv_full, v_stage), v_parity)
+                # instruction_selection: parity retry wait with immediate stage/parity (the 12
+                # MMA kv_full waits in push order carry parities 0,0,0,1,1,1,0,0,0,1,1,1);
+                # extent: one V stage.
+                pv_chain(instance, v_stage, last_pair=(pair == 2))
+                if pair < 2:                                             # prefetch S for slot 5-instance-2*(pair+1)
+                    k_stage, k_parity = kv.stage, kv.parity; kv.advance()
+                    wait(bar(kv_full, k_stage), k_parity)
+                    # instruction_selection: parity retry wait with immediate stage/parity; extent: one K stage.
+                    qk_chain(instance, k_stage)
+        wait(bar(tile_done), PHASE.tile_done); PHASE.tile_done ^= 1
+        # instruction_selection: parity retry wait, `xor.b32`; the epilogue has released TMEM.
+    taddr_again = copy_s2r(OFF.tmem_mailbox, volatile=True)
+    tmem_dealloc(taddr_again, columns=512)
+    # instruction_selection: `ld.volatile.shared.b32`,
+    # `tcgen05.dealloc.cta_group::1.sync.aligned.b32 addr, 512`; extent: warp 12, after the loop.
+
+# 4. Warps 13, 14: idle after the register decrease.
+if 13 <= warp <= 14:
+    pass
+
+# 5. Warp 15: Q load, BSR index publish, K/V ring producer.
+if warp == 15:
+    for tile_idx in serial_range(bid, total_tiles, step=num_bids):       # rolled
+        wait(bar(q_empty), PHASE.q_empty_producer); PHASE.q_empty_producer ^= 1
+        # instruction_selection: parity retry wait (parity register starts at 1, `xor.b32` per
+        # tile; the only load-warp parity that lives across tiles); the previous tile's
+        # epilogue has finished with Q and union_blocks.
+        q_head = udiv(tile_idx, mb); q_tile = tile_idx - q_head*mb; query_base = q_tile*128
+        kv_head = q_head
+        # instruction_selection: `div.u32`, `mul.lo.s32`, `sub.s32`, `shl.b32`.
+        if elect():
+            arrive_expect_tx(bar(q_full), 32768)
+            copy_g2s_tma(Qmap, (0, query_base, q_head, 0), q_byte(0), bar(q_full))
+            # instruction_selection: `elect.sync`, `mbarrier.arrive.expect_tx.release.cta.shared::cta.b64`,
+            # one `cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes`;
+            # extent: 32768 bytes (both dim halves of 128 rows in one issue).
+        q_block = query_base // 128
+        if lane < 6:
+            copy_r2s(copy_g2r(bsr_indices[q_block*6 + lane]), union_block_byte(lane))
+            # instruction_selection: `setp.gt.u32 lane, 5` + `@p bra` (skip when lane > 5),
+            # `mad.lo.s32`, `mul.wide.s32`, `add.s64`, `ld.global.nc.b32`, `st.shared.b32`;
+            # extent: six lanes.
+        named_barrier(8, threads=32)
+        fence("proxy_async_shared_cta")
+        arrive(bar(union_ready))
+        # instruction_selection: `barrier.sync 8, 32`, `fence.proxy.async.shared::cta`,
+        # `mbarrier.arrive.release.cta.shared::cta.b64` by all 32 lanes (count 32).
+        load = ring(stages=3, stage=0, parity=1)                        # per tile; 12 pushes return it to (0, 1)
+
+        def push(map, slot):
+            n_block = copy_s2r(union_block_byte(slot)); token0 = n_block*128; token1 = token0 + 64
+            # instruction_selection: `ld.shared.b32`, `shl.b32`; extent: one scalar.
+            stage, parity = load.stage, load.parity
+            wait(bar(kv_empty, stage), parity)
+            # instruction_selection: parity retry wait by all 32 lanes with immediate stage
+            # address (+48/+56/+64) and immediate parity (push order 1,1,1,0,0,0,1,1,1,0,0,0).
+            if elect():
+                arrive_expect_tx(bar(kv_full, stage), 32768)
+                copy_g2s_tma(map, (0, token0, 0, kv_head), kv_byte(stage, 0, 0), bar(kv_full, stage))
+                copy_g2s_tma(map, (0, token1, 0, kv_head), kv_byte(stage, 1, 0), bar(kv_full, stage))
+                copy_g2s_tma(map, (0, token0, 1, kv_head), kv_byte(stage, 0, 1), bar(kv_full, stage))
+                copy_g2s_tma(map, (0, token1, 1, kv_head), kv_byte(stage, 1, 1), bar(kv_full, stage))
+                # instruction_selection: `elect.sync`, `mbarrier.arrive.expect_tx...` 32768,
+                # four `cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes`
+                # of 8192 bytes; extent: one 128-token K or V tile per push, 12 static sites.
+            load.advance()
+
+        for instance in static_range(2): push(Kmap, 5 - instance)      # K5, K4
+        for pair in static_range(3):
+            for instance in static_range(2):
+                slot = 5 - instance - 2*pair
+                push(Vmap, slot)                                         # V for the block being consumed
+                if slot - 2 >= 0: push(Kmap, slot - 2)                   # K prefetch for the next pair
+```
+
+## Bidirectional source / sketch / PTX map
+
+| semantic edge | source lines | sketch section | exported `.loc` / opcode evidence |
+| --- | --- | --- | --- |
+| helpers: elect, mbarrier init/wait/arrive/expect_tx, commit, TMA, warp-uniform, TMEM ld/st, approx math, f32x2 | 44-61, 92-105, 193-216, 219-274, 277-295, 314-327, 362-392, 395-407, 495-529 | primitive vocabulary | `.loc 53` (14 elect), `60` (20 init), `104` (58 waits), `201` (20 commits), `208` (29 arrives), `215` (13 expect_tx), `234/247/260/273/520` (12/32/12/32/32 TMEM ops), `279` (388 ex2), `286` (rcp), `293` (391 max), `390` (192 add.f32x2), `400` (192 fma.f32x2), `406` (448 mul.f32x2), `502` (49 TMA), `527` (22 shfl.idx), `122` (4 votes) |
+| dead helpers (try_wait/cluster/token waits, `tcgen05_mma_f16`, `desc_encode`, `mma_ss/ts_step`, `warp_reduce_*`, `ex2_emulation_f32x2`, unused f32x2 wrappers, `fma_scale_x32`, `fence_async_shared`, `make_smem_desc`, `tcgen05_commit`) | 64-90, 107-132, 135-190, 298-311, 330-360, 409-476, 481-492, 506-511 | omitted | no `.loc` |
+| ABI, smem carve-up, blockIdx/gridDim | 533-559 | fixed storage / prologue | `.loc 536-538` (`shr`, `shfl.idx`, `and`), `544-545` (`%ctaid.x`, `%nctaid.x`) |
+| mbarrier init, warp sync, TMEM alloc, CTA sync, TMEM base | 561-634 | exact prologue | `.loc 564-601` (20 inits + `fence.mbarrier_init`), `603` `bar.warp.sync`, `609-610` alloc/relinquish, `613` `bar.sync 0`, `614` fence, `628` `ld.volatile.shared` |
+| register redistribution | 638-644, 857-858 | role entries | `.loc 639` dec 48, `644` inc 192, `858` dec 80 |
+| softmax tile loop, tile split, union_ready, uniform broadcasts, rows | 652-676 | role 1 head | `.loc 652` (`setp.ge.u32`/`add.s32`/`setp.lt.u32`), `654` `rem.u32`, `659` `selp`, `667-668` wait+`xor`, `669-672` `shfl.idx` x3, `675-676` `shl`/`setp.lt` |
+| softmax per pair: slot read, s_full wait, S load, folded mask fill, max tree, rescale decision, acc_scale publish | 680-808 | role 1 pair body | `.loc 682` `ld.shared`, `683-689` waits, `702-705` 4 x `32x32b.x32`, `706` `setp.gt.s32`+`and.pred`+128 `mov -inf`, `776-782` (via `.loc 293`), `785-787` `selp`/`mul.ftz`/`neg`+`fma.rn.ftz`, `791` `setp.ltu` (pairs 1-2: `@p bra` + arms at `793/795/798/799`; pair 0: two `selp.f32` under `.loc 0`, hoisted `mul.ftz.f32 scale, 0f00000000`, `st.shared.b32 .., 1065353216`), `802-808` `st.shared`, fence, arrives; no `.loc` for 707-775 |
+| softmax probabilities: fma, exp2, cvt, P store, wait, p_full/corr_done, block sum, running sum | 809-843 | role 1 pair tail | `.loc 810` `neg`+`mov.b64`, `400` (64 fma x2 per pair), `279`/`373-377`/`260` (per quarter 32 ex2, 16 cvt, one x16 store), `827` `wait::st`, `828-836` arrive/wait, `390`/`842` (64 add.f32x2 + `add.ftz`), `843` `fma.rn.ftz` (pairs 1-2) / `add.ftz 0.0` (pair 0) |
+| softmax final stats | 845-852 | role 1 tile tail | `.loc 845-849` two `st.shared`, fence, arrive |
+| correction tile head, handshake, rescale pairs | 866-937 | role 2 loop | `.loc 866/868/871/873` (loop, `div.u32`, `shl`, `selp`), `881-894` waits/arrives, `896-936` (`.loc 899/919` `ld.shared`, `900/920` `setp.lt.ftz`, `122` votes, `247/406/273` x16 ld / mul / x16 st, `913/933` `wait::st`) |
+| epilogue: waits, merge statistics, normalize, store, LSE, release | 938-1022 | role 2 epilogue | `.loc 938-946` waits + fence, `947-966` (`ld.shared` x4, `setp.gt.ftz` x2, `selp`, `max`, `sub.ftz`/`mul.ftz` x2, ex2 x2, `mul.ftz`+`fma.rn.ftz`, `rcp`, `selp`, `mul.ftz` x2), `967-969` row math + branch, `520` (32 x8 loads), `406` (192 mul.f32x2), `988` (128 `add.ftz`), `1001-1005` (64 cvt, 16 `st.global.v4.b32`), `1010-1016` lg2 + LSE + 2 predicated `st.global.b32`, `1019-1022` `wait::ld`, fence, arrives |
+| MMA warp: tile loop, waits, S chains, PV chains, tile_done, dealloc | 1035-1418 | role 3 | `.loc 1035-1041` loop/waits, `1050/1178/1292` 12 kv_full waits with immediate stage/parity (0,0,0,1,1,1,0,0,0,1,1,1), `1052-1053/1110-1111` `shfl.idx`, asm chains closing at `1107/1165/1227/1280/1349/1407` (96 `tcgen05.mma`), `201` commits, `1180/1233` p_full waits, `1414-1418` `tile_done` wait, `ld.volatile.shared`, `tcgen05.dealloc` |
+| idle warps | 1422-1424 | role 4 | none |
+| load warp: q_empty, tile split, Q TMA, BSR publish, ring | 1431-1516 | role 5 | `.loc 1431-1435` loop/wait (parity register init 1 + `xor.b32`)/`div.u32`, `1448-1450` elect/expect_tx/TMA, `1453` `setp.gt.u32 lane, 5`, `1454-1455` `ld.global.nc.b32`/`st.shared`, `1457-1459` `barrier.sync`/fence/arrive, `1464-1516` (`ld.shared` x12, `shl`, 12 kv_empty waits with immediate stage/parity 1,1,1,0,0,0,1,1,1,0,0,0, `502` 48 TMA) |
+
+Reading in reverse, every TMA, TMEM load/store, MMA, commit, mbarrier, named
+barrier, warp vote, shuffle, transcendental, packed f32x2, conversion, vector
+global store, special-register read, unsigned division and register-budget
+instruction in the export maps to a concrete occurrence above. Address arithmetic
+maps to the integer functions of "Fixed storage and integer maps", never to a
+layout.
+
+## TIRx, correctness and performance contract
+
+The public module exports `KERNEL_META`, `CONFIGS`, `BENCH_CONFIGS`,
+`get_kernel`, `prepare_data`, `run_test`, `prepare_bench`, `run_gpu`, and
+`run_bench`. Device code imports only `tirx_kernels.kern as K`; low-level
+instruction families use `K.ptx[...]` / `K.ptx.*`, the grid stride reads
+`%nctaid.x` through `K.cuda.mov_sreg`, and the grid extent is
+`K.min(total_tiles, sm_count)` with the SM count read once at kernel build. There
+is no inline CUDA function call, tile primitive, first-class layout or
+multidimensional SMEM allocation. The kernel is compiled once, shape-generic,
+through nvcc 13.2 (`compile_kernel(..., cuda_compile_mode="nvcc")`) so TIRx and
+the upstream `nvcc -cubin` build share PTX ISA 9.2.
+
+The frozen correctness matrix has 6 rows inside the dispatch domain (8 heads,
+`mb >= 625`, six distinct shared blocks per row): an uneven persistent tail
+without LSE, the six-block dense case with LSE, 1024 KV blocks with unsorted
+caller-order columns, a banded K-amplified case that forces the O rescale and
+unequal combine scales, a diagonal window over 54 waves, and first/last-block
+edges with both LSE stores. TIRx and the pinned upstream kernel share immutable
+inputs and independent outputs; `out`, `lse` and `temperature_lse` must be
+bitwise identical between them, a second TIRx launch must reproduce the first
+bit for bit, no-LSE sentinels stay untouched, NaN is forbidden, the public
+`plan_cake_vsa`/`run_cake_vsa` route must dispatch here and agree bitwise on
+`out`, and both implementations are checked against one FP64 block-gather
+oracle with tolerances frozen from measurement.
+
+Performance truth is exclusively `python -m tirx_kernels.bench_suite` over the
+frozen 6-row benchmark matrix with the pinned FlashInfer reference. Each row
+must have five finite positive Proton samples for both implementations and
+strict `mean(flashinfer)/mean(tirx) > 0.99`.

--- a/.agents/sketch/flashinfer/gemm/dense_blockscaled_gemm_sm107.md
+++ b/.agents/sketch/flashinfer/gemm/dense_blockscaled_gemm_sm107.md
@@ -1,0 +1,616 @@
+<!--
+This file is a design sketch for a TIRx port of FlashInfer
+(https://github.com/flashinfer-ai/flashinfer @ 012cfdb97f217e0d48bc9352c17a74068c9e495b),
+Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+SPDX-FileCopyrightText: Copyright TIRx authors
+-->
+
+# FlashInfer SM107 dense block-scaled FP4 GEMM kernel sketch
+
+This non-executable, operation-level sketch freezes the intended transcription
+of `flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py`, the alpha-scaled
+TMA epilogue in `epilogue_utils.py`, the production `mm_fp4` runner in
+`gemm_base.py`, and its SM107 tactic selector in `kernels/utils.py`. The pinned
+FlashInfer commit is `012cfdb97f217e0d48bc9352c17a74068c9e495b`; the primary
+source SHA-256 is
+`c9def937d2bf76b363bb321aa4053ffd39055febdcef3c890572bd2c4f2946ad`.
+The inherited CUTLASS example is pinned to commit
+`cdcf8d86daa9b417840fd99875a1b1af685d389d`, file SHA-256
+`1517d4cde6b7988d5f44eca5fc2de4516b6f582ae60c37a5d1455a09c647453b`.
+
+The writer exported and executed three independent line-info PTX anchors under
+`.porting/dense_blockscaled_gemm_sm107/writer_export/` with both source caches
+disabled. They cover B keep/reuse, CTA-group 2, NVFP4/MXFP4, FP16/BF16,
+row/column output, N=192, explicit-zero and automatic prefetch:
+
+| anchor | specialization | PTX SHA-256 |
+| --- | --- | --- |
+| `breuse_nvfp4_lineinfo` | tile 256x128, instruction 128x128, cluster 2x1, NVFP4, FP16, no swap, prefetch 0 | `88aa75ff4db0908589bd1fd54cfc3fad63cf17cdacb33e6f3ac3c803c3ab00f7` |
+| `twocta_mxfp4_swap_lineinfo` | tile/instruction 256x128, cluster 2x1, MXFP4, BF16, swap, prefetch 2 | `78e563e3d4fc381c0f19d32a2178bca959b9e9756bcf9dfd0324c5aa825d61cc` |
+| `n192_auto_prefetch_lineinfo` | tile/instruction 128x192, cluster 1x2, NVFP4, FP16, no swap, automatic prefetch | `d3d40f43a93970309c9d18c7d6c752d66a437a3fcf5f30db2cb94fb47cc2776e` |
+
+Every artifact declares PTX 9.4, `.target sm_107a`, `.reqntid 192,1,1`,
+1024-byte-aligned dynamic shared memory, and maps its line records directly to
+the pinned source, CUTLASS parent, and `epilogue_utils.py`.
+
+After the independent sketch reviewer returns PASS, this file is immutable.
+
+## Transcription boundary and invariants
+
+The executable module is one parameterized K-language port and imports the
+device language only as `import tirx_kernels.kern as K`. It may use raw
+`K.ptx[...]`, scalar K control flow, opaque TensorMaps, rank-one shared
+allocations, local register arrays, and ordinary integer helpers. It must not
+use a tile primitive, a first-class mapping/layout object, `K.cuda.func_call`,
+an inline-CUDA function-call exemption, or any change under
+`tirx_kernels/kern/`.
+
+The production boundary is the SM107 branch reachable from `mm_fp4`: both
+operands are packed E2M1 FP4; scales are E4M3 with vector size 16 (NVFP4) or
+E8M0 with vector size 32 (MXFP4); output is FP16 or BF16; batch is one. It
+includes swap, CTA-group 1/2, B keep/reuse, N tiles 64/128/192/256, legal
+1/2/4-by-1/2/4 clusters, and prefetch distances 0, 2, and automatic. The
+separate mixed-cluster class and direct-only FP8/mixed-input modes are out of
+scope.
+
+For public matrices A `(M,K/2)` and B `(K/2,N)`, packed nibbles decode to
+E2M1 values. With source-layout scale storage `SFA` and `SFB`, the operation is
+
+```text
+C[m,n] = cast_output(
+    float32(cast_output(alpha_f32)) * sum_k(
+        decode_fp4(A[m,k]) * decode_scale(SFA[m,k//V]) *
+        decode_fp4(B[k,n]) * decode_scale(SFB[n,k//V])
+    )
+)
+```
+
+where `V` is 16 or 32. Accumulation and alpha multiplication are FP32, but the
+source first rounds the loaded FP32 alpha to the selected FP16/BF16 output
+dtype and widens that scalar back to FP32. The widened rounded alpha is applied
+before the final output conversion. A/B and their scales exchange roles under
+`swap_ab`; the output descriptor becomes column-major so public storage remains
+row-major. TensorMap OOB fill supplies zero for partial M/N tiles. K remains
+16-byte aligned as required by the public runner and every live production
+shape has K divisible by 32.
+
+All source mappings lower before tracing to scalar extents, strides, byte
+offsets, XOR swizzle arithmetic, TensorMap fields, and integer UMMA descriptor
+bits. Every shared object is a byte interval in one rank-one arena. Every TMEM
+reference is a scalar row/column address.
+
+## Static specialization
+
+```python
+P = specialize_static(M, N, K, sf_mode, output_dtype, tactic)
+TILE_M, TILE_N = P.mma_tiler_mn
+INST_M, INST_N = P.mma_instruction_mn
+assert TILE_M in (128, 256) and TILE_N in (64, 128, 192, 256)
+assert INST_M in (128, 256) and INST_N == TILE_N
+assert TILE_M == INST_M or TILE_M == 2*INST_M
+
+CTA_GROUP = INST_M // 128                 # one or two
+B_REUSE = TILE_M == 2*INST_M             # group-one only in production
+CTA_M = TILE_M // CTA_GROUP               # 128 normally; 256 for B-reuse
+CTA_N = TILE_N
+K_TILE = 256
+INSTRUCTION_K = 128
+K_BLOCKS = 2
+SF_VECTOR = 16 if sf_mode == "nvfp4" else 32
+SF_DTYPE = E4M3 if sf_mode == "nvfp4" else E8M0
+ACC_STAGES = 1 if B_REUSE and TILE_N in (192, 256) else 2
+EPI_WARPS = (0, 1, 2, 3)
+MMA_WARP = 4
+TMA_WARP = 5
+WARPS = 6
+EPI_N = source_epilogue_n(CTA_GROUP, CTA_N, output_dtype, swap_ab)
+
+A_STAGE_BYTES = source_a_stage_bytes(P)
+B_STAGE_BYTES = source_b_stage_bytes(P)
+SFA_STAGE_BYTES = source_sfa_stage_bytes(P)
+SFB_STAGE_BYTES = source_sfb_stage_bytes(P)
+C_STAGE_BYTES = source_c_stage_bytes(P)
+AB_STAGE_BYTES = A_STAGE_BYTES + B_STAGE_BYTES + SFA_STAGE_BYTES + SFB_STAGE_BYTES
+SM107_SMEM_CAPACITY = 334848             # pinned get_smem_capacity_in_bytes("sm_107")
+AB_STAGES = (SM107_SMEM_CAPACITY - (1024 + 2*C_STAGE_BYTES)) // AB_STAGE_BYTES
+C_STAGES = 2 + (
+    SM107_SMEM_CAPACITY - AB_STAGES*AB_STAGE_BYTES - (1024 + 2*C_STAGE_BYTES)
+) // C_STAGE_BYTES
+PREFETCH_DISTANCE = AB_STAGES if tactic.prefetch_dist is None else tactic.prefetch_dist
+
+NUM_ACC_TMEM_COLS = CTA_N * ACC_STAGES * (2 if B_REUSE else 1)
+NUM_SFA_TMEM_COLS = SFA_STAGE_BYTES // 128
+NUM_SFB_TMEM_COLS = SFB_STAGE_BYTES // 128
+TMEM_ALLOC_COLS = 576                     # SM107 max allocation, always requested
+assert NUM_ACC_TMEM_COLS + NUM_SFA_TMEM_COLS + NUM_SFB_TMEM_COLS <= 576
+```
+
+The specialization rejects source-illegal alignment, cluster, and tile
+combinations. The validation matrix is generated from all legal production
+modes and reduced only by structural coverage tokens: scale format/vector,
+output conversion, swap/output major, CTA group, B-reuse collector sequence,
+N=64/128/192/256, cluster multicast directions, stage tuple, and prefetch
+0/2/automatic. Generated-PTX hashing may collapse cases only when the entire
+PTX is byte-identical.
+
+## Primitive vocabulary
+
+```python
+tensor_map(base, rank, extents, byte_strides, box_extents,
+           element_strides, dtype, swizzle_code, oob_zero)
+smem_interval(base, byte_offset, byte_count)
+tmem_address(base_column, row, column)
+static_scheduler_cursor(problem_ctas, cluster_shape, grid_clusters, raster="m")
+prefetch_tensormap(map)
+prefetch_tma_tile(map, coordinates, rank, cache_hint)
+tma_load(map, coordinates, shared_address, full_barrier,
+         cta_group, optional_multicast_mask, cache_hint)
+tma_store(map, coordinates, shared_address, cache_hint)
+umma_scale_copy(cta_group, tmem_address, shared_descriptor)
+umma_blockscaled(cta_group, collector, accumulator, a_descriptor, b_descriptor,
+                 instruction_descriptor, sfa_address, sfb_address, accumulate)
+try_wait_mbarrier(address, phase, acquire)
+wait_mbarrier(address, phase)
+arrive_mbarrier(address)
+umma_commit(address, multicast_mask)
+alloc_tmem(cta_group, columns); relinquish_tmem(cta_group); dealloc_tmem(cta_group)
+```
+
+## Complete operation sketch
+
+```python
+# ========================================================================
+# 1. Host descriptors and persistent launch
+# Source primary 864-1207, 1913-1980; runner 6361-6795.
+# ========================================================================
+if tactic.swap_ab:
+    kernel_M, kernel_N = N, M
+    kernel_A, kernel_B = transpose_storage_view(B), A
+    kernel_SFA, kernel_SFB = transpose_storage_view(SFB), SFA
+    C_MAJOR = "m"
+else:
+    kernel_M, kernel_N = M, N
+    kernel_A, kernel_B = A, transpose_storage_view(B)
+    kernel_SFA, kernel_SFB = SFA, transpose_storage_view(SFB)
+    C_MAJOR = "n"
+
+map_A = tensor_map(kernel_A, rank=2, extents=(K//2, kernel_M),
+                   byte_strides=(1, K//2), box_extents=source_a_box(P),
+                   dtype=U8, swizzle_code=source_a_swizzle(P), oob_zero=True)
+map_B = tensor_map(kernel_B, rank=2, extents=(K//2, kernel_N),
+                   byte_strides=(1, K//2), box_extents=source_b_box(P),
+                   dtype=U8, swizzle_code=source_b_swizzle(P), oob_zero=True)
+map_SFA = source_scale_tensormap(kernel_SFA, kernel_M, K, SF_VECTOR, operand="A")
+map_SFB = source_scale_tensormap(kernel_SFB, kernel_N, K, SF_VECTOR, operand="B")
+map_C = source_output_tensormap(C, M, N, output_dtype, C_MAJOR)
+
+problem_ctas = (ceil_div(kernel_M, CTA_M), ceil_div(kernel_N, CTA_N), 1)
+problem_clusters = source_cluster_count(problem_ctas, tactic.cluster)
+grid_clusters = min(problem_clusters, source_max_active_clusters(tactic.cluster))
+launch(grid=(cluster_m, cluster_n, grid_clusters), block_threads=192,
+       cluster=(cluster_m, cluster_n, 1), arch="sm_107a",
+       dynamic_smem_bytes=P.dynamic_smem_bytes, min_blocks_per_sm=1)
+# instruction_selection: PTX 9.4 `.target sm_107a`, `.reqntid 192,1,1`,
+# `.minnctapersm 1`, and `.extern .shared .align 1024`; one persistent launch.
+
+# ========================================================================
+# 2. Exact rank-one shared arena and scalar descriptors
+# Source 414-719, 1264-1474; anchor prologues.
+# ========================================================================
+AB_FULL = smem_interval(smem, 0, 8*AB_STAGES)
+AB_EMPTY = smem_interval(smem, 8*AB_STAGES, 8*AB_STAGES)
+ACC_FULL = smem_interval(smem, 16*AB_STAGES, 8*ACC_STAGES)
+ACC_EMPTY = smem_interval(smem, 16*AB_STAGES + 8*ACC_STAGES, 8*ACC_STAGES)
+TMEM_DEALLOC = smem_interval(smem, source_tmem_dealloc_offset(P), 8)
+TMEM_POINTER = smem_interval(smem, source_tmem_pointer_offset(P), 4)
+C_OFFSET = 1024
+A_OFFSET = C_OFFSET + C_STAGES*C_STAGE_BYTES
+B_OFFSET = A_OFFSET + AB_STAGES*A_STAGE_BYTES
+SFA_OFFSET = B_OFFSET + AB_STAGES*B_STAGE_BYTES
+SFB_OFFSET = source_align_1024(SFA_OFFSET + AB_STAGES*SFA_STAGE_BYTES)
+
+sC = smem_interval(smem, C_OFFSET, C_STAGES*C_STAGE_BYTES)
+sA = smem_interval(smem, A_OFFSET, AB_STAGES*A_STAGE_BYTES)
+sB = smem_interval(smem, B_OFFSET, AB_STAGES*B_STAGE_BYTES)
+sSFA = smem_interval(smem, SFA_OFFSET, AB_STAGES*SFA_STAGE_BYTES)
+sSFB = smem_interval(smem, SFB_OFFSET, AB_STAGES*SFB_STAGE_BYTES)
+
+# One exclusive 576-column allocation. ACC, SFA, and the SFB copy region do not
+# alias; the separate SFB MMA read view intentionally overlaps its copy region.
+# ACC is live from ACC_EMPTY acquire through the four-warp ACC_EMPTY release;
+# SFA/SFB are overwritten only after AB_FULL acquire and are consumed before
+# the matching AB_EMPTY commit. The tail after the shifted-view reserve is
+# untouched.
+TMEM_ACC = tmem_column_interval(tmem_base, 0, NUM_ACC_TMEM_COLS)
+TMEM_SFA = tmem_column_interval(tmem_base, NUM_ACC_TMEM_COLS,
+                                NUM_SFA_TMEM_COLS)
+SFB_COL = NUM_ACC_TMEM_COLS + NUM_SFA_TMEM_COLS
+SFB_SHIFT_RESERVE = 2 if CTA_N in (64, 192) else 0
+TMEM_SFB_COPY = tmem_column_interval(tmem_base, SFB_COL, NUM_SFB_TMEM_COLS)
+# This is an overlapping read alias, never a scale-copy destination. On an odd
+# N tile it begins two columns later; the instruction's N=64/192 logical extent
+# omits the corresponding padded 64-column portion at the other end.
+TMEM_SFB_MMA = lambda tile_n: tmem_column_interval(
+    tmem_base, SFB_COL + (2 if CTA_N in (64,192) and tile_n % 2 else 0),
+    NUM_SFB_TMEM_COLS)
+TMEM_UNUSED = tmem_column_interval(
+    tmem_base, SFB_COL + NUM_SFB_TMEM_COLS + SFB_SHIFT_RESERVE,
+    576 - SFB_COL - NUM_SFB_TMEM_COLS - SFB_SHIFT_RESERVE)
+
+def acc_stage_column(stage, reuse_slice=0):
+    # reuse_slice is 0=B-keep and 1=B-reuse; it is statically zero otherwise.
+    return tmem_base + CTA_N * ((2 if B_REUSE else 1)*stage + reuse_slice)
+def sfa_base_column():
+    return tmem_base + NUM_ACC_TMEM_COLS
+def sfb_copy_base_column():
+    return tmem_base + SFB_COL
+def sfb_mma_base_column(tile_n):
+    # The source applies this only to MMA reads; copies remain at the fixed base.
+    return tmem_base + SFB_COL + (2 if CTA_N in (64,192) and tile_n % 2 else 0)
+
+def a_stage_address(stage, row, kk):
+    return A_OFFSET + stage*A_STAGE_BYTES + source_a_smem_byte_offset(P, row, kk)
+def b_stage_address(stage, col, kk):
+    return B_OFFSET + stage*B_STAGE_BYTES + source_b_smem_byte_offset(P, col, kk)
+def sfa_stage_address(stage, logical_chunk):
+    return SFA_OFFSET + stage*SFA_STAGE_BYTES + source_sfa_byte_offset(P, logical_chunk)
+def sfb_stage_address(stage, logical_chunk):
+    return SFB_OFFSET + stage*SFB_STAGE_BYTES + source_sfb_byte_offset(P, logical_chunk)
+def c_stage_address(stage, row, col):
+    return C_OFFSET + stage*C_STAGE_BYTES + source_c_smem_byte_offset(P, row, col)
+
+A_DESC_BASE = source_smem_descriptor_base(P, operand="A")
+B_DESC_BASE = source_smem_descriptor_base(P, operand="B")
+SF_DESC_BASE = source_smem_descriptor_base(P, operand="SF")
+# instruction_selection: scalar shifts, masks, XORs and ORs only. Shared
+# descriptor address fields are `(shared_address >> 4) & 0x3fff`; no runtime
+# layout/encoder object and no inline function call.
+
+# ========================================================================
+# 3. Coordinates, barriers, and cluster publication
+# Source 1248-1479; all anchor prologues.
+# ========================================================================
+alpha_f32 = load_global_f32(alpha_ptr)
+alpha_output = cvt_rn_scalar_f32(alpha_f32, output_dtype)
+alpha_acc_f32 = widen_scalar_to_f32(alpha_output)
+tid = thread_id_x(); warp = warp_uniform(tid >> 5); lane = tid & 31
+cluster_rank = block_idx_in_cluster()
+cta_v = block_idx_x() % CTA_GROUP
+leader_cta = cta_v == 0
+cluster_m_coord, cluster_n_coord = source_cluster_coord(cluster_rank, P)
+
+if warp == TMA_WARP:
+    for map in (map_A, map_B, map_SFA, map_SFB, map_C):
+        prefetch_tensormap(map)
+# instruction_selection: five `prefetch.tensormap`; one per opaque descriptor.
+
+if warp == 0 and elect_one():
+    for stage in static_range(AB_STAGES): init_mbarrier(AB_FULL+8*stage, 1)
+    for stage in static_range(AB_STAGES):
+        init_mbarrier(AB_EMPTY+8*stage, source_ab_empty_arrivals(P))
+    for stage in static_range(ACC_STAGES): init_mbarrier(ACC_FULL+8*stage, 1)
+    for stage in static_range(ACC_STAGES):
+        init_mbarrier(ACC_EMPTY+8*stage, 4*(2 if CTA_GROUP == 2 else 1))
+if CTA_GROUP == 2 and warp == 0 and elect_one():
+    init_mbarrier(TMEM_DEALLOC, 32)
+# instruction_selection: `mbarrier.init.shared.b64`; exactly
+# `2*AB_STAGES + 2*ACC_STAGES` elected initializations for CTA-group one and
+# one additional warp-0 initialization with arrival count 32 for CTA-group two.
+
+fence_mbarrier_init_cluster()
+if CTA_GROUP == 2:
+    fence_mbarrier_init_cluster()          # publishes TMEM_DEALLOC initialization
+if tactic.cluster_m * tactic.cluster_n > 1:
+    cluster_arrive_relaxed()
+prepare_scalar_multicast_masks_and_descriptors()
+if tactic.cluster_m * tactic.cluster_n > 1:
+    cluster_wait()
+else:
+    cta_sync()
+common_scheduler = static_scheduler(problem_ctas, tactic.cluster, grid_clusters, "m")
+initial_work = common_scheduler.initial_work()
+# instruction_selection: one common `fence.mbarrier_init.release.cluster` and
+# one additional fence only for CTA-group two. Non-singleton clusters issue a
+# relaxed cluster arrival and delayed `barrier.cluster.wait`; singleton clusters
+# issue neither cluster operation and use `bar.sync 0` after the one common fence.
+
+# ========================================================================
+# 4. Persistent TMA producer, warp 5
+# Source 1481-1622; anchor producer regions.
+# ========================================================================
+with role(warp == TMA_WARP):
+    work = common_scheduler.cursor(initial_work)
+    ab_producer = pipeline_state(AB_STAGES, initial_phase=1)
+    while work.valid:
+        tile_m, tile_n = work.coordinate
+        ab_producer.reset()
+        if PREFETCH_DISTANCE > 0:
+            for pf in runtime_range(min(PREFETCH_DISTANCE, ceil_div(K, K_TILE))):
+                prefetch_tma_tile(map_A, source_a_coord(tile_m, pf), 2, source_l2_hint)
+                prefetch_tma_tile(map_B, source_b_coord(tile_n, pf), 2, source_l2_hint)
+                prefetch_tma_tile(map_SFA, source_sfa_coord(tile_m, pf), 3, source_l2_hint)
+                prefetch_tma_tile(map_SFB, source_sfb_coord(tile_n, pf), 3, source_l2_hint)
+        speculative_empty = try_wait_mbarrier(
+            AB_EMPTY+8*ab_producer.stage, ab_producer.phase, acquire=True)
+        for k_tile in runtime_range(ceil_div(K, K_TILE)):
+            wait_if_needed(AB_EMPTY+8*ab_producer.stage,
+                           ab_producer.phase, speculative_empty)
+            if leader_cta and elect_one():
+                arrive_expect_tx(AB_FULL+8*ab_producer.stage,
+                                 source_tma_transaction_bytes(P))
+            if elect_one():
+                current_full = AB_FULL + 8*ab_producer.stage
+                tma_load(map_A, source_a_coord(tile_m,k_tile),
+                         a_stage_address(ab_producer.stage,0,0), current_full,
+                         CTA_GROUP, source_a_multicast_mask(P), source_l2_hint)
+                tma_load(map_B, source_b_coord(tile_n,k_tile),
+                         b_stage_address(ab_producer.stage,0,0), current_full,
+                         CTA_GROUP, source_b_multicast_mask(P), source_l2_hint)
+                tma_load(map_SFA, source_sfa_coord(tile_m,k_tile),
+                         sfa_stage_address(ab_producer.stage,0), current_full,
+                         CTA_GROUP, source_sfa_multicast_mask(P), source_l2_hint)
+                tma_load(map_SFB, source_sfb_coord(tile_n,k_tile),
+                         sfb_stage_address(ab_producer.stage,0), current_full,
+                         CTA_GROUP, source_sfb_multicast_mask(P), source_l2_hint)
+            if PREFETCH_DISTANCE > 0 and k_tile < ceil_div(K,K_TILE)-PREFETCH_DISTANCE:
+                rolling_k = k_tile + PREFETCH_DISTANCE
+                prefetch_tma_tile(map_A, source_a_coord(tile_m,rolling_k), 2, source_l2_hint)
+                prefetch_tma_tile(map_B, source_b_coord(tile_n,rolling_k), 2, source_l2_hint)
+                prefetch_tma_tile(map_SFA, source_sfa_coord(tile_m,rolling_k), 3, source_l2_hint)
+                prefetch_tma_tile(map_SFB, source_sfb_coord(tile_n,rolling_k), 3, source_l2_hint)
+            advance(ab_producer); speculative_empty = next_try_wait_if_live()
+        work.advance()
+    producer_tail_wait_every_stage(ab_producer)
+# instruction_selection: elected `mbarrier.arrive.expect_tx.shared.b64`; four
+# TMA loads per K tile. A/B select
+# `cp.async.bulk.tensor.2d.shared::{cta|cluster}.global.tile.mbarrier::complete_tx::bytes`
+# and SFA/SFB select the otherwise identical `tensor.3d` family. A/SFA use
+# shared::cta when cluster-N is one and otherwise shared::cluster with
+# `.multicast::cluster`; B/SFB use shared::cta when the number of cluster-M
+# groups is one and otherwise shared::cluster with `.multicast::cluster`.
+# Every form ends in `.L2::cache_hint`; CTA-group two uses shared::cluster,
+# its leader completion barrier, and the final `.cta_group::2` modifier, with
+# multicast retained when the operand spans multiple same-direction peers.
+# Each enabled initial iteration and guarded rolling
+# iteration emits A/B `cp.async.bulk.prefetch.tensor.2d.L2.global.tile.L2::cache_hint`
+# and SFA/SFB `cp.async.bulk.prefetch.tensor.3d.L2.global.tile.L2::cache_hint`.
+# The initial extent is `min(PREFETCH_DISTANCE, ceil_div(K,256))`; rolling has
+# exactly `ceil_div(K,256)-PREFETCH_DISTANCE` iterations when positive.
+# Zero-prefetch emits no data-prefetch instructions. Empty-buffer speculative
+# acquires lower to `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`;
+# unresolved waits and the all-`AB_STAGES` producer-tail drain lower to parity
+# `mbarrier.try_wait.parity.shared.b64` loops at the current stage address.
+
+# ========================================================================
+# 5. Persistent MMA, warp 4
+# Source 1624-1779; anchor MMA regions.
+# ========================================================================
+with role(warp == MMA_WARP):
+    named_barrier(2, 160)
+    tmem_base = load_shared_u32(TMEM_POINTER)
+    work = common_scheduler.cursor(initial_work)
+    ab_consumer = pipeline_state(AB_STAGES, initial_phase=0)
+    acc_producer = pipeline_state(ACC_STAGES, initial_phase=1)
+    while work.valid:
+        tile_m, tile_n = work.coordinate
+        ab_consumer.reset()
+        speculative_full = True
+        if leader_cta and ceil_div(K,K_TILE) > 0:
+            speculative_full = try_wait_mbarrier(
+                AB_FULL+8*ab_consumer.stage, ab_consumer.phase, acquire=True)
+        if leader_cta:
+            wait_mbarrier(ACC_EMPTY+8*acc_producer.stage, acc_producer.phase,
+                          acquire=False)
+        accumulate = False
+        for k_tile in runtime_range(ceil_div(K, K_TILE)):
+            if leader_cta:
+                wait_if_needed(AB_FULL+8*ab_consumer.stage,
+                               ab_consumer.phase, speculative_full)
+            if leader_cta:
+                if B_REUSE:
+                    for k_block in static_range(K_BLOCKS):
+                        # Exact interleave: SFA-keep, SFB, SFA-reuse, then two MMAs.
+                        for issue in static_range(2):
+                            umma_scale_copy(1, source_sfa_keep_tmem(P,k_block)+4*issue,
+                                source_sfa_keep_desc(P,ab_consumer.stage,k_block,issue))
+                        for issue in static_range(2):
+                            umma_scale_copy(
+                                1,
+                                sfb_copy_base_column()
+                                + source_sfb_kblock_offset(P,k_block)+4*issue,
+                                source_sfb_desc(P,ab_consumer.stage,k_block,issue))
+                        for issue in static_range(2):
+                            umma_scale_copy(1, source_sfa_reuse_tmem(P,k_block)+4*issue,
+                                source_sfa_reuse_desc(P,ab_consumer.stage,k_block,issue))
+                        umma_blockscaled(1, "a::discard,b::fill",
+                            source_acc_keep(P,acc_producer.stage),
+                            source_a_keep_desc(P,ab_consumer.stage,k_block),
+                            source_b_desc(P,ab_consumer.stage,k_block),
+                            source_instruction_desc(P,"keep"),
+                            source_sfa_keep_tmem(P,k_block),
+                            sfb_mma_base_column(tile_n)+source_sfb_kblock_offset(P,k_block),
+                            accumulate)
+                        umma_blockscaled(1, "a::discard,b::lastuse",
+                            source_acc_reuse(P,acc_producer.stage),
+                            source_a_reuse_desc(P,ab_consumer.stage,k_block),
+                            source_b_desc(P,ab_consumer.stage,k_block),
+                            source_instruction_desc(P,"reuse"),
+                            source_sfa_reuse_tmem(P,k_block),
+                            sfb_mma_base_column(tile_n)+source_sfb_kblock_offset(P,k_block),
+                            accumulate)
+                        accumulate = True
+                else:
+                    for sfa_issue in static_range(SFA_STAGE_BYTES // 512):
+                        umma_scale_copy(CTA_GROUP,
+                            sfa_base_column()+4*sfa_issue,
+                            source_sfa_issue_desc(P,ab_consumer.stage,sfa_issue))
+                    for sfb_issue in static_range(SFB_STAGE_BYTES // 512):
+                        umma_scale_copy(CTA_GROUP,
+                            sfb_copy_base_column()+4*sfb_issue,
+                            source_sfb_issue_desc(P,ab_consumer.stage,sfb_issue))
+                    for k_block in static_range(K_BLOCKS):
+                        umma_blockscaled(CTA_GROUP, "a::discard",
+                            source_acc(P,acc_producer.stage),
+                            source_a_desc(P,ab_consumer.stage,k_block),
+                            source_b_desc(P,ab_consumer.stage,k_block),
+                            source_instruction_desc(P),
+                            source_sfa_tmem(P,k_block),
+                            sfb_mma_base_column(tile_n)+source_sfb_kblock_offset(P,k_block),
+                            accumulate)
+                        accumulate = True
+                umma_commit(AB_EMPTY+8*ab_consumer.stage,
+                            source_ab_empty_multicast_mask(P,cluster_rank))
+            advance(ab_consumer)
+            if leader_cta and k_tile+1 < ceil_div(K,K_TILE):
+                speculative_full = try_wait_mbarrier(
+                    AB_FULL+8*ab_consumer.stage, ab_consumer.phase, acquire=True)
+        if leader_cta:
+            umma_commit(ACC_FULL+8*acc_producer.stage,
+                        source_acc_full_multicast_mask(P,cluster_rank))
+        advance(acc_producer); work.advance()
+    if leader_cta:
+        for unused in static_range(ACC_STAGES-1):
+            advance(acc_producer)
+        wait_mbarrier(ACC_EMPTY+8*acc_producer.stage, acc_producer.phase,
+                      acquire=False)
+# instruction_selection: `tcgen05.cp.cta_group::{1|2}.32x128b.warpx4`;
+# `tcgen05.mma.cta_group::{1|2}.kind::mxf4nvf4.block_scale.block{16|32}`.
+# Ordinary cases use `.collector::a::discard`. B-reuse cases use paired
+# `.collector::a::discard.collector::b::fill` and `...b::lastuse` in the exact
+# interleaved order. The elected leader CTA issues one AB_EMPTY commit per K
+# tile and one ACC_FULL commit per output tile. CTA-group two and clustered
+# group one use
+# `tcgen05.commit.cta_group::{2|1}.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64`
+# with the exact source AB-consumer or ACC-producer mask. Singleton group one
+# uses
+# `tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64`
+# with no multicast operand.
+# Ordinary SFA and SFB loops have `SFA_STAGE_BYTES/512` then
+# `SFB_STAGE_BYTES/512` static issues, respectively (for example 4 then 8 for
+# N=192 NVFP4). In B-reuse NVFP4, each SFA-keep, SFB, and SFA-reuse source-copy
+# call expands to two static issues per K block: six per block, twelve total.
+# AB_FULL speculative probes use current parity and
+# `mbarrier.try_wait.parity.acquire.cta.shared::cta.b64`; unresolved AB_FULL
+# waits and the blocking ACC_EMPTY producer acquire use non-acquire
+# `mbarrier.try_wait.parity.shared.b64` loops. At the tail, only the leader CTA
+# advances accumulator state `ACC_STAGES-1` times and performs one final
+# non-acquire ACC_EMPTY wait. AB release commits target the current AB_EMPTY
+# stage and ACC publication targets the current ACC_FULL stage.
+
+# ========================================================================
+# 6. Four persistent alpha-scaled TMA epilogue warps
+# Source 1781-1911; epilogue_utils 486-574; anchor epilogues.
+# ========================================================================
+with role(warp in EPI_WARPS):
+    if warp == 0:
+        alloc_tmem(CTA_GROUP, TMEM_ALLOC_COLS, destination=TMEM_POINTER,
+                   exclusive=True)
+        # tcgen05.alloc.exclusive.cta_group::{1|2}.sync.aligned.shared::cta.b32
+    named_barrier(2, 160)
+    # allocation retrieval: bar.sync 2,160
+    tmem_base = load_shared_u32(TMEM_POINTER)
+    work = common_scheduler.cursor(initial_work)  # reset to source initial work
+    acc_consumer = pipeline_state(ACC_STAGES, initial_phase=0)
+    c_sequence = 0
+    while work.valid:
+        tile_m, tile_n = work.coordinate
+        wait_mbarrier(ACC_FULL+8*acc_consumer.stage, acc_consumer.phase,
+                      acquire=False)
+        for subtile in static_range(source_epilogue_subtiles(P)):
+            values = tmem_load_source_fragment(P, tmem_base,
+                                               acc_consumer.stage, warp, subtile)
+            for pair in static_range(16):
+                values[2*pair:2*pair+2] = mul_f32x2(
+                    values[2*pair:2*pair+2], alpha_acc_f32)
+            packed = cvt_rn_x2_f32(values, output_dtype)
+            c_stage = c_sequence % C_STAGES
+            source_register_store_shared(P, packed,
+                                         c_stage_address(c_stage,0,0), warp, lane)
+            fence_async_shared_cta()       # fence.proxy.async.shared::cta
+            named_barrier(1,128)           # bar.sync 1,128
+            if warp == 0:
+                for source_store_piece in source_output_store_pieces(P):
+                    tma_store(map_C, source_c_coord(tile_m,tile_n,subtile,source_store_piece),
+                              source_c_piece_address(P,c_stage,source_store_piece),
+                              source_l2_hint)
+                tma_commit()                # cp.async.bulk.commit_group
+                tma_wait(pending=C_STAGES-1) # cp.async.bulk.wait_group.read C_STAGES-1
+            named_barrier(1,128)           # bar.sync 1,128
+            c_sequence += 1
+        named_barrier(1,128)               # bar.sync 1,128 before ACC release
+        if elect_one():
+            if CTA_GROUP == 1:
+                mbarrier_arrive_shared(
+                    ACC_EMPTY+8*acc_consumer.stage)  # mbarrier.arrive.shared.b64
+            else:
+                acc_owner = source_acc_empty_peer_rank(cluster_rank, warp)
+                remote_acc_empty = mapa_shared_cluster_u32(
+                    ACC_EMPTY+8*acc_consumer.stage, acc_owner)
+                mbarrier_arrive_shared_cluster(
+                    remote_acc_empty)       # mbarrier.arrive.shared::cluster.b64
+        advance(acc_consumer); work.advance()
+    tma_wait(pending=0)                    # cp.async.bulk.wait_group.read 0
+    if warp == 0:
+        relinquish_tmem(CTA_GROUP)
+        # tcgen05.relinquish_alloc_permit.cta_group::{1|2}.sync.aligned
+        if CTA_GROUP == 2:
+            peer_rank = cluster_rank ^ 1
+            peer_dealloc = mapa_shared_cluster_u32(TMEM_DEALLOC, peer_rank)
+            # mapa.shared::cluster.u32
+            mbarrier_arrive_shared_cluster(peer_dealloc)
+            # mbarrier.arrive.shared::cluster.b64
+            wait_mbarrier(TMEM_DEALLOC, phase=0, acquire=False)
+            # mbarrier.try_wait.parity.shared.b64, phase 0
+        dealloc_tmem(CTA_GROUP, tmem_base, TMEM_ALLOC_COLS, exclusive=True)
+# instruction_selection: output-major N, for either CTA group, uses one
+# `tcgen05.ld.sync.aligned.32x32b.x32.b32` and exactly four
+# `st.shared.v4.b32` per lane per subtile.
+# Output-major M, for either CTA group, uses two
+# `tcgen05.ld.sync.aligned.16x256b.x4.b32` and four
+# `stmatrix.sync.aligned.m8n8.x4.trans.shared.b16` per subtile. Each family is
+# repeated exactly `source_epilogue_subtiles(P)` times. Output-major N issues
+# one and output-major M issues two
+# `cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group.L2::cache_hint`
+# instructions per subtile before one TMA-store commit/wait sequence.
+# Alpha first uses scalar `cvt.rn.f16.f32; cvt.f32.f16` or
+# `cvt.rn.bf16.f32; cvt.f32.bf16`, then sixteen FP32x2 multiplies precede
+# sixteen `cvt.rn.{f16x2|bf16x2}.f32`. Stores are
+# rank-2 `cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group`, followed
+# by `cp.async.bulk.commit_group`,
+# `cp.async.bulk.wait_group.read C_STAGES-1`, and `bar.sync 1,128`;
+# the tail is `cp.async.bulk.wait_group.read 0`. ACC_FULL waits use non-acquire
+# `mbarrier.try_wait.parity.shared.b64` with the current parity;
+# after all subtiles, each epilogue warp elects one lane to issue one ACC_EMPTY
+# arrival: group one targets its local shared::cta barrier and group two uses
+# the source remote cluster destination. Store tail drains to pending zero.
+# Both groups use `tcgen05.relinquish_alloc_permit.cta_group::{1|2}.sync.aligned`
+# then `tcgen05.dealloc.exclusive.cta_group::{1|2}.sync.aligned.b32` for 576
+# columns. Only group two executes, in between, XOR-peer
+# `mapa.shared::cluster.u32`, remote `mbarrier.arrive.shared::cluster.b64`,
+# and a local phase-zero `mbarrier.try_wait.parity.shared.b64` loop.
+```
+
+## Required verification boundary
+
+Correctness must exercise a structural cover of every production-reachable
+SM107 mode, with explicit rows for B-reuse, CTA-group 2, both scale modes, both
+output dtypes, swap, every N tile, every cluster multicast direction, all three
+prefetch settings, non-tile-multiple M/N boundaries, and multiple K tiles.
+Inputs use deterministic nibble patterns and exactly representable scale/alpha
+values, plus randomized finite payloads. Output storage has front/back canaries
+and every case is rerun for determinism.
+
+The first comparison is byte-for-byte against the pinned source on the exact
+same tensors and forced tactic. An independent FP64 decode-and-matmul oracle
+checks both outputs with dtype-tight error bounds, using
+`float32(cast_output(alpha_f32))` exactly: zero tolerance whenever the
+reference result is exactly representable; otherwise at most one output ULP
+plus the explicitly computed FP32 accumulation bound. NaNs, infinities,
+unwritten values, canary damage, or non-determinism are hard failures. Low-level
+IR must reject `K.cuda.func_call` and inline-CUDA function-call exemptions.
+
+Performance is a later, permanently reviewer-free gate. Only `bench_suite`
+paired source/reference rows count, both sides must compile PTX 9.4 for
+`sm_107a`, and every frozen row must satisfy the strict ratio
+`source_time / tirx_time > 0.99`.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/elect-a-warp-collectives-issue-lane-in-hardware.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/elect-a-warp-collectives-issue-lane-in-hardware.md
@@ -46,12 +46,42 @@ selected, so it rebuilds the election and its reconvergence around each issue.
 The hardware election yields the uniform predicate the instruction already
 wants, and the surrounding machinery disappears.
 
+When one lane owns a complete stateful persistent role, apply the same rule to
+the outer role guard. A literal lane-zero comparison can leave ptxas proving
+single-issuer semantics again around every uniform operation in the loop:
+
+```python
+# before: the literal lane comparison does not carry an elected-lane proof.
+with K.If(lane == K.int32(0)), K.Then():
+    with K.While(has_work):
+        update_role_state()
+        issue_transfers_and_collectives()
+
+# after: one hardware election owns the complete persistent role.
+with K.If(K.cuda.elect_sync() != K.uint32(0)), K.Then():
+    with K.While(has_work):
+        update_role_state()
+        issue_transfers_and_collectives()
+```
+
 Measured on a warp-specialized backward attention kernel whose issuing warp runs
 ten chains and ten commits per tile: static `PLOP3` fell from 213 to 48 against
 the reference's 3, `ELECT` from 58 to 18 against 13, `VOTEU` from 52 to 1, and
 total static SASS from 3679 to 3359. Four benchmark shapes moved by -9.5%,
 -10.2%, -10.5% and -11.4%, taking the required matrix from 0 of 16 shapes
 passing to 10 of 16 in one change.
+
+In a seven-warp persistent matrix pipeline, tensor, TMA, shared-memory, and
+global-store issue counts already matched the reference and both sides had zero
+spill traffic, but three long single-lane roles were guarded by literal lane-zero
+comparisons. Changing only those outer guards to one hardware election per role
+reduced static `ELECT` from 371 to 6 and total static `PLOP3` from 1116 to 11,
+with registers unchanged at 46 and no stack or local allocation. The affected
+latency fell from 241.522 to 134.206 microseconds, a 1.80x speedup, and the
+reference/port ratio moved from 0.5591x to 0.9800x. Exact correctness,
+determinism, allocation guards, and placement checks all passed; the elected
+form was retained through the final complete correctness and performance
+matrices.
 
 The predicate *form* is the lever, not the absence of a branch. Moving the same
 guards off branches and onto `pred=` first -- the standard predication rewrite,
@@ -83,6 +113,10 @@ one.
 
 An election establishes *a* lane, not lane 0. Do not swap it in where the
 guarded code also depends on being the lowest lane for addressing or ordering.
+
+For the persistent-role form, keep the election at converged warp scope and let
+it own the whole loop-carried state. Re-electing inside the loop or around each
+issue recreates the repeated control work this rewrite removes.
 
 ## Verification
 

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/fence-generic-stores-before-an-async-proxy-copy.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/fence-generic-stores-before-an-async-proxy-copy.md
@@ -1,0 +1,59 @@
+# Fence generic stores before an async-proxy copy reads them
+
+**Symptoms:** `bitwise_mismatch`, `nondeterministic_output`, `stale_shared_data`, `multi_tile_only_failure`
+
+## Symptom
+
+Outputs that are bitwise-exact on one-tile-per-CTA grids differ on a few rows of
+a few tiles once CTAs process several tiles, and two identical launches of the
+same binary disagree with each other. The affected rows are those whose per-row
+scale words are written to shared memory with ordinary stores and then consumed
+through the tensor-memory copy path.
+
+## What to change
+
+Put `fence.proxy.async.shared::cta` between the generic-proxy `st.shared` of
+data that a `tcgen05.cp` (or any async-proxy consumer) will read and the
+barrier arrive that publishes it.
+
+```python
+# before: the scale word is published to the matrix warp without a proxy fence.
+K.ptx.st.shared.b32(sSFP.ptr_to([offset]), sf_word)
+K.ptx[TMEM_ST](tmem_col, *p_words)
+K.ptx.tcgen05.wait__st.sync.aligned()
+P_full.arrive(stage)            # matrix warp then issues tcgen05.cp from sSFP
+
+# after: order the generic stores before the async-proxy read.
+K.ptx.st.shared.b32(sSFP.ptr_to([offset]), sf_word)
+K.ptx.fence.proxy.async_.shared__cta()
+K.ptx[TMEM_ST](tmem_col, *p_words)
+K.ptx.tcgen05.wait__st.sync.aligned()
+P_full.arrive(stage)
+```
+
+## Rationale
+
+The mbarrier orders generic-proxy work; `tcgen05.cp` reads shared memory
+through the async proxy and can observe the previous step's scale factors. The
+race only surfaces when timing shifts, which here meant persistent grids with
+several tiles per CTA. The reference kernel itself omitted the fence: on a
+4096-key, 32-head NVFP4-P shape two back-to-back launches of the unpatched
+reference differed on 100,050 and 133,944 of 16.8M elements, and its error
+against an fp64 oracle on the disputed rows was the larger one. Adding the one
+fence to the reference made it deterministic and bitwise-equal to the port,
+which issues the same fence: 45 configurations then matched bit for bit. One
+fence per softmax step was not measurable in the 74-row benchmark matrix.
+
+## Boundary
+
+Needed only when a generic store feeds an async-proxy reader (`tcgen05.cp`,
+TMA store, bulk copy). Stores consumed by `tcgen05.st`/`tcgen05.ld` register
+paths or by ordinary loads after an mbarrier do not need it. Do not treat a
+bitwise-clean single-tile matrix as proof: the failing regime is multi-tile.
+
+## Verification
+
+Launch the reference twice on a multi-tile persistent shape and `torch.equal`
+the two outputs before using it as a bitwise oracle; then compare the port.
+Include at least one configuration with several tiles per CTA for every
+quantized-P mode in the correctness matrix.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/keep-sibling-role-guards-when-the-reference-dispatches-with-sibling-ifs.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/keep-sibling-role-guards-when-the-reference-dispatches-with-sibling-ifs.md
@@ -1,0 +1,49 @@
+# Keep sibling role guards when the reference dispatches with sibling ifs
+
+**Symptoms:** `slow_small_shape`, `dispatch_specific_deficit`, `instruction_parity_with_deficit`, `schedule_regression`
+
+## Symptom
+
+A warp-specialized port whose static SASS already matches the reference (same
+registers, no spills, identical MMA/TMA/TMEM/barrier and float-pipe counts) sits
+slightly below the reference on its smallest, latency-bound shapes, and the
+role dispatch was folded into an if/else-if chain while the reference selects
+its roles with independent sibling `if` blocks.
+
+## What to change
+
+Let the role guards stay sibling `if`s, matching the reference, when the kernel
+has no register pressure for the chain to relieve.
+
+```python
+# before: chained dispatch, the K.specialize default.
+roles = K.specialize()
+
+# after: sibling guards, the reference's structure.
+roles = K.specialize(chain_dispatch=False)
+```
+
+## Rationale
+
+The chain exists to tell ptxas that role bodies are mutually exclusive, which
+matters at the register cliff. Without that pressure it only changes the
+dispatch control flow, and on one 16-warp block-sparse attention kernel that was
+a pure cost: with 128 registers and zero spill bytes in both forms, the chained
+build measured 19.25 us against 18.82 us for the sibling build on the sparsest
+shape (4 KV blocks per 128-row tile, 128 CTAs) and 53.10 us against 52.45 us on
+the next shape (256 CTAs), i.e. 2.3% and 1.2% slower, moving the reference/port
+ratio from 0.996 to 0.974 and from 1.007 to 0.995. Large streaming shapes were
+not measured because the small shapes already decided the direction.
+
+## Boundary
+
+Applies when the reference's dispatch is sibling `if`s and the port assembles
+without spills at its register targets. When a role sits at the 255-register
+cliff or ptxas reports spills, the chain is still the documented remedy
+(`K.specialize` docstring) and its cost here is the price of assembling.
+
+## Verification
+
+Build both forms, confirm identical `ptxas -v` register and spill counts, and
+compare the smallest required shapes in the bench suite before choosing; the
+difference is invisible in static opcode histograms.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/match-conversion-and-packing-idioms.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/match-conversion-and-packing-idioms.md
@@ -183,6 +183,17 @@ cleared the strict gate, while the former still required an independent
 register-schedule fix. This rewrite was retained through the complete
 correctness and performance matrices.
 
+Where no compound four-pair conversion intrinsic exists (the `cvt.rn.satfinite.e2m1x2.f32`
+table entry stages its `.b8` result through a `cvt.u16.u8` carrier and the table
+has no `mov.b32 {b8x4}`), every spelling of the four-byte pack costs the same:
+shift/or and explicit `prmt` both lowered to 4 LOP3 + 2 PRMT (or 3 PRMT) per
+word around the same 4 `F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`, because the
+carrier's `(uint8_t)` truncation survives as an `and.b16 255` per byte. The
+reference's `mov.b32 {b0,b1,b2,b3}` chained the four merges for free. Measured
+in a softmax step that quantizes 128 values: +92 instructions per step (LOP3
++248k, PRMT +131k dynamic per launch), about 6% of the step; every benchmarked
+shape of that mode still passed, so it was recorded rather than worked around.
+
 ## Boundary
 
 The exact packed/scalar selector is a property of the source fragment layout

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/match-the-mma-descriptor-leading-byte-offset.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/match-the-mma-descriptor-leading-byte-offset.md
@@ -1,6 +1,6 @@
 # Match the MMA descriptor's physical leading-byte offset
 
-**Symptoms:** `illegal_shared_access`, `utchmma_fault`, `mma_descriptor_lbo_mismatch`, `second_kphase_fault`
+**Symptoms:** `illegal_shared_access`, `utchmma_fault`, `mma_descriptor_lbo_mismatch`, `second_kphase_fault`, `bitwise_mismatch`
 
 ## Symptom
 
@@ -25,6 +25,18 @@ that stride and faulted at `UTCHMMA`. Overriding only the four MN-major operands
 restored `0x4000404002000000`, passed Compute Sanitizer with zero errors, and
 made all valid intermediate tiles bit-identical across ten registered
 configurations.
+
+The mismatch does not always fault. An MN-major bf16 V operand whose N extent
+spans two 64-column SW128B atoms (TMA writes the halves 16 KB apart) was
+encoded with LBO 1 like the K-major operands; the kernel ran to completion and
+output columns 0-63 were bitwise-equal to the reference while columns 64-127
+were wrong in every row (16368 of 32768 elements, 0.52 cosine). The reference
+PTX carried `or.b32 lo, 1024 << 16` for that operand only: LBO 1024 (the
+16 KB half stride) for the two-atom bf16 V, 0 for single-atom MN-major e4m3 or
+64-wide V, and 1 for every K-major operand. Encoding those three values made
+all 45 configurations bitwise-equal. Read the LBO per operand from the
+reference's descriptor low-word constant rather than assuming one value for
+all swizzled layouts.
 
 ## Boundary
 

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/match-the-reference-ptxas-register-usage-level.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/match-the-reference-ptxas-register-usage-level.md
@@ -1,0 +1,71 @@
+# Match the reference ptxas register-usage level
+
+**Symptoms:** `register_spill`, `local_memory_traffic`, `register_budget_mismatch`, `sass_schedule_divergence`, `warp_retry_region`
+
+## Symptom
+
+Same key-instruction counts as the reference (`UTCHMMA`, `LDTM`, `STTM`,
+`UTMALDG`, `MUFU`) but several times more `MOV.SPILL`/`R2UR.FILL` pairs,
+`LDL.64`/`STL.64` of 64-bit descriptor packs in a 48-register issuer or
+producer warp, and a larger stack frame, in a build that goes through the
+nvcc path with its default `--register-usage-level=10`.
+
+## What to change
+
+Pin the ptxas register-usage level the reference is built with (its native
+default is 5) around the kernel's compile call, and document the measurement.
+
+```python
+_PTXAS_REG_LEVEL = "5"
+
+previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = _PTXAS_REG_LEVEL
+try:
+    executable = compile_kernel(func, cuda_compile_mode="nvcc")
+finally:
+    ...  # restore the previous value
+```
+
+## Rationale
+
+Level 10 lets ptxas schedule aggressively; in narrow `setmaxnreg` roles that
+stretches the lifetimes of `mov.b64` descriptor packs and uniform barrier and
+coordinate values until they spill. One 16-warp persistent block-sparse
+attention kernel (roles 192/80/48) went from 336 bytes of stack, 120 `LDL`,
+99 `STL` and 268 uniform spill/fill pairs at level 10 to 88 bytes, 30 `LDL`,
+27 `STL` and 23 pairs at level 5, the reference's own profile (96 bytes,
+48/34/23). Bench-suite ratios moved from 1.0074x to 1.0667x on a 1.46 ms
+streaming shape and from 1.0457x to 1.0717x on a 0.74 ms shape; the other
+four required shapes gained 6-7% as well and outputs stayed bitwise identical.
+
+In a second 16-warp block-sparse attention kernel, both implementations still
+allocated 128 registers, but level 10 introduced a 56-byte stack and dynamic
+local traffic that grew from 7,168 spill instructions on a short path to
+1,970,176 on the deepest measured path; the reference had none. Level 5
+removed the stack and all local spill traffic, and reduced static SASS from
+2,248 to 2,072 instructions, exactly matching the reference count. On a
+representative streaming path it also reduced synchronization try-waits from
+14,170,782 to 11,061,280, close to the reference's 10,968,668. The complete
+six-row bench-suite minimum/geometric-mean ratios moved from
+0.9734x/0.9749x to 0.9926x/1.0055x, with all seven correctness configurations
+remaining bitwise identical to the reference.
+
+## Boundary
+
+The sibling kernel of the same source family, which had zero spills at level
+10, measured level 5 as neutral (within 0.5%); sweep only when the SASS shows
+allocation traffic the reference lacks. This is a beta ptxas option, so record
+the toolkit version with the measurement and re-check after toolchain moves.
+
+The register-usage-level response is non-monotonic. In a fixed three-shape
+sweep around the reference level, levels 4, 5, and 6 produced targeted
+minimum/geometric-mean ratios of 0.9904x/0.9997x, 0.9929x/1.0085x, and
+0.9741x/0.9833x respectively; level 6 failed two rows. Match the reference as
+the primary candidate, but measure adjacent levels instead of assuming that a
+more aggressive setting is better.
+
+## Verification
+
+Compare stack bytes, static and dynamic `LDL`/`STL`/`MOV.SPILL`/`R2UR.FILL`
+against the reference build at both levels, rerun the bitwise correctness
+rows, and accept only on bench-suite timing.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/move-whole-rows-with-vector-global-accesses.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/move-whole-rows-with-vector-global-accesses.md
@@ -1,6 +1,6 @@
 # Move whole rows with vector global accesses
 
-**Symptoms:** `fixed_overhead`, `slow_small_shape`, `dispatch_specific_deficit`, `instruction_count_gap`
+**Symptoms:** `fixed_overhead`, `slow_small_shape`, `dispatch_specific_deficit`, `instruction_count_gap`, `excessive_sectors`
 
 ## Symptom
 
@@ -51,6 +51,15 @@ looking proven. A dispatch that no benchmark covers can hide an arbitrarily
 large fixed cost; when a new port puts that dispatch on the gate, check its
 access widths against the reference before trusting the inheritance.
 
+The same rule applies when only one direction is scalar. In another persistent
+state path, the drain was already vectorized but the 32-element seed still used
+scalar FP32 loads. Explicit 16-byte seed loads reduced global-load requests from
+141,632 to 43,328 and sectors from 4,204,864 to 1,059,136; the matched reference
+reported 43,392 requests and 1,059,200 sectors. Registers stayed at 128 while
+stack allocation fell from 24 to 16 bytes. The shortest state-carrying ratio
+moved from 0.979x to 1.018x, exact correctness passed for both FP32 and BF16
+state, and the complete 18-shape matrix cleared the gate.
+
 ## Boundary
 
 Only for contiguous runs whose base alignment follows from the row length, not
@@ -63,5 +72,8 @@ adds to the enclosing loop body rather than the accesses it issues.
 
 Compare the state-carrying and state-free builds of the same kernel: take the
 difference in `ld.global`/`st.global` sites on each side and require the port's
-delta to match the reference's. Absolute counts across two compilers are not
-comparable; the delta between two builds of the same program is.
+delta to match the reference's. Static absolute counts across two compilers are
+not comparable; the delta between two builds of the same program is. For a
+matched dynamic profile, also compare global-load requests and sectors before
+and after the rewrite. They should collapse on the row-carrying build while a
+build that does not execute the row move stays flat.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/prefetch-a-shallow-tma-ring-into-l2-under-cold-cache.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/prefetch-a-shallow-tma-ring-into-l2-under-cold-cache.md
@@ -1,0 +1,78 @@
+# Prefetch a shallow TMA ring into L2 under cold cache
+
+**Symptoms:** `cold_cache_regression`, `exposed_load_latency`, `insufficient_memory_parallelism`, `instruction_parity_with_deficit`, `barrier_stall`
+
+## Symptom
+
+A warp-specialized pipeline beats its reference under a warm L2 yet loses to it
+in the benchmark suite, whose timer flushes L2 before every launch. The deficit
+is per block, independent of wave count, and appears only in the specialization
+whose shared-memory budget leaves the fewest ring stages. Barrier attribution
+shows the consumer side spinning on the accumulator-ready barrier (the matrix
+warp starves on operands) far more than the reference does, while executed
+instructions, issue efficiency, and the MMA issue code are equal or better.
+
+## What to change
+
+Have the producer warp issue a TMA L2 prefetch (`cp.async.bulk.prefetch.tensor`,
+no shared memory, no barrier) for the block a fixed distance ahead of the one it
+loads, and gate it on ring depth: only rings whose in-flight bytes no longer
+cover a cold HBM fetch at the port's block time.
+
+```python
+# before: the ring is the only prefetch; with 3 slots and 2 loads per block it
+# holds 1.5 blocks, so a cold-L2 fetch stalls the matrix warp.
+with K.serial(n_blocks - 1, unroll=False) as i:
+    n = n_max - 2 - i
+    load_k(n)
+    load_v(n)
+
+# after: pull block n-2 into L2 while the ring is busy with n and n-1.
+PREFETCH = 2 if kv_stage <= 3 else 0
+with K.serial(n_blocks - 1, unroll=False) as i:
+    n = n_max - 2 - i
+    if PREFETCH:
+        with K.If(n - PREFETCH >= 0), K.Then():
+            with K.If(elected()), K.Then():
+                K.ptx["cp.async.bulk.prefetch.tensor.4d.L2.global.tile"](
+                    K.address_of(tmap_k), K.int32(0), K.Cast("int32", n_pf * BLK_N), head, batch
+                )
+                # ... and the V box(es) of the same block
+    load_k(n)
+    load_v(n)
+```
+
+Also prefetch the first two blocks of every tile before the ring's own loads
+begin, since the ring is empty at a tile boundary.
+
+## Rationale
+
+The ring depth that hides latency is a function of block time, not a constant of
+the algorithm. One attention forward with an e4m3 K plus bf16 V (48 KB per
+block) fit only three ring slots in 227 KB; its reference ran 1.2 us per block
+and covered the cold fetch, the port ran 1.0 us per block and did not. Measured
+with CUPTI, warm versus cold (256 MB flush): port 101.2 -> 125.7 us (+24%),
+reference 120.6 -> 124.2 us (+3%); sibling modes with four or more slots moved
++1-4%, and a 32768-key stream 0%. Under the suite's cold protocol the row sat
+at 0.984x. With the prefetch, 125.7 -> 111.0 us (1.118x); two sibling rows of
+the same mode moved 1.008 -> 1.133x and 1.036 -> 1.096x. Applied to every mode,
+the same prefetch cost 0.5-2.3% on rings of 4-13 slots (long bf16 and fp8
+streams), so the gate at three slots keeps only the beneficiary.
+
+## Boundary
+
+Only for rings that are provably too shallow for the cold fetch: deeper rings
+already overlap the latency and pay the prefetch's issue slots and L2 traffic
+for nothing. Prefetch distance must stay within the tile so no out-of-range
+block is touched; guard the block index. This does not change bytes moved into
+shared memory or any barrier count, so it needs no protocol re-review, but the
+touched blocks' L2 footprint grows by the distance.
+
+## Verification
+
+Reproduce the suite's protocol before optimizing: time with a 256 MB L2 flush
+between launches and compare against a warm loop on both sides; a large
+warm/cold gap on the port only is the signature. Attribute `try_wait` retries
+per barrier from the NCU source view to confirm the operand-ready barrier is
+the one starving. After the change, re-measure the affected mode and every
+deeper-ring sibling at one long and one short shape.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/read-special-registers-at-the-use-site.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/read-special-registers-at-the-use-site.md
@@ -1,0 +1,51 @@
+# Read special registers at the use site
+
+**Symptoms:** `local_memory_traffic`, `register_spill`, `long_scoreboard`, `persistent_grid_regression`
+
+## Symptom
+
+A persistent kernel keeps a special-register value (`gridDim.x` as the
+grid stride, a rank, a lane mask) in one kernel-scope local for the whole tile
+loop. Dynamic `LDL` rises against the reference, the hottest new stall is the
+tile-increment `IMAD.IADD` whose operand comes from a local-memory fill, and the
+reference shows thousands of extra `S2R` instead.
+
+## What to change
+
+Emit the special-register read where it is consumed instead of carrying it.
+
+```python
+# before: one asm-volatile read lives across every role's persistent loop.
+num_bids = K.local_scalar("uint32", init=K.cuda.mov_sreg(32, "nctaid.x"))
+...
+K.assign(tile_idx, tile_idx + num_bids)
+
+# after: the read is re-issued at each increment; nothing stays live.
+def num_bids():
+    return K.cast(K.cuda.mov_sreg(32, "nctaid.x"), "uint32")
+...
+K.assign(tile_idx, tile_idx + num_bids())
+```
+
+## Rationale
+
+`K.cuda.mov_sreg` lowers to `asm volatile("mov.u32 %0, %nctaid.x")`. A volatile
+asm result cannot be rematerialized, so under a tight role budget ptxas spills
+it to local memory and refills it at every use; a plain PTX special-register
+read (what nvcc emits for `gridDim.x`) is rematerialized as `S2R` for free. In a
+16-warp persistent attention kernel with 192/80/48 role budgets the carried
+value cost 48 `LDL` per tile in the 80-register epilogue role and its fill sat
+on the `tile_idx += gridDim.x` critical path. Re-reading it moved the two
+streaming benchmark rows from 0.9693x to 1.0074x and from 1.0054x to 1.0457x;
+static stack fell from 352 to 336 bytes and `LDL` from 128 to 120.
+
+## Boundary
+
+A once-read local is the right form when it is consumed inside one short region
+or when the value must be provably warp-uniform for a later guard. The
+re-read costs one `S2R` per use, so keep it out of unrolled inner chains.
+
+## Verification
+
+Compare dynamic `LDL`/`STL` and `S2R` counts against the reference and confirm
+the increment's operand no longer comes from a local-memory fill in the SASS.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/reuse-one-elected-lane-predicate-across-a-transfer-group.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/reuse-one-elected-lane-predicate-across-a-transfer-group.md
@@ -60,6 +60,16 @@ equivalence did not make the three regions one profitable issue group. Hoist
 only after the source PTX/SASS shows one election governing the same contiguous
 region.
 
+A second counterexample combined this hoist with plain-scalar descriptor
+halves in a 16-warp block-scaled attention matrix-issue role (four
+`tcgen05.cp` scale copies plus two block-scaled MMAs per group, thirteen-slot
+FP4 operand ring). The two target rows did not move (18.54 and 126.07 us) and
+the long 4096-key stream regressed from 131.6 to 167.2 us (1.012x -> 0.797x).
+The two changes were applied together, so the regression is not attributed to
+either alone; the reviewed per-instruction form was restored and the sentinel
+recovered to 131.6 us. Measure the long-stream sentinel of every ring depth
+before keeping a hoist that only the latency-bound shape motivated.
+
 ## Verification
 
 Confirm in SASS that the hot loop contains one election for the logical transfer

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/specialize-an-exact-multiplicative-identity-before-tracing.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/specialize-an-exact-multiplicative-identity-before-tracing.md
@@ -1,0 +1,63 @@
+# Specialize an exact multiplicative identity before tracing
+
+**Symptoms:** `redundant_identity_math`, `slow_epilogue`, `dispatch_specific_deficit`, `instruction_count_gap`
+
+## Symptom
+
+A scalar is fixed by the compiled specialization to exactly `1.0`, but the
+kernel still receives it through a runtime pointer. Generated code loads and
+round-trips the scalar through the output format, then multiplies every output
+pair by the widened value. The runtime ABI prevents ordinary constant folding,
+so one otherwise identical specialization retains an avoidable epilogue chain.
+
+## What to change
+
+Derive the exact-identity fact from the static specialization inputs before
+tracing. Omit the load, conversion, and multiply only in that compiled branch;
+retain the pointer argument and the complete generic path.
+
+```python
+# before: a statically fixed scale remains opaque behind the runtime pointer.
+scale = _load_and_round_scale(scale_ptr, OUTPUT_DTYPE)
+for pair in range(NUM_PAIRS):
+    values[pair] = _mul_f32x2(values[pair], scale)
+
+# after: tracing emits no scale chain for the exact-identity specialization.
+scale_is_one = float(static_scale) == 1.0
+if not scale_is_one:
+    scale = _load_and_round_scale(scale_ptr, OUTPUT_DTYPE)
+    for pair in range(NUM_PAIRS):
+        values[pair] = _mul_f32x2(values[pair], scale)
+```
+
+## Rationale
+
+On one SM107 BF16 epilogue, the identity specialization removed one PTX
+`ld.global.f32`, two scalar conversion instructions, and sixteen
+`mul.f32x2`; final SASS removed all sixteen corresponding `FMUL2`
+instructions. Target time fell from 26.0168 to 25.3485 us, a 1.0264x speedup,
+while the reference/target ratio moved from 0.9893 to 1.0170. The retained
+implementation passed an exact identity-scale source/oracle comparison with
+zero differing bits, output guards, and a deterministic rerun, then passed the
+complete seven-case correctness and five-shape performance matrices.
+
+## Boundary
+
+The scalar must be compile-time fixed for that exact artifact and exactly the
+multiplicative identity under the reference's load and rounding semantics.
+Do not infer identity merely because a nearby value rounds to one unless that
+rounding is itself part of the frozen contract. Keep the generic path for every
+other scalar and preserve the public ABI when callers still pass the pointer.
+
+Skipping a floating-point instruction can change NaN quieting, denormal/FTZ
+behavior, or exception semantics even for a mathematical identity. Require
+bitwise evidence over the supported input domain; use tolerance only when the
+kernel's existing correctness contract already permits it.
+
+## Verification
+
+Compare PTX and final SASS for identity and non-identity specializations. The
+identity artifact should lose the scalar load, round-trip conversions, and
+pairwise multiplies while the generic artifact retains them. Run exact
+correctness for both branches, including exceptional values when supported,
+then run the affected and complete performance matrices.

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/sweep-register-budgets-by-role-and-shape.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/sweep-register-budgets-by-role-and-shape.md
@@ -72,6 +72,19 @@ matrix at a 0.9932x minimum. Once the target already has the shorter instruction
 stream, a register deficit plus excess consumer-release polling is a reason to
 sweep the consumer role rather than keep deleting arithmetic.
 
+The ptxas `--register-usage-level` knob has the same regime dependence and can
+flip as a step, not a slope. One 16-warp block-scaled attention forward with a
+quantized P was 18.46 us at levels 4-10 and 15.47 us at levels 1-3 on a
+single-wave grid (64 tiles on 152 SMs, eight blocks per tile; reference 16.23
+us, ratio 0.877x -> 1.049x), with identical executed-instruction counts and an
+identical softmax-role binary: only the matrix-issue and correction roles were
+rescheduled (R2UR 46 -> 25, IMAD 71 -> 48 in the issue role). The same level 3
+ran 168.8 us against 130.9 us (+28%) on the 4096-key, 24-head stream of the
+same kernel, and every other mode of the kernel measured flat across levels
+3-10. The level was therefore keyed on the grid regime (`num_tiles <= num_sms`)
+for that one specialization; a per-mode key alone would have traded the small
+shape against the long streams.
+
 ## Boundary
 
 An occupancy proof only shows that a larger budget is affordable; it does not

--- a/.agents/skills/tirx-codegen-diagnostics/references/db/tune-pipeline-shape-and-transfer-granularity.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/tune-pipeline-shape-and-transfer-granularity.md
@@ -43,10 +43,36 @@ for box in T.unroll(4):
     )
 ```
 
+Treat a separate L2-only data-prefetch stream as another compile-time pipeline
+parameter. When the staged input ring already supplies enough lookahead, try a
+specialization that omits only the `cp.async.bulk.prefetch.tensor.*.L2`
+instructions. Keep TensorMap descriptor prefetches, the real global-to-shared
+TMA loads, and their barrier protocol unchanged.
+
+```python
+# before: every specialization issues an independent L2 data-prefetch stream.
+for future_k in range(PREFETCH_DISTANCE):
+    _prefetch_input_tiles_to_l2(future_k)
+
+# after: select the stream at trace time from the measured pipeline regime.
+if ENABLE_L2_DATA_PREFETCH:
+    for future_k in range(PREFETCH_DISTANCE):
+        _prefetch_input_tiles_to_l2(future_k)
+```
+
 ## Rationale
 
 Ring depth trades buffering against footprint and stage completion timing, and
 extra TMA issue instructions often regress short shapes.
+
+Two SM107 specializations made that issue cost concrete. Disabling only the
+L2 data-prefetch stream removed eight static `UTMAL2CCTL` instructions from
+each final SASS while leaving TensorMap prefetches and functional TMA transfers
+present. One specialization moved from 17.7983 to 13.2121 us, a 1.3471x
+speedup, and its reference/target ratio moved from 0.9788 to 1.3200. A second
+moved from 15.7198 to 13.3047 us, a 1.1815x speedup, and its ratio moved from
+0.9853 to 1.1641. Both changes passed bitwise source/oracle checks and the
+complete correctness and performance matrices.
 
 ## Boundary
 
@@ -58,7 +84,19 @@ in flight when the ring was cut from four to three to fund an extra output
 stage -- two shapes near 0.99x fell to 0.92x and 0.82x, and the cut was
 reverted. Fund new stages from rings whose consumers hold no lookahead.
 
+Do not turn L2 prefetch off globally. In the measurements above, one ring
+covered its complete eleven-tile K loop, while the other covered only six of
+twelve tiles; full-loop coverage is therefore sufficient motivation to test,
+not a necessary or transferable cutoff. A sibling prefetching specialization
+that already passed was left unchanged. Cold-cache behavior, reuse distance,
+and a different producer schedule can reverse the result. The timing and
+binary diff prove the instruction removal and its effect, not which downstream
+stall counter changed.
+
 ## Verification
 
 Benchmark both sides of every dispatch boundary and validate deadlock freedom,
-footprints, registers, stage completion timing, and issue counts.
+footprints, registers, stage completion timing, and issue counts. For an
+L2-only prefetch change, confirm that `UTMAL2CCTL.PF` disappears while
+descriptor prefetches, functional TMA loads, and barrier byte counts remain;
+then test both the changed specialization and unchanged prefetching guards.

--- a/LICENSE
+++ b/LICENSE
@@ -220,6 +220,9 @@ tirx_kernels/flashinfer/ (ports of flashinfer-ai/flashinfer kernels, including
 MIT License
 -----------
 
+tirx_kernels/fastcu/ (ports of pranjalssh/fast.cu kernels; the upstream
+                      license text and copyright notice are reproduced in
+                      licenses/LICENSE.fast-cu.txt)
 tirx_kernels/deepgemm/ (ports of deepseek-ai/DeepGEMM kernels)
 tirx_kernels/flashmla/ (ports of deepseek-ai/FlashMLA kernels)
 tirx_kernels/msa/ (ports of MiniMax-AI/MSA kernels)
@@ -233,6 +236,11 @@ BSD 3-Clause "New" or "Revised" License
 
 tirx_kernels/flashattention/ (ports of Dao-AILab/flash-attention kernels; the
                               AUTHORS file its copyright notice refers to is
+                              licenses/AUTHORS.flash-attention.txt)
+tirx_kernels/flashattention/flash_attention4_fp4.py (port of hao-ai-lab/flash-attention-fp4,
+                              a fork of Dao-AILab/flash-attention; its LICENSE and
+                              flash_attn/cute/AUTHORS are byte-identical to
+                              licenses/LICENSE.flash-attention.txt and
                               licenses/AUTHORS.flash-attention.txt)
 tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py (full license text is
                               reproduced in the file header)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ High-performance GPU kernels authored in
 
 ## Kernels
 
-All registered kernels target `sm_100a`. Each linked name below is the public
-registry name accepted by `--kernel`; the link opens its implementation. Run
-`python -m tirx_kernels.registry --format json` for the authoritative config
-list.
+Registered kernels declare their CUDA target architecture in `KERNEL_META`.
+Each linked name below is the public registry name accepted by `--kernel`; the
+link opens its implementation. Run `python -m tirx_kernels.registry --format json`
+for the authoritative config list.
 
 ### Native TIRx
 
@@ -51,6 +51,7 @@ contract and results.
   [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py),
   [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
+  [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py),
   [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),
   [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
 - **CSA compression:**
@@ -117,6 +118,11 @@ Grouped by the FlashInfer Python entry point each port backs.
 - **`flashinfer.gdn_prefill`:**
   [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py),
   [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
+- **`flashinfer.cake_vsa`:**
+  [`cake_vsa_blk128_compact_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py),
+  [`cake_vsa_ultrasparse_bsr_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py),
+  [`cake_vsa_longseq_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py),
+  [`cake_vsa_longseq_sm103`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py)
 - **`flashinfer.gemm`:**
   [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py),
   [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py)
@@ -275,7 +281,7 @@ License 2.0; see [LICENSE](LICENSE). Required Apache attribution notices are
 collected in [NOTICE](NOTICE).
 
 Every Python source file carries SPDX tags. Kernel ports derived from third-party projects
-(cuDNN Frontend, DeepGEMM, FlashMLA, flash-attention, FlashInfer, MSA) additionally cite the upstream
+(cuDNN Frontend, DeepGEMM, fast.cu, FlashMLA, flash-attention, flash-attention-fp4, FlashInfer, MSA) additionally cite the upstream
 project and the exact commit ported, retain the upstream copyright notice, and
 declare the combined terms — for example `Apache-2.0 AND MIT`. Where an upstream
 license requires its conditions text to travel with the source, that text is kept

--- a/licenses/LICENSE.fast-cu.txt
+++ b/licenses/LICENSE.fast-cu.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Pranjal Shankhdhar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/reference-dependencies.json
+++ b/reference-dependencies.json
@@ -50,6 +50,13 @@
       "install_subdirectory": "flash_attn/cute"
     },
     {
+      "name": "flash-attention-fp4",
+      "import_name": "flash_attn.cute",
+      "url": "https://github.com/hao-ai-lab/flash-attention-fp4.git",
+      "revision": "5aa37a9680f7b76a11799b5f4846100ed5a3e6d8",
+      "install_subdirectory": "flash_attn/cute"
+    },
+    {
       "name": "flash-mla",
       "import_name": "flash_mla",
       "url": "https://github.com/deepseek-ai/FlashMLA.git",

--- a/scripts/install_reference_dependencies.py
+++ b/scripts/install_reference_dependencies.py
@@ -38,6 +38,29 @@ def load_lock() -> dict[str, Any]:
     return lock
 
 
+def source_patches(source: dict[str, Any]) -> list[Path]:
+    """Repository-tracked patches applied on the pinned revision (paths relative to the repo)."""
+    return [(LOCK_PATH.parent / patch).resolve() for patch in source.get("patches", [])]
+
+
+def patches_applied(source: dict[str, Any], checkout: Path) -> bool:
+    """True when the checkout carries exactly the declared patches (they reverse-apply cleanly)."""
+    patches = source_patches(source)
+    if not patches:
+        return False
+    try:
+        for patch in patches:
+            output("git", "apply", "--reverse", "--check", str(patch), cwd=checkout)
+    except subprocess.CalledProcessError:
+        return False
+    return True
+
+
+def apply_patches(source: dict[str, Any], checkout: Path) -> None:
+    for patch in source_patches(source):
+        run("git", "apply", str(patch), cwd=checkout)
+
+
 def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
     checkout = source_root / source["name"]
     revision = source["revision"]
@@ -52,7 +75,7 @@ def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
     except subprocess.CalledProcessError:
         has_head = False
     materialized = any(path.name != ".git" for path in checkout.iterdir())
-    if (
+    dirty = (
         has_head
         and materialized
         and output(
@@ -63,7 +86,9 @@ def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
             "--ignore-submodules=untracked",
             cwd=checkout,
         )
-    ):
+    )
+    already_patched = bool(dirty) and patches_applied(source, checkout)
+    if dirty and not already_patched:
         raise RuntimeError(f"reference source checkout has local changes: {checkout}")
     origin = output("git", "remote", "get-url", "origin", cwd=checkout)
     if origin.rstrip("/").removesuffix(".git") != source["url"].rstrip("/").removesuffix(".git"):
@@ -73,11 +98,14 @@ def checkout_source(source: dict[str, Any], source_root: Path) -> Path:
         output("git", "cat-file", "-e", f"{revision}^{{commit}}", cwd=checkout)
     except subprocess.CalledProcessError:
         run("git", "fetch", "--filter=blob:none", "origin", revision, cwd=checkout)
+    if already_patched and output("git", "rev-parse", "HEAD", cwd=checkout) == revision:
+        return checkout
     run("git", "checkout", "--detach", revision, cwd=checkout)
     run("git", "submodule", "update", "--init", "--recursive", cwd=checkout)
     actual = output("git", "rev-parse", "HEAD", cwd=checkout)
     if actual != revision:
         raise RuntimeError(f"{source['name']} resolved to {actual}, expected {revision}")
+    apply_patches(source, checkout)
     return checkout
 
 
@@ -262,8 +290,10 @@ def check(lock: dict[str, Any], source_root: Path, only: set[str] | None = None)
             "--ignore-submodules=untracked",
             cwd=checkout,
         )
-        if dirty:
+        if dirty and not patches_applied(source, checkout):
             failures.append(f"reference source checkout has local changes: {checkout}")
+        elif not dirty and source_patches(source):
+            failures.append(f"declared patches are not applied in {checkout}")
         try:
             materialize_source_links(source, checkout)
         except (FileNotFoundError, RuntimeError) as error:

--- a/tests/lint/check_license_headers.py
+++ b/tests/lint/check_license_headers.py
@@ -89,6 +89,11 @@ PORT_BUCKETS = {
         "https://github.com/flashinfer-ai/flashinfer",
         "Apache-2.0",
     ),
+    "tirx_kernels/fastcu/": (
+        "fast.cu",
+        "https://github.com/pranjalssh/fast.cu",
+        "Apache-2.0 AND MIT",
+    ),
     "tirx_kernels/msa/": ("MSA", "https://github.com/MiniMax-AI/MSA", "Apache-2.0 AND MIT"),
 }
 
@@ -96,6 +101,13 @@ PORT_BUCKETS = {
 # license requires to stay in the file verbatim (BSD-3 clause 1: the copyright
 # notice, the conditions list and the disclaimer travel with the source).
 FILE_OVERRIDES = {
+    # Port of hao-ai-lab/flash-attention-fp4, a fork of Dao-AILab/flash-attention whose
+    # LICENSE and flash_attn/cute/AUTHORS are byte-identical to the upstream texts under
+    # licenses/; only the canonical URL and commit history differ from the bucket.
+    "tirx_kernels/flashattention/flash_attention4_fp4.py": {
+        "project": "flash-attention-fp4",
+        "url": "https://github.com/hao-ai-lab/flash-attention-fp4",
+    },
     "tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py": {
         "spdx": "Apache-2.0 AND MIT AND BSD-3-Clause",
         "required_text": (
@@ -118,6 +130,13 @@ FILE_OVERRIDES = {
         ),
     },
     "tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py": {
+        "spdx": "Apache-2.0 AND BSD-3-Clause",
+        "required_text": (
+            "Redistribution and use in source and binary forms",
+            'THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"',
+        ),
+    },
+    "tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py": {
         "spdx": "Apache-2.0 AND BSD-3-Clause",
         "required_text": (
             "Redistribution and use in source and binary forms",
@@ -211,6 +230,8 @@ def check(rel: str, text: str) -> list[str]:
 
     project, url, spdx = expect
     override = FILE_OVERRIDES.get(rel, {})
+    project = override.get("project", project)
+    url = override.get("url", url)
     spdx = override.get("spdx", spdx)
 
     if ids[0] != spdx:
@@ -242,10 +263,16 @@ def self_test() -> int:
     cudnn = dict(project="cuDNN Frontend", url="https://github.com/NVIDIA/cudnn-frontend")
     fi = dict(project="FlashInfer", url="https://github.com/flashinfer-ai/flashinfer")
     msa = dict(project="MSA", url="https://github.com/MiniMax-AI/MSA")
+    fastcu = dict(project="fast.cu", url="https://github.com/pranjalssh/fast.cu")
     bsa_combine = "tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py"
     gdn = "tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py"
     gdn_cp = "tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py"
     bmm_fp8_rubin = "tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py"
+    fa4 = dict(project="flash-attention", url="https://github.com/Dao-AILab/flash-attention")
+    fa4_fp4 = dict(
+        project="flash-attention-fp4", url="https://github.com/hao-ai-lab/flash-attention-fp4"
+    )
+    fp4_port = "tirx_kernels/flashattention/flash_attention4_fp4.py"
     bsd_port = (
         "# Copyright (c) 2025 Upstream\n"
         "# Redistribution and use in source and binary forms\n"
@@ -253,6 +280,52 @@ def self_test() -> int:
     )
     cases = [
         # (name, rel, text, must_error)
+        (
+            "valid flash-attention-fp4 fork port",
+            fp4_port,
+            port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fa4_fp4),
+            False,
+        ),
+        (
+            "flash-attention-fp4 port citing the Dao-AILab URL",
+            fp4_port,
+            port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fa4),
+            True,
+        ),
+        (
+            "flash-attention-fp4 port naming the parent project",
+            fp4_port,
+            port.format(
+                spdx="Apache-2.0 AND BSD-3-Clause", project="flash-attention", url=fa4_fp4["url"]
+            ),
+            True,
+        ),
+        (
+            "flash-attention-fp4 port tagged plain Apache",
+            fp4_port,
+            port.format(spdx="Apache-2.0", **fa4_fp4),
+            True,
+        ),
+        (
+            "flash-attention-fp4 port missing the upstream copyright",
+            fp4_port,
+            port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fa4_fp4).replace(
+                "Copyright (c) 2025 Upstream", "2025 Upstream"
+            ),
+            True,
+        ),
+        (
+            "sibling flashattention port citing the fork URL",
+            "tirx_kernels/flashattention/x.py",
+            port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fa4_fp4),
+            True,
+        ),
+        (
+            "valid flash-attention port",
+            "tirx_kernels/flashattention/x.py",
+            port.format(spdx="Apache-2.0 AND BSD-3-Clause", **fa4),
+            False,
+        ),
         (
             "valid deepgemm port",
             "tirx_kernels/deepgemm/x.py",
@@ -264,6 +337,36 @@ def self_test() -> int:
             "tirx_kernels/cudnn/amax/x.py",
             port.format(spdx="Apache-2.0", **cudnn),
             False,
+        ),
+        (
+            "valid fast.cu port",
+            "tirx_kernels/fastcu/x.py",
+            port.format(spdx="Apache-2.0 AND MIT", **fastcu),
+            False,
+        ),
+        (
+            "fast.cu tagged plain Apache-2.0",
+            "tirx_kernels/fastcu/x.py",
+            port.format(spdx="Apache-2.0", **fastcu),
+            True,
+        ),
+        (
+            "fast.cu port citing another upstream URL",
+            "tirx_kernels/fastcu/x.py",
+            port.format(
+                spdx="Apache-2.0 AND MIT",
+                project="fast.cu",
+                url="https://github.com/deepseek-ai/DeepGEMM",
+            ),
+            True,
+        ),
+        (
+            "fast.cu port with no upstream copyright",
+            "tirx_kernels/fastcu/x.py",
+            port.format(spdx="Apache-2.0 AND MIT", **fastcu).replace(
+                ", Copyright (c) 2025 Upstream", ""
+            ),
+            True,
         ),
         (
             "valid cudnn-frontend BSD/MIT combine port",

--- a/tests/test_bench_suite_run.py
+++ b/tests/test_bench_suite_run.py
@@ -176,6 +176,21 @@ def test_default_roster_includes_curated_rubin_bmm():
     }
 
 
+def test_default_roster_includes_curated_dense_blockscaled_gemm_sm107():
+    workloads = bench_run.load_config_dir()
+    labels = {
+        workload["config"]
+        for workload in workloads
+        if workload["kernel"] == "dense_blockscaled_gemm_sm107"
+    }
+
+    assert labels == {
+        "bench_t1_mxfp4_bf16_m4096_n1024_k3072",
+        "bench_t3_mxfp4_fp16_m256_n10304_k2688",
+        "bench_t4_nvfp4_bf16_m4096_n2048_k7168",
+    }
+
+
 def test_default_roster_is_available_on_sm103_and_sm107():
     workloads = bench_run.load_config_dir()
 
@@ -183,14 +198,41 @@ def test_default_roster_is_available_on_sm103_and_sm107():
     sm103, sm103_incompatible = bench_run.partition_workloads_by_arch(workloads, "sm_103a")
     sm100, sm100_incompatible = bench_run.partition_workloads_by_arch(workloads, "sm_100a")
 
-    assert len(sm107) == 260
-    assert sm107_incompatible == []
-    assert len(sm103) == 257
-    assert len(sm103_incompatible) == 3
-    assert {workload["kernel"] for workload in sm103_incompatible} == {"bmm_fp8_rubin"}
-    assert len(sm100) == 257
-    assert len(sm100_incompatible) == 3
-    assert {workload["kernel"] for workload in sm100_incompatible} == {"bmm_fp8_rubin"}
+    def kernels(rows):
+        return {workload["kernel"] for workload in rows}
+
+    # 260 rows run everywhere; eight single-architecture kernels contribute three default rows
+    # each: cake_vsa_{blk128_compact,longseq,ultrasparse_bsr}_sm100 (sm_100a), bmm_fp8_rubin and
+    # dense_blockscaled_gemm_sm107 (sm_107a), cake_vsa_longseq_sm103, fastcu_nvfp4_gemm_gb300 and
+    # flash_attention4_fp4 (sm_103a).
+    assert len(sm107) == 266
+    assert len(sm107_incompatible) == 18
+    assert kernels(sm107_incompatible) == {
+        "cake_vsa_blk128_compact_sm100",
+        "cake_vsa_longseq_sm100",
+        "cake_vsa_longseq_sm103",
+        "cake_vsa_ultrasparse_bsr_sm100",
+        "fastcu_nvfp4_gemm_gb300",
+        "flash_attention4_fp4",
+    }
+    assert len(sm103) == 269
+    assert len(sm103_incompatible) == 15
+    assert kernels(sm103_incompatible) == {
+        "bmm_fp8_rubin",
+        "cake_vsa_blk128_compact_sm100",
+        "cake_vsa_longseq_sm100",
+        "cake_vsa_ultrasparse_bsr_sm100",
+        "dense_blockscaled_gemm_sm107",
+    }
+    assert len(sm100) == 269
+    assert len(sm100_incompatible) == 15
+    assert kernels(sm100_incompatible) == {
+        "bmm_fp8_rubin",
+        "cake_vsa_longseq_sm103",
+        "dense_blockscaled_gemm_sm107",
+        "fastcu_nvfp4_gemm_gb300",
+        "flash_attention4_fp4",
+    }
 
 
 def test_validate_workload_archs_rejects_mismatch_before_prepare(monkeypatch):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -46,11 +46,17 @@ def test_exact_architectures_are_stored_in_source_index():
     assert index
     assert all(record.runtime_cuda_archs for record in index.values())
     assert index["bmm_fp8_rubin"].runtime_cuda_archs == ("sm_107a",)
+    assert index["dense_blockscaled_gemm_sm107"].runtime_cuda_archs == ("sm_107a",)
     counts = {
         archs: sum(record.runtime_cuda_archs == archs for record in index.values())
-        for archs in (("sm_100a",), ("sm_107a",), ("sm_100a", "sm_103a", "sm_107a"))
+        for archs in (("sm_100a",), ("sm_103a",), ("sm_107a",), ("sm_100a", "sm_103a", "sm_107a"))
     }
-    assert counts == {("sm_100a",): 6, ("sm_107a",): 1, ("sm_100a", "sm_103a", "sm_107a"): 89}
+    assert counts == {
+        ("sm_100a",): 9,
+        ("sm_103a",): 3,
+        ("sm_107a",): 2,
+        ("sm_100a", "sm_103a", "sm_107a"): 90,
+    }
 
 
 def test_reference_requirements_are_stored_in_source_index():
@@ -67,8 +73,21 @@ def test_reference_requirements_are_stored_in_source_index():
         "flashinfer": ("flashinfer-python", "nvidia-cutlass-dsl"),
         "msa": ("msa", "nvidia-cutlass-dsl", "quack-kernels"),
     }
+    # Kernels whose upstream reference is not a CuTe-DSL program pin only the
+    # source project (the Cake VSA route loads a prebuilt cubin via FlashInfer's
+    # own tvm-ffi launcher).
+    expected_by_kernel = {
+        "cake_vsa_blk128_compact_sm100": ("flashinfer-python",),
+        "cake_vsa_longseq_sm100": ("flashinfer-python",),
+        "cake_vsa_longseq_sm103": ("flashinfer-python",),
+        "cake_vsa_ultrasparse_bsr_sm100": ("flashinfer-python",),
+        # The FP4 FA4 port quantizes its correctness inputs with FlashInfer.
+        "flash_attention4_fp4": ("flash-attn-4", "nvidia-cutlass-dsl", "flashinfer-python"),
+    }
     for name, record in index.items():
-        if record.category in expected_by_category:
+        if name in expected_by_kernel:
+            assert packages(name) == expected_by_kernel[name]
+        elif record.category in expected_by_category:
             assert packages(name) == expected_by_category[record.category]
 
     assert {

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -15,10 +15,12 @@ replace the direct verdict. The same flag exists on
 registered kernel has one file. Files with `default_suite: true` select one to
 three representative single-GPU rows with `default: true`; curated three-row
 files label them `small`, `medium`, and `large`. The current default roster is
-263 rows across 90 device kernels: 260 rows from 89 kernels validated on
-`sm_100a`, `sm_103a`, and `sm_107a`, plus 3 rows from the `sm_107a`-only Rubin
-BMM. Thus an SM107 run selects all 263 rows, while SM100 and SM103 runs retain
-the 260-row subset.
+284 rows across 97 device kernels: 260 rows from 89 kernels validated on
+`sm_100a`, `sm_103a`, and `sm_107a`, plus three rows each from eight
+single-architecture kernels (the `sm_107a`-only Rubin BMM and SM107 block-scaled
+GEMM, the `sm_100a`-only Cake VSA blk128/longseq/ultrasparse ports, and the
+`sm_103a`-only Cake VSA longseq, fast.cu NVFP4 GEMM, and FP4 FA4 forward). Thus
+an SM107 run selects 266 rows while SM100 and SM103 runs select 269.
 GPU runs retain only rows registered for the pool's exact architecture.
 
 With no `--workloads`, the suite writes the selected rows to

--- a/tirx_kernels/bench_suite/config/agent_evolved/agent_evolved_kda_forward_b1_t8192.yaml
+++ b/tirx_kernels/bench_suite/config/agent_evolved/agent_evolved_kda_forward_b1_t8192.yaml
@@ -1,8 +1,9 @@
 kernel: agent_evolved_kda_forward_b1_t8192
+selection_rationale: All six rows pack 8192 tokens; the defaults step up from 64 heads over eight uniform 1024-token sequences, to 96 heads over the same packing, to 96 heads over one 8192-token sequence, which carries the longest per-sequence recurrence.
 configs:
-  - {config: h96_fixed, default: true, timer: proton}
-  - {config: h96_mixed, timer: proton}
-  - {config: h96_uniform, default: true, timer: proton}
-  - {config: h64_fixed, timer: proton}
-  - {config: h64_mixed, timer: proton}
-  - {config: h64_uniform, default: true, timer: proton}
+  - {config: h96_fixed, default: true, selection_role: large, timer: proton}
+  - {config: h96_mixed, default: false, timer: proton}
+  - {config: h96_uniform, default: true, selection_role: medium, timer: proton}
+  - {config: h64_fixed, default: false, timer: proton}
+  - {config: h64_mixed, default: false, timer: proton}
+  - {config: h64_uniform, default: true, selection_role: small, timer: proton}

--- a/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn2_recompute_f16.yaml
+++ b/tirx_kernels/bench_suite/config/cudnn/linear_attention/cudnn_sm100_gdn2_recompute_f16.yaml
@@ -1,0 +1,22 @@
+# Complete production sweep for the cuDNN Frontend GDN2 state-recompute port.
+kernel: cudnn_sm100_gdn2_recompute_f16
+selection_rationale: The selected defaults cover an underfilled single-batch launch, the central four-batch production point, and the longest seeded-state workload; the full matrix sweeps production sequence lengths, batch occupancy, and both the checkpoint-only regen specialization the backward pass runs and the seeded initial/final-state one.
+configs:
+  - {config: perf_b4_s2048_h64_nostate, default: false}
+  - {config: perf_b4_s4096_h64_nostate, default: false}
+  - {config: perf_b4_s8192_h64_nostate, default: true, selection_role: medium}
+  - {config: perf_b4_s16384_h64_nostate, default: false}
+  - {config: perf_b4_s32768_h64_nostate, default: false}
+  - {config: perf_b1_s8192_h64_nostate, default: true, selection_role: small}
+  - {config: perf_b2_s8192_h64_nostate, default: false}
+  - {config: perf_b8_s8192_h64_nostate, default: false}
+  - {config: perf_b16_s8192_h64_nostate, default: false}
+  - {config: perf_b4_s2048_h64_state, default: false}
+  - {config: perf_b4_s4096_h64_state, default: false}
+  - {config: perf_b4_s8192_h64_state, default: false}
+  - {config: perf_b4_s16384_h64_state, default: false}
+  - {config: perf_b4_s32768_h64_state, default: true, selection_role: large}
+  - {config: perf_b1_s8192_h64_state, default: false}
+  - {config: perf_b2_s8192_h64_state, default: false}
+  - {config: perf_b8_s8192_h64_state, default: false}
+  - {config: perf_b16_s8192_h64_state, default: false}

--- a/tirx_kernels/bench_suite/config/fastcu/fastcu_nvfp4_gemm_gb300.yaml
+++ b/tirx_kernels/bench_suite/config/fastcu/fastcu_nvfp4_gemm_gb300.yaml
@@ -1,0 +1,8 @@
+kernel: fastcu_nvfp4_gemm_gb300
+selection_rationale: Square GEMMs at 1024, 4096, and 16384 bound the GB300 NVFP4 scaling curve; all five registered squares remain available for the port performance gate.
+configs:
+  - {config: square_1024, default: true, selection_role: small, timer: proton}
+  - {config: square_2048, default: false, timer: proton}
+  - {config: square_4096, default: true, selection_role: medium, timer: proton}
+  - {config: square_8192, default: false, timer: proton}
+  - {config: square_16384, default: true, selection_role: large, timer: proton}

--- a/tirx_kernels/bench_suite/config/flashattention/flash_attention4_fp4.yaml
+++ b/tirx_kernels/bench_suite/config/flashattention/flash_attention4_fp4.yaml
@@ -1,0 +1,81 @@
+# Three reviewed default points span the launch-latency regime (s=1024: 8x16 tiles, below one
+# 152-SM wave), the causal GQA LPT-scheduled regime, and the MMA/softmax-bound persistent
+# regime, across both QK formats and the bf16/fp8 PV paths. Every other point of the upstream
+# GB300 headline table and causal-GQA sweep stays benchable on request.
+kernel: flash_attention4_fp4
+selection_rationale: Sequence length grows from 1024 (launch-latency bound, tile count below one 152-SM wave) through the causal GQA s=4096 LPT-scheduled point to the s=32768 h=24 MMA-bound persistent point, while spanning NVFP4 and MXFP8 QK and the bf16/fp8 PV paths.
+configs:
+  - {config: nvfp4_bf16_b1_s256_h16kv16_d128, default: false}
+  - {config: nvfp4_bf16_b1_s1024_h16kv16_d128, default: true, selection_role: small}
+  - {config: nvfp4_bf16_b4_s4096_h16kv16_d128, default: false}
+  - {config: nvfp4_bf16_b1_s32768_h16kv16_d128, default: false}
+  - {config: nvfp4_bf16_b4_s4096_h32kv32_d128, default: false}
+  - {config: nvfp4_bf16_b1_s4096_h12kv12_d128, default: false}
+  - {config: nvfp4_bf16_b1_s32768_h12kv12_d128, default: false}
+  - {config: nvfp4_bf16_b1_s4096_h24kv24_d128, default: false}
+  - {config: nvfp4_bf16_b1_s32768_h24kv24_d128, default: false}
+  - {config: nvfp4_fp8_b1_s256_h16kv16_d128, default: false}
+  - {config: nvfp4_fp8_b1_s1024_h16kv16_d128, default: false}
+  - {config: nvfp4_fp8_b4_s4096_h16kv16_d128, default: false}
+  - {config: nvfp4_fp8_b1_s32768_h16kv16_d128, default: false}
+  - {config: nvfp4_fp8_b4_s4096_h32kv32_d128, default: false}
+  - {config: nvfp4_fp8_b1_s4096_h12kv12_d128, default: false}
+  - {config: nvfp4_fp8_b1_s32768_h12kv12_d128, default: false}
+  - {config: nvfp4_fp8_b1_s4096_h24kv24_d128, default: false}
+  - {config: nvfp4_fp8_b1_s32768_h24kv24_d128, default: true, selection_role: large}
+  - {config: nvfp4_nvfp4_b1_s256_h16kv16_d128, default: false}
+  - {config: nvfp4_nvfp4_b1_s1024_h16kv16_d128, default: false}
+  - {config: nvfp4_nvfp4_b4_s4096_h16kv16_d128, default: false}
+  - {config: nvfp4_nvfp4_b1_s32768_h16kv16_d128, default: false}
+  - {config: nvfp4_nvfp4_b4_s4096_h32kv32_d128, default: false}
+  - {config: nvfp4_nvfp4_b1_s4096_h12kv12_d128, default: false}
+  - {config: nvfp4_nvfp4_b1_s32768_h12kv12_d128, default: false}
+  - {config: nvfp4_nvfp4_b1_s4096_h24kv24_d128, default: false}
+  - {config: nvfp4_nvfp4_b1_s32768_h24kv24_d128, default: false}
+  - {config: nvfp4_mxfp8_b1_s256_h16kv16_d128, default: false}
+  - {config: nvfp4_mxfp8_b1_s1024_h16kv16_d128, default: false}
+  - {config: nvfp4_mxfp8_b4_s4096_h16kv16_d128, default: false}
+  - {config: nvfp4_mxfp8_b1_s32768_h16kv16_d128, default: false}
+  - {config: nvfp4_mxfp8_b4_s4096_h32kv32_d128, default: false}
+  - {config: nvfp4_mxfp8_b1_s4096_h12kv12_d128, default: false}
+  - {config: nvfp4_mxfp8_b1_s32768_h12kv12_d128, default: false}
+  - {config: nvfp4_mxfp8_b1_s4096_h24kv24_d128, default: false}
+  - {config: nvfp4_mxfp8_b1_s32768_h24kv24_d128, default: false}
+  - {config: mxfp8_bf16_b1_s256_h16kv16_d128, default: false}
+  - {config: mxfp8_bf16_b1_s1024_h16kv16_d128, default: false}
+  - {config: mxfp8_bf16_b4_s4096_h16kv16_d128, default: false}
+  - {config: mxfp8_bf16_b1_s32768_h16kv16_d128, default: false}
+  - {config: mxfp8_bf16_b4_s4096_h32kv32_d128, default: false}
+  - {config: mxfp8_bf16_b1_s4096_h12kv12_d128, default: false}
+  - {config: mxfp8_bf16_b1_s32768_h12kv12_d128, default: false}
+  - {config: mxfp8_bf16_b1_s4096_h24kv24_d128, default: false}
+  - {config: mxfp8_bf16_b1_s32768_h24kv24_d128, default: false}
+  - {config: mxfp8_fp8_b1_s256_h16kv16_d128, default: false}
+  - {config: mxfp8_fp8_b1_s1024_h16kv16_d128, default: false}
+  - {config: mxfp8_fp8_b4_s4096_h16kv16_d128, default: false}
+  - {config: mxfp8_fp8_b1_s32768_h16kv16_d128, default: false}
+  - {config: mxfp8_fp8_b4_s4096_h32kv32_d128, default: false}
+  - {config: mxfp8_fp8_b1_s4096_h12kv12_d128, default: false}
+  - {config: mxfp8_fp8_b1_s32768_h12kv12_d128, default: false}
+  - {config: mxfp8_fp8_b1_s4096_h24kv24_d128, default: false}
+  - {config: mxfp8_fp8_b1_s32768_h24kv24_d128, default: false}
+  - {config: nvfp4_bf16_b1_s32768_h24kv24_d64, default: false}
+  - {config: nvfp4_fp8_b1_s32768_h24kv24_d64, default: false}
+  - {config: nvfp4_bf16_b1_s1024_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_bf16_b1_s2048_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_bf16_b1_s4096_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_bf16_b1_s8192_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_bf16_b1_s16384_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_bf16_b1_s32768_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_fp8_b1_s1024_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_fp8_b1_s2048_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_fp8_b1_s4096_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_fp8_b1_s8192_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_fp8_b1_s16384_h32kv8_d128_causal, default: false}
+  - {config: nvfp4_fp8_b1_s32768_h32kv8_d128_causal, default: false}
+  - {config: mxfp8_fp8_b1_s1024_h32kv8_d128_causal, default: false}
+  - {config: mxfp8_fp8_b1_s2048_h32kv8_d128_causal, default: false}
+  - {config: mxfp8_fp8_b1_s4096_h32kv8_d128_causal, default: true, selection_role: medium}
+  - {config: mxfp8_fp8_b1_s8192_h32kv8_d128_causal, default: false}
+  - {config: mxfp8_fp8_b1_s16384_h32kv8_d128_causal, default: false}
+  - {config: mxfp8_fp8_b1_s32768_h32kv8_d128_causal, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+kernel: cake_vsa_blk128_compact_sm100
+selection_rationale: The three defaults span the blk128_compact dispatch domain by scale and density (4K tokens with 8 heads and 8 selected blocks, 16K tokens with 16 heads and 16 selected blocks plus LSE output, 32K tokens with 24 heads and 32 selected blocks); the non-default rows add the very sparse prologue-bound regime, the 64-block capacity regime with LSE, and a 40-head low-density video-DiT shape.
+defaults:
+  num_gpus: 1
+configs:
+  - {config: m4096_n4096_h8_sel8, default: true, selection_role: small}
+  - {config: m16384_n16384_h16_sel16_lse, default: true, selection_role: medium}
+  - {config: m32768_n32768_h24_sel32, default: true, selection_role: large}
+  - {config: m2048_n8192_h8_sel4, default: false}
+  - {config: m8192_n8192_h8_sel64_lse, default: false}
+  - {config: m32768_n32768_h40_sel12, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_longseq_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_longseq_sm100.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+kernel: cake_vsa_longseq_sm100
+selection_rationale: The three defaults span the longseq fixed-top-k dispatch domain by sparse-work scale (4K query tokens with one selected block, 16K query tokens with 32 selected blocks, and 8K query tokens at the 192-block capacity); the non-default rows add an eight-block prologue-sensitive case, a larger 64-block query sweep, and a 128-block streaming regime.
+defaults:
+  num_gpus: 1
+configs:
+  - {config: m4096_n16384_h8_sel1, default: true, selection_role: small}
+  - {config: m16384_n32768_h8_sel32, default: true, selection_role: medium}
+  - {config: m8192_n32768_h8_sel192, default: true, selection_role: large}
+  - {config: m4096_n16384_h8_sel8, default: false}
+  - {config: m32768_n65536_h8_sel64, default: false}
+  - {config: m8192_n24576_h8_sel128, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_longseq_sm103.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_longseq_sm103.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+kernel: cake_vsa_longseq_sm103
+selection_rationale: The three defaults span the longseq dispatch domain by query count, KV length, and selected-block density (2K/16K with 8 blocks, 8K/32K with 64 blocks, and 32K/128K at the 192-block capacity); the non-default rows isolate large-KV sparse prologue pressure, a locality-rich 32-block window, and the amplified-Q rescale path.
+defaults:
+  num_gpus: 1
+configs:
+  - {config: m2048_n16384_h8_sel8, default: true, selection_role: small}
+  - {config: m8192_n32768_h8_sel64, default: true, selection_role: medium}
+  - {config: m32768_n131072_h8_sel192, default: true, selection_role: large}
+  - {config: m2048_n131072_h8_sel8, default: false}
+  - {config: m16384_n32768_h8_sel32_window, default: false}
+  - {config: m8192_n65536_h8_sel64_kramp, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.yaml
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+kernel: cake_vsa_ultrasparse_bsr_sm100
+selection_rationale: The three defaults span the ultrasparse_bsr dispatch domain (8 MHA heads, exactly six shared BSR blocks per 128-row query block, at least 625 query blocks, persistent grid of min(mb*8, SM count) CTAs) by scale (80000 tokens with 5000 tiles and an uneven persistent tail, 131072 tokens with 8192 tiles and 67 MB K/V gathers, 262144 tokens with 16384 tiles and 268 MB K/V); the non-default rows add the six-block dense regime with L2-resident K/V, a diagonal window with high L2 reuse across adjacent persistent tiles, and a banded K-amplified pattern that keeps the O-rescale branch active.
+defaults:
+  num_gpus: 1
+configs:
+  - {config: m80000_n8192_h8_sel6, default: true, selection_role: small}
+  - {config: m131072_n32768_h8_sel6, default: true, selection_role: medium}
+  - {config: m262144_n131072_h8_sel6, default: true, selection_role: large}
+  - {config: m80256_n768_h8_sel6_dense, default: false}
+  - {config: m131072_n16384_h8_sel6_window, default: false}
+  - {config: m80000_n4096_h8_sel6_kramp, default: false}

--- a/tirx_kernels/bench_suite/config/flashinfer/gemm/dense_blockscaled_gemm_sm107.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/gemm/dense_blockscaled_gemm_sm107.yaml
@@ -1,0 +1,9 @@
+kernel: dense_blockscaled_gemm_sm107
+default_suite: true
+selection_rationale: The complete five-row matrix covers every frozen source tactic, both FP4 scale formats, both output dtypes, one-CTA and two-CTA MMA, B reuse, operand swapping, and 1x1, 1x2, and 2x1 clusters. The selected defaults retain a narrow/long one-CTA case plus medium and large two-CTA cases.
+configs:
+  - {config: bench_t0_nvfp4_fp16_m4096_n2048_k7168, default: false}
+  - {config: bench_t1_mxfp4_bf16_m4096_n1024_k3072, default: true, selection_role: medium}
+  - {config: bench_t2_nvfp4_fp16_m1024_n4096_k3072, default: false}
+  - {config: bench_t3_mxfp4_fp16_m256_n10304_k2688, default: true, selection_role: small}
+  - {config: bench_t4_nvfp4_bf16_m4096_n2048_k7168, default: true, selection_role: large}

--- a/tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py
@@ -1,0 +1,2830 @@
+# This file is a TIRx port of code from cuDNN Frontend
+# (https://github.com/NVIDIA/cudnn-frontend @ aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5), Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Blackwell FP16/BF16 Gated DeltaNet v2 state-recompute kernels.
+
+Upstream source:
+``python/cudnn/linear_attention/frost/kernel/gdn2_recompute_f16.py``
+(``prologue_kernel``, ``kernel``, and the two-launch ``run_recompute`` entry,
+driven by ``chunk_gdn2_recompute_sm100``).
+"""
+
+import tirx_kernels.kern as K
+from tvm.ir.type import PointerType, PrimType
+
+KERNEL_META = {
+    "name": "cudnn_sm100_gdn2_recompute_f16",
+    "category": "cudnn",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "nvidia-cudnn-frontend",
+            "git": {
+                "url": "https://github.com/NVIDIA/cudnn-frontend.git",
+                "commit": "aded9909c3c2a897fdbc7b5fd79fa53bc915f4f5",
+            },
+            "import": "cudnn",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
+
+# Deterministic pairwise cover of the frozen legal capability set.  Candidates
+# are scored by uncovered pairs, ties use the categorical label order, and a
+# reverse pass removes redundant cases.  Ragged cases include zero- and
+# one-token sequences while retaining a nonzero TensorMap outer dimension.
+CONFIGS = [
+    {
+        "label": "pairwise_00",
+        "seq_lens": (31, 0, 63, 1),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 4,
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 16,
+        "l2norm": True,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_01",
+        "seq_lens": (17, 65),
+        "heads": 1,
+        "io_dtype": "float16",
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 32,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+    },
+    {
+        "label": "pairwise_02",
+        "seq_lens": (17, 65),
+        "heads": 1,
+        "io_dtype": "float16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "checkpoint_every_n_tokens": 48,
+        "l2norm": True,
+    },
+    {
+        "label": "pairwise_03",
+        "seq_lens": (31, 0, 63, 1),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 4,
+        "io_dtype": "float16",
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 16,
+        "l2norm": True,
+        "order_generate": False,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_04",
+        "seq_lens": (96,),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "io_dtype": "float16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_05",
+        "seq_lens": (31, 0, 63, 1),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "state_dtype": "bfloat16",
+        "checkpoint_every_n_tokens": 48,
+        "safe_gate": True,
+        "beta_sigmoid": True,
+        "dynamic_scheduler": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_06",
+        "seq_lens": (96,),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 4,
+        "state_dtype": "bfloat16",
+        "cu_dtype": "int64",
+        "use_initial_state": True,
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 32,
+        "l2norm": True,
+        "safe_gate": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_07",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 4,
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 48,
+        "order_generate": False,
+        "split": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_08",
+        "seq_lens": (31, 0, 63, 1),
+        "heads": 1,
+        "state_dtype": "bfloat16",
+        "use_initial_state": True,
+        "store_final_state": True,
+        "l2norm": True,
+        "safe_gate": True,
+        "dynamic_scheduler": True,
+    },
+    {
+        "label": "pairwise_09",
+        "seq_lens": (31, 0, 63, 1),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "cu_dtype": "int64",
+        "checkpoint_every_n_tokens": 32,
+        "l2norm": True,
+        "beta_sigmoid": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_10",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 16,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_11",
+        "seq_lens": (96,),
+        "heads": 1,
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 16,
+    },
+    {
+        "label": "pairwise_12",
+        "seq_lens": (17, 65),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 4,
+        "state_dtype": "bfloat16",
+        "store_final_state": True,
+        "num_sms": 2,
+    },
+    {
+        "label": "pairwise_13",
+        "seq_lens": (96,),
+        "heads": 4,
+        "k_heads": 4,
+        "v_heads": 2,
+        "store_final_state": False,
+        "checkpoint_every_n_tokens": 48,
+        "num_sms": 2,
+    },
+]
+
+BENCH_CONFIGS = [
+    {
+        "label": f"perf_b{batch}_s{seqlen}_h64_{mode}",
+        "seq_lens": (seqlen,) * batch,
+        "heads": 64,
+        "l2norm": True,
+        "dynamic_scheduler": True,
+        "checkpoint_every_n_tokens": 16,
+        **(
+            {"use_initial_state": True, "store_final_state": True}
+            if mode == "state"
+            else {"store_final_state": False}
+        ),
+    }
+    for mode in ("nostate", "state")
+    for batch, seqlen in (
+        (4, 2048),
+        (4, 4096),
+        (4, 8192),
+        (4, 16384),
+        (4, 32768),
+        (1, 8192),
+        (2, 8192),
+        (8, 8192),
+        (16, 8192),
+    )
+]
+
+
+_BT = 16
+_DK = 128
+_DV = 128
+_TENSOR_MAP_BYTES = 128
+_TENSOR_MAP_WORDS = 16
+_TENSOR_MAP_ARRAYS = 6
+_TRY_WAIT_TICKS = 10_000_000
+_LOG2_E = 1.4426950408889634
+_L2_NORM_EPS2 = 1.0e-24
+_TMA_G2S_3D = "cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes"
+_TMA_S2G_3D = "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+_TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+
+_NORMAL_PROTOCOL = (
+    (0, 48, 6, 5, 1, 128, 14),
+    (88, 136, 6, 5, 1, 128, 14),
+    (176, 224, 6, 5, 1, 128, 14),
+    (264, 312, 6, 5, 1, 128, 14),
+    (352, 400, 6, 5, 1, 128, 14),
+    (440, None, 1, 0, 1, None, 13),
+    (448, None, 1, 0, 1, None, 13),
+    (456, None, 1, 0, 128, None, 13),
+    (464, None, 1, 0, 128, None, 13),
+    (472, None, 1, 0, 128, None, 13),
+    (480, 496, 2, 2, 128, 1, 12),
+    (512, None, 2, 0, 32, None, 13),
+    (528, None, 2, 0, 1, None, 13),
+    (544, None, 4, 0, 128, None, 12),
+    (576, None, 4, 0, 1, None, 13),
+    (608, 624, 2, 2, 32, 1, 12),
+    (640, None, 1, 0, 128, None, 15),
+    (648, None, 1, 0, 128, None, 13),
+    (656, 664, 1, 1, 128, 32, 15),
+    (672, 736, 8, 8, 1, 15, 15),
+)
+
+_CHECKPOINT_PROTOCOL = (
+    (0, 32, 4, 4, 1, 128, 14),
+    (64, 96, 4, 4, 1, 128, 14),
+    (128, 160, 4, 4, 1, 128, 14),
+    (192, 224, 4, 4, 1, 128, 14),
+    (256, 288, 4, 4, 1, 128, 14),
+    (320, None, 1, 0, 1, None, 13),
+    (328, None, 1, 0, 1, None, 13),
+    (336, None, 1, 0, 128, None, 13),
+    (344, None, 1, 0, 128, None, 13),
+    (352, None, 1, 0, 128, None, 13),
+    (360, 376, 2, 2, 128, 1, 12),
+    (392, None, 2, 0, 32, None, 13),
+    (408, None, 2, 0, 1, None, 13),
+    (424, None, 4, 0, 128, None, 12),
+    (456, None, 4, 0, 1, None, 13),
+    (488, 504, 2, 2, 32, 1, 12),
+    (520, None, 1, 0, 128, None, 15),
+    (528, None, 1, 0, 128, None, 13),
+    (536, 552, 2, 2, 128, 32, 15),
+    (568, 632, 8, 8, 1, 15, 15),
+)
+
+
+def _elected():
+    lane = K.local_scalar("uint32")
+    pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(lane, pred, K.uint32(0xFFFFFFFF))
+    return pred == K.uint32(1)
+
+
+def _copy_tensormap(src_map, dst):
+    """Copy one grid-constant TensorMap parameter into descriptor workspace."""
+    source = K.decl_buffer(
+        (_TENSOR_MAP_WORDS,),
+        K.u64,
+        data=K.reinterpret(PointerType(PrimType("uint64"), "param"), K.address_of(src_map)),
+        scope="param",
+    )
+    target = K.reinterpret("uint64", dst)
+    for group in range(4):
+        for word in range(4):
+            K.ptx.st.global_.b64(
+                K.reinterpret("handle", target + K.uint64((group * 4 + word) * 8)),
+                source[group * 4 + word],
+            )
+
+
+def _replace_tensormap_address(desc, address):
+    K.ptx.tensormap_replace.tile.global_address.global_.b1024.b64(
+        desc, K.reinterpret("uint64", address)
+    )
+
+
+def _replace_tensormap_dim(desc, ordinal, value):
+    K.ptx.tensormap_replace.tile.global_dim.global_.b1024.b32(
+        desc, K.uint32(ordinal), K.cast(value, "uint32")
+    )
+
+
+def _barrier_ptr(arena, byte_offset, stage=0):
+    return arena.ptr_to([byte_offset + K.cast(stage, "int32") * 8])
+
+
+def _wait_barrier(arena, byte_offset, stage, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+            ready,
+            _barrier_ptr(arena, byte_offset, stage),
+            K.cast(phase, "uint32"),
+            K.uint32(_TRY_WAIT_TICKS),
+        )
+
+
+def _arrive_barrier(arena, byte_offset, stage=0):
+    K.ptx.mbarrier.arrive.shared.b64(_barrier_ptr(arena, byte_offset, stage))
+
+
+def _expect_tx(arena, byte_offset, stage, nbytes):
+    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+        _barrier_ptr(arena, byte_offset, stage), K.uint32(nbytes)
+    )
+
+
+def _tcgen_commit(arena, byte_offset, stage=0, *, leader):
+    K.ptx.tcgen05.commit.cta_group__1.mbarrier__arrive__one.shared__cluster.b64(
+        _barrier_ptr(arena, byte_offset, stage), pred=leader
+    )
+
+
+def _load_work_item(work_items, tile):
+    values = K.alloc_local((8,), "int32")
+    K.ptx.ld.global_.v4.b32(
+        values[0], values[1], values[2], values[3], work_items.ptr_to([tile * 8])
+    )
+    K.ptx.ld.global_.v4.b32(
+        values[4], values[5], values[6], values[7], work_items.ptr_to([tile * 8 + 4])
+    )
+    return values
+
+
+def _load_cu(cu_seqlens, index, cu_dtype):
+    if cu_dtype == "int64":
+        wide = K.local_scalar("int64")
+        K.ptx.ld.global_.s64(wide, cu_seqlens.ptr_to([index]))
+        return K.cast(wide, "int32")
+    value = K.local_scalar("int32")
+    K.ptx.ld.global_.s32(value, cu_seqlens.ptr_to([index]))
+    return value
+
+
+def _load_state_value(pointer, index, state_dtype):
+    value = K.local_scalar("float32")
+    if state_dtype == "float32":
+        K.ptx.ld.global_.f32(value, pointer.ptr_to([index]))
+    else:
+        bits = K.local_scalar("uint16")
+        K.ptx.ld.global_.b16(bits, pointer.ptr_to([index]))
+        K.ptx.cvt.f32.bf16(value, bits)
+    return value
+
+
+def _store_state_value(pointer, index, value, state_dtype):
+    if state_dtype == "float32":
+        K.ptx.st.global_.f32(pointer.ptr_to([index]), value)
+    else:
+        K.ptx.st.global_.b16(
+            pointer.ptr_to([index]), K.reinterpret("uint16", K.cast(value, "bfloat16"))
+        )
+
+
+def _descriptor_slot(workspace, n_desc, array, batch):
+    return workspace.ptr_to([(K.cast(array, "int64") * n_desc + batch) * _TENSOR_MAP_WORDS])
+
+
+def _pack_io_pair(lo, hi, io_dtype):
+    packed = K.local_scalar("uint32")
+    if io_dtype == "float16":
+        K.ptx.cvt.rn.f16x2.f32(packed, hi, lo)
+    else:
+        K.ptx.cvt.rn.bf16x2.f32(packed, hi, lo)
+    return packed
+
+
+def _unpack_io_pair(packed, lo, hi, io_dtype):
+    low = K.cast(K.bitwise_and(packed, K.uint32(0xFFFF)), "uint16")
+    high = K.cast(K.shift_right(packed, K.uint32(16)), "uint16")
+    if io_dtype == "float16":
+        K.assign(lo, K.cast(K.reinterpret("float16", low), "float32"))
+        K.assign(hi, K.cast(K.reinterpret("float16", high), "float32"))
+    else:
+        K.ptx.cvt.f32.bf16(lo, low)
+        K.ptx.cvt.f32.bf16(hi, high)
+
+
+def _load_state_block_128b(pointer, index, values, state_dtype):
+    """Load one 32-value state block using the source's 16-byte accesses."""
+    if state_dtype == "float32":
+        for group in range(8):
+            key = group * 4
+            K.ptx.ld.global_.v4.f32(
+                values[key],
+                values[key + 1],
+                values[key + 2],
+                values[key + 3],
+                pointer.ptr_to([index + key]),
+            )
+    else:
+        for group in range(4):
+            key = group * 8
+            words = K.alloc_local((4,), "uint32")
+            K.ptx.ld.global_.v4.b32(
+                words[0], words[1], words[2], words[3], pointer.ptr_to([index + key])
+            )
+            for pair in range(4):
+                _unpack_io_pair(
+                    words[pair], values[key + pair * 2], values[key + pair * 2 + 1], state_dtype
+                )
+
+
+def _mul_io_pair(dst, lhs, rhs, io_dtype):
+    if io_dtype == "float16":
+        K.ptx.mul.f16x2(dst, lhs, rhs)
+    else:
+        K.ptx.mul.bf16x2(dst, lhs, rhs)
+
+
+def _sub_io_pair(dst, lhs, rhs, io_dtype):
+    if io_dtype == "float16":
+        K.ptx.sub.f16x2(dst, lhs, rhs)
+    else:
+        K.ptx["sub.bf16x2"](dst, lhs, rhs)
+
+
+def _movmatrix_b16(value):
+    result = K.local_scalar("uint32")
+    K.ptx["movmatrix.sync.aligned.m8n8.trans.b16"](result, value)
+    return result
+
+
+def _mma_m16n16k16(acc, a, b, io_dtype):
+    opcode = (
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"
+        if io_dtype == "float16"
+        else "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32"
+    )
+    K.ptx[opcode](
+        acc[0],
+        acc[1],
+        acc[2],
+        acc[3],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b[0],
+        b[1],
+        acc[0],
+        acc[1],
+        acc[2],
+        acc[3],
+    )
+    K.ptx[opcode](
+        acc[4],
+        acc[5],
+        acc[6],
+        acc[7],
+        a[0],
+        a[1],
+        a[2],
+        a[3],
+        b[2],
+        b[3],
+        acc[4],
+        acc[5],
+        acc[6],
+        acc[7],
+    )
+
+
+def _fadd2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.add.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _fmul2(a0, a1, b0, b1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.mul.rn.f32x2(packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1))
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _ffma2(a0, a1, b0, b1, c0, c1):
+    packed = K.local_scalar("uint64")
+    out0 = K.local_scalar("float32")
+    out1 = K.local_scalar("float32")
+    K.ptx.fma.rn.f32x2(
+        packed, K.cuda.make_float2(a0, a1), K.cuda.make_float2(b0, b1), K.cuda.make_float2(c0, c1)
+    )
+    K.ptx.mov.b64(out0, out1, packed)
+    return out0, out1
+
+
+def _shuffle_xor_f32(value, delta):
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        shuffled,
+        K.reinterpret("uint32", value),
+        K.uint32(delta),
+        K.uint32(31),
+        K.uint32(0xFFFFFFFF),
+    )
+    return K.reinterpret("float32", shuffled)
+
+
+def _exp2(value):
+    result = K.local_scalar("float32")
+    K.ptx.ex2.approx.ftz.f32(result, value)
+    return result
+
+
+def _rcp(value):
+    result = K.local_scalar("float32")
+    K.ptx.rcp.approx.ftz.f32(result, value)
+    return result
+
+
+def _rsqrt(value):
+    result = K.local_scalar("float32")
+    K.ptx.rsqrt.approx.ftz.f32(result, value)
+    return result
+
+
+def _tanh(value):
+    result = K.local_scalar("float32")
+    K.ptx.tanh.approx.f32(result, value)
+    return result
+
+
+def _opaque_one():
+    zero = K.local_scalar("float32")
+    K.ptx.mov.b32(zero, K.uint32(0))
+    return zero + K.float32(1.0)
+
+
+def _raw_descriptor(arena, byte_offset, leading_bytes, stride_bytes, layout):
+    shared = K.cuda.cvta_generic_to_shared(arena.ptr_to([byte_offset]))
+    address = K.bitwise_and(K.shift_right(shared, K.uint32(4)), K.uint32(0x3FFF))
+    fixed = (
+        (((leading_bytes >> 4) & 0x3FFF) << 16) | (((stride_bytes >> 4) & 0x3FFF) << 32) | (1 << 46)
+    )
+    desc = K.bitwise_or(K.uint64(fixed), K.cast(address, "uint64"))
+    return K.bitwise_or(desc, K.shift_left(K.uint64(layout & 7), K.uint64(61)))
+
+
+def _swizzle_xor_128b(row, column, elem_bytes):
+    return K.bitwise_xor(column, (row & 7) * (16 // elem_bytes))
+
+
+def _raw_io_byte(base, stage, token, channel):
+    segment = channel // 64
+    within = channel - segment * 64
+    element = segment * 1024 + token * 64 + _swizzle_xor_128b(token, within, 2)
+    return base + stage * 4096 + element * 2
+
+
+def _raw_f32_byte(base, stage, token, channel):
+    segment = channel // 32
+    within = channel - segment * 32
+    element = segment * 512 + token * 32 + _swizzle_xor_128b(token, within, 4)
+    return base + stage * 8192 + element * 4
+
+
+def _tmem_cell(base, row, column):
+    return base + column + K.shift_left(row, K.int32(16))
+
+
+def _tcgen_mma_ts(
+    dst, tmem_a, b_desc, idesc, *, n, k_extent, leader, b_transpose=False, accumulate=False
+):
+    inner_bytes = (n if b_transpose else k_extent) * 2
+    swizzle_b = 128 if inner_bytes % 128 == 0 else 64 if inner_bytes % 64 == 0 else 32
+    intra_b = 16 * swizzle_b if b_transpose else 32
+    subtile_b = k_extent * swizzle_b if b_transpose else swizzle_b * n
+    steps_b = k_extent // 16 if b_transpose else (swizzle_b // 2) // 16
+    for step in range(k_extent // 16):
+        inc_b = (intra_b * (step % steps_b) + subtile_b * (step // steps_b)) >> 4
+        K.ptx["tcgen05.mma.cta_group::1.kind::f16"](
+            K.cast(dst, "uint32"),
+            K.cast(tmem_a + step * 8, "uint32"),
+            b_desc + K.uint64(inc_b),
+            K.uint32(idesc),
+            0,
+            0,
+            0,
+            0,
+            K.ptx.pred(accumulate if step == 0 else 1),
+            pred=leader,
+        )
+
+
+def _make_prologue(
+    *, run_order, order_generate, dynamic_scheduler, n_heads_out, checkpoints, cu_dtype
+):
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+
+    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    def prologue(
+        base_k: K.TensorMap,
+        base_v: K.TensorMap,
+        base_gate: K.TensorMap,
+        base_beta: K.TensorMap,
+        base_w: K.TensorMap,
+        base_checkpoint: K.TensorMap,
+        descriptor_workspace: K.gptr[K.i64],
+        cu_seqlens: K.gptr[cu_t],
+        k: K.gptr[K.u8],
+        v: K.gptr[K.u8],
+        gate: K.gptr[K.u8],
+        beta: K.gptr[K.u8],
+        w: K.gptr[K.u8],
+        checkpoint: K.gptr[K.u8],
+        work_item_staging: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        work_items: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        n_batch: K.i32,
+        k_row_stride_bytes: K.i32,
+        v_row_stride_bytes: K.i32,
+        gate_row_stride_bytes: K.i32,
+        beta_row_stride_bytes: K.i32,
+        w_row_stride_bytes: K.i32,
+        checkpoint_row_stride_bytes: K.i32,
+        checkpoint_every_n: K.i32,
+    ):
+        thread = K.thread_id()
+        warp = K.warp_id()
+        if run_order:
+            order_arena = K.alloc_buffer((32_776,), K.u8, scope="shared.dyn", align=16)
+            with K.If(thread == 0), K.Then():
+                if dynamic_scheduler:
+                    for slot in range(4):
+                        K.ptx.st.global_.s32(scheduler.ptr_to([slot]), K.int32(0))
+
+            item_count = K.local_scalar("int32")
+            if order_generate:
+                K.assign(item_count, n_batch * n_heads_out)
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.global_.s32(work_count.ptr_to([0]), item_count)
+            else:
+                K.ptx.ld.global_.s32(item_count, work_count.ptr_to([0]))
+
+            def write_work_item(destination, source):
+                if order_generate:
+                    batch = source // n_heads_out
+                    head = source - batch * n_heads_out
+                    begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                    end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                    chunks = (end - begin + _BT - 1) // _BT
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8]), batch, head, K.int32(0), chunks
+                    )
+                    K.ptx.st.global_.v4.b32(
+                        work_items.ptr_to([destination * 8 + 4]), K.int32(0), chunks, begin, end
+                    )
+                else:
+                    for field in range(8):
+                        value = K.local_scalar("int32")
+                        K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
+                        K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
+
+            with K.If(item_count > 4096), K.Then():
+                item = K.local_scalar("int32", init=thread)
+                with K.While(item < item_count):
+                    write_work_item(item, item)
+                    K.assign(item, item + 1024)
+            with K.If(item_count <= 4096), K.Then():
+                with K.If(thread == 0), K.Then():
+                    K.ptx.st.shared.v2.u32(
+                        order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
+                    )
+                padded_count = K.local_scalar("int32", init=K.int32(1))
+                with K.While(padded_count < item_count):
+                    K.assign(padded_count, padded_count * 2)
+                K.cuda.cta_sync()
+                local_min = K.local_scalar("int32", init=K.int32(2_147_483_647))
+                local_max = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                for element in range(4):
+                    item = thread + element * 1024
+                    with K.If(item < padded_count), K.Then():
+                        key = K.local_scalar("int32", init=K.int32(-2_147_483_648))
+                        with K.If(item < item_count), K.Then():
+                            if order_generate:
+                                batch = item // n_heads_out
+                                begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                                end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                                K.assign(key, (end - begin + _BT - 1) // _BT)
+                            else:
+                                cstart = K.local_scalar("int32")
+                                cend = K.local_scalar("int32")
+                                K.ptx.ld.global_.s32(
+                                    cstart, work_item_staging.ptr_to([item * 8 + 4])
+                                )
+                                K.ptx.ld.global_.s32(cend, work_item_staging.ptr_to([item * 8 + 5]))
+                                K.assign(key, cend - cstart)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key)
+                        K.ptx.st.shared.s32(order_arena.ptr_to([16_384 + item * 4]), item)
+                        with K.If(item < item_count), K.Then():
+                            K.assign(local_min, K.if_then_else(local_min < key, local_min, key))
+                            K.assign(local_max, K.if_then_else(local_max > key, local_max, key))
+                old = K.local_scalar("int32")
+                K.ptx["atom.shared::cta.min.s32"](old, order_arena.ptr_to([32_768]), local_min)
+                K.ptx["atom.shared::cta.max.s32"](old, order_arena.ptr_to([32_772]), local_max)
+                K.cuda.cta_sync()
+                spread_min = K.local_scalar("int32")
+                spread_max = K.local_scalar("int32")
+                K.ptx.ld.shared.s32(spread_min, order_arena.ptr_to([32_768]))
+                K.ptx.ld.shared.s32(spread_max, order_arena.ptr_to([32_772]))
+                with K.If(spread_min == spread_max), K.Then():
+                    destination = K.local_scalar("int32", init=thread)
+                    with K.While(destination < item_count):
+                        write_work_item(destination, destination)
+                        K.assign(destination, destination + 1024)
+                with K.If(spread_min != spread_max), K.Then():
+                    network = K.local_scalar("int32", init=K.int32(2))
+                    with K.While(network <= padded_count):
+                        distance = K.local_scalar("int32", init=network // 2)
+                        with K.While(distance > 0):
+                            for element in range(4):
+                                item = thread + element * 1024
+                                partner = K.bitwise_xor(item, distance)
+                                with K.If(K.And(item < padded_count, partner > item)), K.Then():
+                                    key_i = K.local_scalar("int32")
+                                    key_j = K.local_scalar("int32")
+                                    K.ptx.ld.shared.s32(key_i, order_arena.ptr_to([item * 4]))
+                                    K.ptx.ld.shared.s32(key_j, order_arena.ptr_to([partner * 4]))
+                                    ascending = ((item // network) % 2) == 0
+                                    swap = K.Or(
+                                        K.And(ascending, key_i < key_j),
+                                        K.And(K.Not(ascending), key_i > key_j),
+                                    )
+                                    with K.If(swap), K.Then():
+                                        index_i = K.local_scalar("int32")
+                                        index_j = K.local_scalar("int32")
+                                        K.ptx.ld.shared.s32(
+                                            index_i, order_arena.ptr_to([16_384 + item * 4])
+                                        )
+                                        K.ptx.ld.shared.s32(
+                                            index_j, order_arena.ptr_to([16_384 + partner * 4])
+                                        )
+                                        K.ptx.st.shared.s32(order_arena.ptr_to([item * 4]), key_j)
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([partner * 4]), key_i
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + item * 4]), index_j
+                                        )
+                                        K.ptx.st.shared.s32(
+                                            order_arena.ptr_to([16_384 + partner * 4]), index_i
+                                        )
+                            K.cuda.cta_sync()
+                            K.assign(distance, distance // 2)
+                        K.assign(network, network * 2)
+                    for element in range(4):
+                        destination = thread + element * 1024
+                        with K.If(destination < item_count), K.Then():
+                            source = K.local_scalar("int32")
+                            K.ptx.ld.shared.s32(
+                                source, order_arena.ptr_to([16_384 + destination * 4])
+                            )
+                            write_work_item(destination, source)
+
+        maps = (base_k, base_v, base_gate, base_beta, base_w, base_checkpoint)
+        bases = (k, v, gate, beta, w)
+        strides = (
+            k_row_stride_bytes,
+            v_row_stride_bytes,
+            gate_row_stride_bytes,
+            beta_row_stride_bytes,
+            w_row_stride_bytes,
+        )
+        for array_index in range(5):
+            with K.If(warp == array_index), K.Then():
+                with K.If(_elected()), K.Then():
+                    with K.serial(n_batch) as batch:
+                        begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                        end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                        slot = _descriptor_slot(descriptor_workspace, n_batch, array_index, batch)
+                        _copy_tensormap(maps[array_index], slot)
+                        _replace_tensormap_address(
+                            slot,
+                            bases[array_index].ptr_to(
+                                [K.cast(begin, "int64") * strides[array_index]]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, end - begin)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+        if checkpoints:
+            with K.If(warp == 5), K.Then():
+                with K.If(_elected()), K.Then():
+                    checkpoint_prefix = K.local_scalar("int32", init=K.int32(0))
+                    with K.serial(n_batch) as batch:
+                        begin = _load_cu(cu_seqlens, batch, cu_dtype)
+                        end = _load_cu(cu_seqlens, batch + 1, cu_dtype)
+                        length = end - begin
+                        count = K.local_scalar("int32", init=K.int32(0))
+                        with K.If(length > 0), K.Then():
+                            K.assign(count, (length - 1) // checkpoint_every_n + 1)
+                        slot = _descriptor_slot(descriptor_workspace, n_batch, 5, batch)
+                        _copy_tensormap(base_checkpoint, slot)
+                        _replace_tensormap_address(
+                            slot,
+                            checkpoint.ptr_to(
+                                [K.cast(checkpoint_prefix, "int64") * checkpoint_row_stride_bytes]
+                            ),
+                        )
+                        _replace_tensormap_dim(slot, 2, count)
+                        K.assign(checkpoint_prefix, checkpoint_prefix + count)
+                    K.ptx.fence.proxy.tensormap__generic.release.gpu()
+
+    return prologue
+
+
+# KERNEL_SKETCH_START
+def _make_main(
+    *,
+    num_sms,
+    io_dtype,
+    state_dtype,
+    cu_dtype,
+    use_initial_state,
+    store_final_state,
+    checkpoints,
+    peel_cg1_first_chunk,
+    l2norm,
+    safe_gate,
+    gate_scale_log2,
+    beta_sigmoid,
+    dynamic_scheduler,
+    k_ratio,
+    v_ratio,
+    n_heads_out,
+    full_tiles,
+):
+    io_t = K.f16 if io_dtype == "float16" else K.bf16
+    state_t = K.bf16 if state_dtype == "bfloat16" else K.f32
+    cu_t = K.i64 if cu_dtype == "int64" else K.i32
+    protocol = _CHECKPOINT_PROTOCOL if checkpoints else _NORMAL_PROTOCOL
+    arena_bytes = 206_848 if checkpoints else 165_888
+    raw_stages = 4 if checkpoints else 5
+    raw_ready_stages = 4 if checkpoints else 6
+    checkpoint_stages = 2 if checkpoints else 1
+    tmem_mailbox = 696 if checkpoints else 800
+    sched_base = 704 if checkpoints else 816
+    k_decay_base = 1_024
+    k_restore_base = 9_216
+    intermediate_base = 17_408
+    k_raw_base = 18_432
+    v_raw_base = 34_816 if checkpoints else 38_912
+    gate_raw_base = 51_200 if checkpoints else 59_392
+    diag_base = 83_968 if checkpoints else 100_352
+    k_inv_base = 100_352 if checkpoints else 116_736
+    beta_raw_base = 108_544 if checkpoints else 124_928
+    w_raw_base = 124_928 if checkpoints else 145_408
+    checkpoint_base = 141_312
+    idesc_ts = 0x08040010 if io_dtype == "float16" else 0x08040490
+    idesc_final = 0x08210010 if io_dtype == "float16" else 0x08210490
+
+    @K.kernel(warps=16, arch="sm_100a", min_blocks_per_sm=1, grid=num_sms)
+    def main(
+        descriptor_workspace: K.gptr[K.i64],
+        n_desc: K.i32,
+        k: K.gptr[io_t],
+        v: K.gptr[io_t],
+        gate: K.gptr[K.f32],
+        a_log: K.gptr[K.f32],
+        dt_bias: K.gptr[K.f32],
+        beta: K.gptr[io_t],
+        w: K.gptr[io_t],
+        cu_seqlens: K.gptr[cu_t],
+        initial_state: K.gptr[state_t],
+        final_state: K.gptr[state_t],
+        work_items: K.gptr[K.i32],
+        work_count: K.gptr[K.i32],
+        scheduler: K.gptr[K.i32],
+        checkpoint_every_n: K.i32,
+    ):
+        arena = K.alloc_buffer((arena_bytes,), K.u8, scope="shared.dyn", align=1024)
+        K.smem_pool(base=arena)
+        thread = K.thread_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        # Declaration-ordered physical mbarrier table.  The normal source
+        # compiles the checkpoint and state-read edges away entirely.
+        for edge_index, edge in enumerate(protocol):
+            ready_off, done_off, ready_stages, done_stages, ready_count, done_count, owner = edge
+            if checkpoints or edge_index not in (16, 18):
+                with K.If(warp == owner), K.Then():
+                    with K.If(_elected()), K.Then():
+                        for stage in range(ready_stages):
+                            K.ptx.mbarrier.init.shared.b64(
+                                _barrier_ptr(arena, ready_off, stage), K.uint32(ready_count)
+                            )
+                        if done_off is not None:
+                            for stage in range(done_stages):
+                                K.ptx.mbarrier.init.shared.b64(
+                                    _barrier_ptr(arena, done_off, stage), K.uint32(done_count)
+                                )
+
+        # Four diagonal stages, eight 16x16 blocks per stage.
+        with K.unroll(16) as diagonal_pass:
+            element = thread + diagonal_pass * 512
+            K.ptx.st.shared.b16(arena.ptr_to([diag_base + element * 2]), K.uint16(0))
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+
+        total_tiles = K.local_scalar("int32")
+        K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
+        roles = K.specialize()
+        cg0 = roles.role("cg0", warps=range(0, 8), regs=160)
+        cg1 = roles.role("cg1", warps=range(8, 12), regs=136)
+        super_mma = roles.role("super_mma", warps=[12], regs=56)
+        tcgen = roles.role("tcgen", warps=[13], regs=56)
+        tma = roles.role("tma", warps=[14], regs=56)
+        epilogue = roles.role("epilogue", warps=[15], regs=56)
+
+        # Warp 14: descriptor acquire, five input TMA rings, scheduler producer.
+        with tma:
+            raw = K.PipelineState(raw_stages, phase=1)
+            raw_ready = K.PipelineState(raw_ready_stages, phase=0)
+            sched_producer = K.PipelineState(8, phase=1)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                cstart = item[4]
+                wend = item[3]
+                head_k = head if k_ratio == 1 else head // k_ratio
+                head_v = head if v_ratio == 1 else head // v_ratio
+                desc_k = _descriptor_slot(descriptor_workspace, n_desc, 0, batch)
+                desc_v = _descriptor_slot(descriptor_workspace, n_desc, 1, batch)
+                desc_gate = _descriptor_slot(descriptor_workspace, n_desc, 2, batch)
+                desc_beta = _descriptor_slot(descriptor_workspace, n_desc, 3, batch)
+                desc_w = _descriptor_slot(descriptor_workspace, n_desc, 4, batch)
+                with K.If(_elected()), K.Then():
+                    for desc in (desc_k, desc_v, desc_gate, desc_beta, desc_w):
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc)
+
+                with K.serial(wend - cstart, unroll=False) as local_chunk:
+                    chunk = cstart + local_chunk
+                    token = chunk * _BT
+                    raw_stage = raw.stage
+                    ready_stage = raw_ready.stage
+                    with K.If(_elected()), K.Then():
+                        # K
+                        _wait_barrier(arena, protocol[0][1], raw_stage, raw.phase)
+                        _expect_tx(arena, protocol[0][0], ready_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to([k_raw_base + raw_stage * 4096 + d_coord * 32]),
+                                desc_k,
+                                K.int32(d_coord),
+                                head_k,
+                                token,
+                                _barrier_ptr(arena, protocol[0][0], ready_stage),
+                            )
+                        # V
+                        _wait_barrier(arena, protocol[1][1], raw_stage, raw.phase)
+                        _expect_tx(arena, protocol[1][0], ready_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to([v_raw_base + raw_stage * 4096 + d_coord * 32]),
+                                desc_v,
+                                K.int32(d_coord),
+                                head_v,
+                                token,
+                                _barrier_ptr(arena, protocol[1][0], ready_stage),
+                            )
+                        # Beta
+                        _wait_barrier(arena, protocol[4][1], raw_stage, raw.phase)
+                        _expect_tx(arena, protocol[4][0], ready_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to([beta_raw_base + raw_stage * 4096 + d_coord * 32]),
+                                desc_beta,
+                                K.int32(d_coord),
+                                head,
+                                token,
+                                _barrier_ptr(arena, protocol[4][0], ready_stage),
+                            )
+                        # W
+                        _wait_barrier(arena, protocol[2][1], raw_stage, raw.phase)
+                        _expect_tx(arena, protocol[2][0], ready_stage, 4096)
+                        for d_coord in (0, 64):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to([w_raw_base + raw_stage * 4096 + d_coord * 32]),
+                                desc_w,
+                                K.int32(d_coord),
+                                head,
+                                token,
+                                _barrier_ptr(arena, protocol[2][0], ready_stage),
+                            )
+                        # Gate
+                        _wait_barrier(arena, protocol[3][1], raw_stage, raw.phase)
+                        _expect_tx(arena, protocol[3][0], ready_stage, 8192)
+                        for d_coord in (0, 32, 64, 96):
+                            K.ptx[_TMA_G2S_3D](
+                                arena.ptr_to([gate_raw_base + raw_stage * 8192 + d_coord * 64]),
+                                desc_gate,
+                                K.int32(d_coord),
+                                head,
+                                token,
+                                _barrier_ptr(arena, protocol[3][0], ready_stage),
+                            )
+                    raw.advance()
+                    raw_ready.advance()
+
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, protocol[19][1], sched_producer.stage, sched_producer.phase
+                    )
+                    with K.If(_elected()), K.Then():
+                        ticket = K.local_scalar("uint32")
+                        K.ptx.atom.global_.add.u32(ticket, scheduler.ptr_to([0]), K.uint32(1))
+                        K.ptx.st.shared.u32(
+                            arena.ptr_to([sched_base + sched_producer.stage * 4]),
+                            K.uint32(num_sms) + ticket,
+                        )
+                    K.cuda.warp_sync()
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([sched_base + sched_producer.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, protocol[19][0], sched_producer.stage)
+                    sched_producer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+
+        # Warp 12: register KK, strict-lower L, and three Neumann rounds.
+        with super_mma:
+            rhs_row = lane % 8 + K.if_then_else(lane // 16 != 0, 8, 0)
+            rhs_col = K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_row = lane % 8 + K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+            lhs_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_row = (lane & 7) + K.if_then_else((lane // 8) & 1 != 0, 8, 0)
+            store_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+            store_linear = store_row * 16 + (store_col ^ 8)
+            store_swizzled = K.bitwise_xor(
+                store_linear,
+                K.shift_left(
+                    K.bitwise_and(K.shift_right(store_linear, K.uint32(6)), K.uint32(1)),
+                    K.uint32(3),
+                ),
+            )
+            row_lo = lane // 4
+            row_hi = row_lo + 8
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            sched_consumer = K.PipelineState(8, phase=0)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                num_chunks = item[3] - item[4]
+                with K.serial(num_chunks, unroll=False) as local_chunk:
+                    serial = serial_base + local_chunk
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+                    _wait_barrier(arena, protocol[10][0], decay_stage, (serial // 2) & 1)
+
+                    kk = K.alloc_local((8,), "float32")
+                    for accum in range(8):
+                        K.assign(kk[accum], K.float32(0.0))
+                    with K.unroll(8) as key_block:
+                        a = K.alloc_local((4,), "uint32")
+                        b = K.alloc_local((4,), "uint32")
+                        inv_channel = key_block * 16 + rhs_col
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            b[0],
+                            b[1],
+                            b[2],
+                            b[3],
+                            arena.ptr_to(
+                                [_raw_io_byte(k_inv_base, decay_stage, rhs_row, inv_channel)]
+                            ),
+                        )
+                        storage_key = K.bitwise_xor(key_block * 16 + lhs_col, K.int32(8))
+                        storage_slice = storage_key // 64
+                        decay_element = storage_slice * 1024 + _swizzle_xor_128b(
+                            lhs_row, lhs_row * 64 + storage_key - storage_slice * 64, 2
+                        )
+                        K.ptx.ldmatrix.sync.aligned.m8n8.x4.shared.b16(
+                            a[0],
+                            a[1],
+                            a[2],
+                            a[3],
+                            arena.ptr_to([k_decay_base + decay_stage * 4096 + decay_element * 2]),
+                        )
+                        _mma_m16n16k16(kk, a, b, io_dtype)
+
+                    l_words = K.alloc_local((4,), "uint32")
+                    rounded_l = K.alloc_local((8,), "float32")
+                    tinv = K.alloc_local((8,), "float32")
+                    for pair in range(4):
+                        idx0 = pair * 2
+                        idx1 = idx0 + 1
+                        row0 = row_hi if idx0 % 4 >= 2 else row_lo
+                        row1 = row_hi if idx1 % 4 >= 2 else row_lo
+                        col0 = (idx0 // 4) * 8 + 2 * (lane % 4) + (idx0 & 1)
+                        col1 = (idx1 // 4) * 8 + 2 * (lane % 4) + (idx1 & 1)
+                        l0 = K.if_then_else(row0 > col0, kk[idx0], K.float32(0.0))
+                        l1 = K.if_then_else(row1 > col1, kk[idx1], K.float32(0.0))
+                        K.assign(l_words[pair], _pack_io_pair(l0, l1, io_dtype))
+                        _unpack_io_pair(l_words[pair], rounded_l[idx0], rounded_l[idx1], io_dtype)
+                        K.assign(
+                            tinv[idx0],
+                            K.if_then_else(row0 == col0, K.float32(1.0), K.float32(0.0))
+                            - rounded_l[idx0],
+                        )
+                        K.assign(
+                            tinv[idx1],
+                            K.if_then_else(row1 == col1, K.float32(1.0), K.float32(0.0))
+                            - rounded_l[idx1],
+                        )
+
+                    l_power = K.alloc_local((4,), "uint32")
+                    l_power_t = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(l_power[pair], l_words[pair])
+                        K.assign(l_power_t[pair], _movmatrix_b16(l_power[pair]))
+                    for _ in range(3):
+                        square = K.alloc_local((8,), "float32")
+                        for accum in range(8):
+                            K.assign(square[accum], K.float32(0.0))
+                        _mma_m16n16k16(square, l_power, l_power_t, io_dtype)
+                        for pair in range(4):
+                            K.assign(
+                                l_power[pair],
+                                _pack_io_pair(square[pair * 2], square[pair * 2 + 1], io_dtype),
+                            )
+                            K.assign(l_power_t[pair], _movmatrix_b16(l_power[pair]))
+
+                        tinv_words = K.alloc_local((4,), "uint32")
+                        for pair in range(4):
+                            K.assign(
+                                tinv_words[pair],
+                                _pack_io_pair(tinv[pair * 2], tinv[pair * 2 + 1], io_dtype),
+                            )
+                        update = K.alloc_local((8,), "float32")
+                        for accum in range(8):
+                            K.assign(update[accum], K.float32(0.0))
+                        _mma_m16n16k16(update, tinv_words, l_power_t, io_dtype)
+                        for pair in range(4):
+                            old_lo = K.local_scalar("float32")
+                            old_hi = K.local_scalar("float32")
+                            _unpack_io_pair(tinv_words[pair], old_lo, old_hi, io_dtype)
+                            next_lo, next_hi = _fadd2(
+                                old_lo, old_hi, update[pair * 2], update[pair * 2 + 1]
+                            )
+                            K.assign(tinv[pair * 2], next_lo)
+                            K.assign(tinv[pair * 2 + 1], next_hi)
+
+                    _wait_barrier(arena, protocol[15][1], inter_stage, (serial // 2 + 1) & 1)
+                    tinv_out = K.alloc_local((4,), "uint32")
+                    for pair in range(4):
+                        K.assign(
+                            tinv_out[pair],
+                            _pack_io_pair(tinv[pair * 2], tinv[pair * 2 + 1], io_dtype),
+                        )
+                    K.ptx.stmatrix.sync.aligned.m8n8.x4.shared.b16(
+                        arena.ptr_to([intermediate_base + inter_stage * 512 + store_swizzled * 2]),
+                        tinv_out[0],
+                        tinv_out[1],
+                        tinv_out[2],
+                        tinv_out[3],
+                    )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, protocol[15][0], inter_stage)
+                    _arrive_barrier(arena, protocol[11][0], decay_stage)
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, protocol[19][0], sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([sched_base + sched_consumer.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, protocol[19][1], sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+
+        # Warp 13: TMEM lifecycle and the four source-ordered tcgen05 GEMM chains.
+        with tcgen:
+            tcgen_lane = K.local_scalar("uint32")
+            tcgen_leader = K.local_scalar("uint32")
+            K.ptx.elect_sync(tcgen_lane, tcgen_leader, K.uint32(0xFFFFFFFF))
+            K.ptx.tcgen05.alloc.cta_group__1.sync.aligned.shared__cta.b32(
+                arena.ptr_to([tmem_mailbox]), K.uint32(512)
+            )
+            K.ptx.bar.sync(K.uint32(3), K.uint32(160))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([tmem_mailbox]))
+            state_inp = K.PipelineState(1, phase=0)
+            state_read = K.PipelineState(1, phase=0)
+            y_inp = K.PipelineState(1, phase=0)
+            u_inp = K.PipelineState(1, phase=0)
+            qk_scale = K.PipelineState(4, phase=0)
+            sched_consumer = K.PipelineState(8, phase=0)
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                num_chunks = item[3] - item[4]
+                with K.serial(num_chunks, unroll=False) as local_chunk:
+                    serial = serial_base + local_chunk
+                    have_state = K.bool(True) if use_initial_state else local_chunk > 0
+                    decay_stage = serial % 2
+                    inter_stage = serial % 2
+                    diag_stage = qk_scale.stage
+                    k_decay_desc = _raw_descriptor(
+                        arena, k_decay_base + decay_stage * 4096, 16, 1024, 2
+                    )
+                    k_restore_desc = _raw_descriptor(
+                        arena, k_restore_base + decay_stage * 4096, 2048, 1024, 2
+                    )
+                    tinv_desc = _raw_descriptor(
+                        arena, intermediate_base + inter_stage * 512, 16, 256, 6
+                    )
+
+                    # state_k_acc = state(T) @ K_decay.T
+                    _wait_barrier(arena, protocol[10][0], decay_stage, (serial // 2) & 1)
+                    with K.If(have_state), K.Then():
+                        _wait_barrier(arena, protocol[7][0], state_inp.stage, state_inp.phase)
+                        state_inp.advance()
+                        _tcgen_mma_ts(
+                            tmem_base + 192,
+                            tmem_base + 128,
+                            k_decay_desc,
+                            idesc_ts,
+                            n=16,
+                            k_extent=128,
+                            leader=tcgen_leader,
+                        )
+                        _tcgen_commit(arena, protocol[5][0], leader=tcgen_leader)
+                    _tcgen_commit(arena, protocol[10][1], decay_stage, leader=tcgen_leader)
+
+                    if checkpoints:
+                        with K.If(have_state), K.Then():
+                            _wait_barrier(
+                                arena, protocol[16][0], state_read.stage, state_read.phase
+                            )
+                            state_read.advance()
+
+                    # state decay = state(T) @ diag(exp2(g_last))
+                    _wait_barrier(arena, protocol[13][0], diag_stage, qk_scale.phase)
+                    with K.If(have_state), K.Then():
+                        for key_block in range(8):
+                            diag_desc = _raw_descriptor(
+                                arena, diag_base + diag_stage * 4096 + key_block * 512, 16, 256, 6
+                            )
+                            _tcgen_mma_ts(
+                                tmem_base + key_block * 16,
+                                tmem_base + 128 + key_block * 8,
+                                diag_desc,
+                                idesc_ts,
+                                n=16,
+                                k_extent=16,
+                                leader=tcgen_leader,
+                            )
+                    _tcgen_commit(arena, protocol[14][0], diag_stage, leader=tcgen_leader)
+
+                    # u_acc = Y(T) @ T_inv.T
+                    _wait_barrier(arena, protocol[15][0], inter_stage, (serial // 2) & 1)
+                    _wait_barrier(arena, protocol[8][0], y_inp.stage, y_inp.phase)
+                    y_inp.advance()
+                    _tcgen_mma_ts(
+                        tmem_base + 208,
+                        tmem_base + 224,
+                        tinv_desc,
+                        idesc_ts,
+                        n=16,
+                        k_extent=16,
+                        leader=tcgen_leader,
+                    )
+                    _tcgen_commit(arena, protocol[6][0], leader=tcgen_leader)
+                    _tcgen_commit(arena, protocol[15][1], inter_stage, leader=tcgen_leader)
+
+                    # state += U(T) @ K_restore
+                    _wait_barrier(arena, protocol[9][0], u_inp.stage, u_inp.phase)
+                    u_inp.advance()
+                    _tcgen_mma_ts(
+                        tmem_base,
+                        tmem_base + 232,
+                        k_restore_desc,
+                        idesc_final,
+                        n=128,
+                        k_extent=16,
+                        leader=tcgen_leader,
+                        b_transpose=True,
+                        accumulate=have_state,
+                    )
+                    _tcgen_commit(arena, protocol[12][0], decay_stage, leader=tcgen_leader)
+                    qk_scale.advance()
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, protocol[19][0], sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([sched_base + sched_consumer.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, protocol[19][1], sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _wait_barrier(arena, protocol[17][0], 0, 0)
+            K.ptx.tcgen05.relinquish_alloc_permit.cta_group__1.sync.aligned()
+            K.ptx.tcgen05.dealloc.cta_group__1.sync.aligned.b32(
+                K.cast(tmem_base, "uint32"), K.uint32(512)
+            )
+
+        # Warp 15: checkpoint TMA store drain.
+        with epilogue:
+            checkpoint_ready = K.PipelineState(checkpoint_stages, phase=0)
+            sched_consumer = K.PipelineState(8, phase=0)
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cstart = item[4]
+                num_chunks = wend - cstart
+                if checkpoints:
+                    desc_checkpoint = _descriptor_slot(descriptor_workspace, n_desc, 5, batch)
+                    checkpoint_chunks = checkpoint_every_n // _BT
+                    checkpoint_quot = K.local_scalar(
+                        "int32", init=(cstart + 1) // checkpoint_chunks
+                    )
+                    checkpoint_mod = K.local_scalar("int32", init=(cstart + 1) % checkpoint_chunks)
+                    with K.If(_elected()), K.Then():
+                        K.ptx.fence.proxy.tensormap__generic.acquire.gpu(desc_checkpoint)
+
+                    with K.If(K.And(num_chunks > 0, wstart == 0)), K.Then():
+                        cp_stage = K.local_scalar("int32")
+                        K.ptx.mov.b32(cp_stage, checkpoint_ready.stage)
+                        _wait_barrier(
+                            arena, protocol[18][0], checkpoint_ready.stage, checkpoint_ready.phase
+                        )
+                        checkpoint_ready.advance()
+                        for value_coord in (0, 64):
+                            K.ptx[_TMA_S2G_4D](
+                                desc_checkpoint,
+                                K.int32(value_coord),
+                                K.int32(0),
+                                K.int32(0),
+                                head,
+                                arena.ptr_to(
+                                    [checkpoint_base + cp_stage * 32768 + value_coord * 256]
+                                ),
+                            )
+                        K.ptx.cp.async_.bulk.commit_group()
+                        K.ptx.cp.async_.bulk.wait_group.read(0)
+                        _arrive_barrier(arena, protocol[18][1], cp_stage)
+
+                    with K.serial(num_chunks, unroll=False) as local_chunk:
+                        chunk = cstart + local_chunk
+                        with K.If(local_chunk > 0), K.Then():
+                            do_checkpoint = K.And(checkpoint_mod == 0, chunk >= wstart)
+                            with K.If(do_checkpoint), K.Then():
+                                cp_stage = K.local_scalar("int32")
+                                K.ptx.mov.b32(cp_stage, checkpoint_ready.stage)
+                                _wait_barrier(
+                                    arena,
+                                    protocol[18][0],
+                                    checkpoint_ready.stage,
+                                    checkpoint_ready.phase,
+                                )
+                                checkpoint_ready.advance()
+                                for value_coord in (0, 64):
+                                    K.ptx[_TMA_S2G_4D](
+                                        desc_checkpoint,
+                                        K.int32(value_coord),
+                                        K.int32(0),
+                                        checkpoint_quot,
+                                        head,
+                                        arena.ptr_to(
+                                            [checkpoint_base + cp_stage * 32768 + value_coord * 256]
+                                        ),
+                                    )
+                                K.ptx.cp.async_.bulk.commit_group()
+                                K.ptx.cp.async_.bulk.wait_group.read(0)
+                                _arrive_barrier(arena, protocol[18][1], cp_stage)
+                            K.assign(checkpoint_mod, checkpoint_mod + 1)
+                            with K.If(checkpoint_mod == checkpoint_chunks), K.Then():
+                                K.assign(checkpoint_mod, K.int32(0))
+                                K.assign(checkpoint_quot, checkpoint_quot + 1)
+
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, protocol[19][0], sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([sched_base + sched_consumer.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, protocol[19][1], sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+
+        # Warps 0..7: two four-warp ping-pong CG0 groups.
+        with cg0:
+            cg0_warp = K.warp_id_in_role()
+            group = cg0_warp // 4
+            local_warp = cg0_warp % 4
+            prefix_dim = local_warp * 32 + lane
+            decay_row = local_warp * 4 + lane // 8
+            lane_in_row = lane % 8
+            sched_consumer = K.PipelineState(8, phase=0)
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                head = item[1]
+                cstart = item[4]
+                wend = item[3]
+                bos = item[6]
+                eos = item[7]
+                sequence_length = eos - bos
+                num_chunks = wend - cstart
+                a_log_exp = K.local_scalar("float32", init=K.float32(1.0))
+                dt_value = K.local_scalar("float32", init=K.float32(0.0))
+                if safe_gate:
+                    with K.If(num_chunks > 0), K.Then():
+                        a_value = K.local_scalar("float32")
+                        K.ptx.ld.global_.f32(a_value, a_log.ptr_to([head]))
+                        K.assign(a_log_exp, _exp2(a_value * K.float32(_LOG2_E)))
+                        K.ptx.ld.global_.f32(
+                            dt_value, dt_bias.ptr_to([K.cast(head, "int64") * 128 + prefix_dim])
+                        )
+
+                K.ptx.bar.sync(K.uint32(5), K.uint32(256))
+                local_chunk = K.local_scalar("int32", init=group)
+                with K.While(local_chunk < num_chunks):
+                    chunk = cstart + local_chunk
+                    serial = serial_base + local_chunk
+                    raw_stage = serial % raw_stages
+                    ready_stage = serial % raw_ready_stages
+                    ready_phase = (serial // raw_ready_stages) & 1
+                    decay_stage = serial % 2
+                    diag_stage = serial % 4
+                    _wait_barrier(arena, protocol[3][0], ready_stage, ready_phase)
+
+                    gate_prefix = K.alloc_local((16,), "float32")
+                    for row in range(16):
+                        raw_gate = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(
+                            raw_gate,
+                            arena.ptr_to(
+                                [_raw_f32_byte(gate_raw_base, raw_stage, row, prefix_dim)]
+                            ),
+                        )
+                        if safe_gate:
+                            K.assign(raw_gate, a_log_exp * (raw_gate + dt_value))
+                            sigmoid = _tanh(raw_gate * K.float32(0.5)) * K.float32(0.5)
+                            K.assign(
+                                raw_gate, (sigmoid + K.float32(0.5)) * K.float32(gate_scale_log2)
+                            )
+                            if not full_tiles:
+                                with K.If(chunk * 16 + row >= sequence_length), K.Then():
+                                    K.assign(raw_gate, K.float32(0.0))
+                        else:
+                            K.assign(raw_gate, raw_gate * K.float32(_LOG2_E))
+                            if not full_tiles:
+                                with K.If(chunk * 16 + row >= sequence_length), K.Then():
+                                    K.assign(raw_gate, K.float32(0.0))
+                        K.assign(gate_prefix[row], raw_gate)
+
+                    prefix_acc = K.local_scalar("float32", init=K.float32(0.0))
+                    for pair in range(8):
+                        row0 = pair * 2
+                        row1 = row0 + 1
+                        prefix0, pair_sum = _fadd2(
+                            prefix_acc, gate_prefix[row0], gate_prefix[row0], gate_prefix[row1]
+                        )
+                        prefix1 = prefix_acc + pair_sum
+                        K.assign(gate_prefix[row0], prefix0)
+                        K.assign(gate_prefix[row1], prefix1)
+                        K.assign(prefix_acc, prefix1)
+                    for row in range(16):
+                        K.assign(gate_prefix[row], _exp2(gate_prefix[row]))
+                        K.ptx.st.shared.f32(
+                            arena.ptr_to(
+                                [_raw_f32_byte(gate_raw_base, raw_stage, row, prefix_dim)]
+                            ),
+                            gate_prefix[row],
+                        )
+                    exp_last = gate_prefix[15]
+
+                    _wait_barrier(arena, protocol[14][0], diag_stage, (serial // 4 + 1) & 1)
+                    block = prefix_dim // 16
+                    coord = prefix_dim - block * 16
+                    storage_col = coord ^ 8
+                    diagonal_linear = block * 256 + coord * 16 + storage_col
+                    diagonal_swizzled = K.bitwise_xor(
+                        diagonal_linear,
+                        K.shift_left(
+                            K.bitwise_and(K.shift_right(diagonal_linear, K.uint32(6)), K.uint32(1)),
+                            K.uint32(3),
+                        ),
+                    )
+                    K.ptx.st.shared.b16(
+                        arena.ptr_to([diag_base + diag_stage * 4096 + diagonal_swizzled * 2]),
+                        K.reinterpret("uint16", K.cast(exp_last, io_dtype)),
+                    )
+                    K.ptx.bar.sync(K.cast(1 + group, "uint32"), K.uint32(128))
+
+                    _wait_barrier(arena, protocol[0][0], ready_stage, ready_phase)
+                    _wait_barrier(arena, protocol[4][0], ready_stage, ready_phase)
+                    raw_k = K.alloc_local((16,), "float32")
+                    raw_beta = K.alloc_local((16,), "float32")
+                    if l2norm:
+                        kk_lo = K.local_scalar("float32", init=K.float32(0.0))
+                        kk_hi = K.local_scalar("float32", init=K.float32(0.0))
+                    for dim_half in range(2):
+                        dim_base = dim_half * 64 + lane_in_row * 8
+                        k_words = K.alloc_local((4,), "uint32")
+                        beta_words = K.alloc_local((4,), "uint32")
+                        K.ptx.ld.shared.v4.b32(
+                            k_words[0],
+                            k_words[1],
+                            k_words[2],
+                            k_words[3],
+                            arena.ptr_to(
+                                [_raw_io_byte(k_raw_base, raw_stage, decay_row, dim_base)]
+                            ),
+                        )
+                        K.ptx.ld.shared.v4.b32(
+                            beta_words[0],
+                            beta_words[1],
+                            beta_words[2],
+                            beta_words[3],
+                            arena.ptr_to(
+                                [_raw_io_byte(beta_raw_base, raw_stage, decay_row, dim_base)]
+                            ),
+                        )
+                        for pair in range(4):
+                            reg = dim_half * 8 + pair * 2
+                            _unpack_io_pair(k_words[pair], raw_k[reg], raw_k[reg + 1], io_dtype)
+                            _unpack_io_pair(
+                                beta_words[pair], raw_beta[reg], raw_beta[reg + 1], io_dtype
+                            )
+                            if beta_sigmoid:
+                                for parity in range(2):
+                                    beta_value = _tanh(
+                                        raw_beta[reg + parity] * K.float32(0.5)
+                                    ) * K.float32(0.5) + K.float32(0.5)
+                                    rounded = _pack_io_pair(beta_value, beta_value, io_dtype)
+                                    rounded_lo = K.local_scalar("float32")
+                                    rounded_hi = K.local_scalar("float32")
+                                    _unpack_io_pair(rounded, rounded_lo, rounded_hi, io_dtype)
+                                    K.assign(raw_beta[reg + parity], rounded_lo)
+                            if l2norm:
+                                next_lo, next_hi = _ffma2(
+                                    raw_k[reg],
+                                    raw_k[reg + 1],
+                                    raw_k[reg],
+                                    raw_k[reg + 1],
+                                    kk_lo,
+                                    kk_hi,
+                                )
+                                K.assign(kk_lo, next_lo)
+                                K.assign(kk_hi, next_hi)
+
+                    k_inv_norm = K.local_scalar("float32", init=_opaque_one())
+                    if l2norm:
+                        k_sum = K.local_scalar("float32", init=kk_lo + kk_hi)
+                        for delta in (4, 2, 1):
+                            K.assign(k_sum, k_sum + _shuffle_xor_f32(k_sum, delta))
+                        k_floor = K.if_then_else(
+                            k_sum > K.float32(_L2_NORM_EPS2), k_sum, K.float32(_L2_NORM_EPS2)
+                        )
+                        K.assign(k_inv_norm, _rsqrt(k_floor))
+
+                    exp_g = K.alloc_local((16,), "float32")
+                    exp_g_last = K.alloc_local((16,), "float32")
+                    k_inv_words = K.alloc_local((8,), "uint32")
+                    for dim_half in range(2):
+                        dim_base = dim_half * 64 + lane_in_row * 8
+                        reg_base = dim_half * 8
+                        exp_neg_g = K.alloc_local((8,), "float32")
+                        for group4 in range(2):
+                            dim4 = dim_base + group4 * 4
+                            values = K.alloc_local((4,), "float32")
+                            lasts = K.alloc_local((4,), "float32")
+                            K.ptx.ld.shared.v4.f32(
+                                values[0],
+                                values[1],
+                                values[2],
+                                values[3],
+                                arena.ptr_to(
+                                    [_raw_f32_byte(gate_raw_base, raw_stage, decay_row, dim4)]
+                                ),
+                            )
+                            K.ptx.ld.shared.v4.f32(
+                                lasts[0],
+                                lasts[1],
+                                lasts[2],
+                                lasts[3],
+                                arena.ptr_to([_raw_f32_byte(gate_raw_base, raw_stage, 15, dim4)]),
+                            )
+                            for offset in range(4):
+                                half_reg = group4 * 4 + offset
+                                reg = reg_base + half_reg
+                                K.assign(exp_g[reg], values[offset])
+                                K.assign(exp_neg_g[half_reg], _rcp(values[offset]))
+                                K.assign(exp_g_last[reg], lasts[offset])
+
+                        decay_words = K.alloc_local((4,), "uint32")
+                        for pair in range(4):
+                            reg = reg_base + pair * 2
+                            k0, k1 = _fmul2(raw_k[reg], raw_k[reg + 1], k_inv_norm, k_inv_norm)
+                            kb0, kb1 = _fmul2(k0, k1, raw_beta[reg], raw_beta[reg + 1])
+                            k_beta = _pack_io_pair(kb0, kb1, io_dtype)
+                            exp_pair = _pack_io_pair(exp_g[reg], exp_g[reg + 1], io_dtype)
+                            _mul_io_pair(decay_words[pair], k_beta, exp_pair, io_dtype)
+                            inv_pair = _pack_io_pair(
+                                exp_neg_g[pair * 2], exp_neg_g[pair * 2 + 1], io_dtype
+                            )
+                            k_pair = _pack_io_pair(k0, k1, io_dtype)
+                            _mul_io_pair(
+                                k_inv_words[dim_half * 4 + pair], k_pair, inv_pair, io_dtype
+                            )
+
+                        if dim_half == 0:
+                            _wait_barrier(
+                                arena, protocol[11][0], decay_stage, (serial // 2 + 1) & 1
+                            )
+                            _wait_barrier(
+                                arena, protocol[10][1], decay_stage, (serial // 2 + 1) & 1
+                            )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_io_byte(k_inv_base, decay_stage, decay_row, dim_base)]
+                            ),
+                            k_inv_words[dim_half * 4],
+                            k_inv_words[dim_half * 4 + 1],
+                            k_inv_words[dim_half * 4 + 2],
+                            k_inv_words[dim_half * 4 + 3],
+                        )
+                        storage_key = K.bitwise_xor(dim_base, K.int32(8))
+                        storage_slice = storage_key // 64
+                        decay_element = storage_slice * 1024 + _swizzle_xor_128b(
+                            decay_row, decay_row * 64 + storage_key - storage_slice * 64, 2
+                        )
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to([k_decay_base + decay_stage * 4096 + decay_element * 2]),
+                            decay_words[0],
+                            decay_words[1],
+                            decay_words[2],
+                            decay_words[3],
+                        )
+
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, protocol[10][0], decay_stage)
+                    _arrive_barrier(arena, protocol[0][1], raw_stage)
+                    _arrive_barrier(arena, protocol[3][1], raw_stage)
+                    _arrive_barrier(arena, protocol[4][1], raw_stage)
+
+                    _wait_barrier(arena, protocol[12][0], decay_stage, (serial // 2 + 1) & 1)
+                    for dim_half in range(2):
+                        dim_base = dim_half * 64 + lane_in_row * 8
+                        reg_base = dim_half * 8
+                        restore_words = K.alloc_local((4,), "uint32")
+                        for pair in range(4):
+                            reg = reg_base + pair * 2
+                            last_pair = _pack_io_pair(
+                                exp_g_last[reg], exp_g_last[reg + 1], io_dtype
+                            )
+                            _mul_io_pair(
+                                restore_words[pair],
+                                k_inv_words[dim_half * 4 + pair],
+                                last_pair,
+                                io_dtype,
+                            )
+                        storage_row = decay_row ^ 8
+                        K.ptx.st.shared.v4.b32(
+                            arena.ptr_to(
+                                [_raw_io_byte(k_restore_base, decay_stage, storage_row, dim_base)]
+                            ),
+                            restore_words[0],
+                            restore_words[1],
+                            restore_words[2],
+                            restore_words[3],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    _arrive_barrier(arena, protocol[13][0], diag_stage)
+                    K.assign(local_chunk, local_chunk + 2)
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, protocol[19][0], sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([sched_base + sched_consumer.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, protocol[19][1], sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+
+        # Warps 8..11: recurrent state owner, Y/U repack, checkpoint staging.
+        with cg1:
+            K.ptx.bar.sync(K.uint32(3), K.uint32(160))
+            tmem_base = K.local_scalar("int32")
+            K.ptx.ld.volatile.shared.s32(tmem_base, arena.ptr_to([tmem_mailbox]))
+            tmem_col = tmem_base & 0xFFFF
+            tmem_row = tmem_base >> 16
+            subpartition = warp % 4
+            value_base = subpartition * 32
+            value_dim = value_base + lane
+            frag_row = (lane // 16) * 8 + (lane & 7)
+            frag_col = ((lane // 8) & 1) * 8
+            row_id = tmem_row + value_base
+            state_k_cursor = K.PipelineState(1, phase=0)
+            u_acc_cursor = K.PipelineState(1, phase=0)
+            k_restore_cursor = K.PipelineState(2, phase=0)
+            raw_cursor = K.PipelineState(raw_stages, phase=0)
+            raw_ready_cursor = K.PipelineState(raw_ready_stages, phase=0)
+            checkpoint_done = K.PipelineState(checkpoint_stages, phase=1)
+            sched_consumer = K.PipelineState(8, phase=0)
+            serial_base = K.local_scalar("int32", init=K.int32(0))
+
+            def stage_y(have_state, raw_stage, ready_stage, ready_phase):
+                _wait_barrier(arena, protocol[1][0], ready_stage, ready_phase)
+                raw_v0 = K.alloc_local((4,), "uint32")
+                raw_v1 = K.alloc_local((4,), "uint32")
+                K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                    raw_v0[0],
+                    raw_v0[1],
+                    raw_v0[2],
+                    raw_v0[3],
+                    arena.ptr_to(
+                        [_raw_io_byte(v_raw_base, raw_stage, frag_row, value_base + frag_col)]
+                    ),
+                )
+                K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                    raw_v1[0],
+                    raw_v1[1],
+                    raw_v1[2],
+                    raw_v1[3],
+                    arena.ptr_to(
+                        [_raw_io_byte(v_raw_base, raw_stage, frag_row, value_base + 16 + frag_col)]
+                    ),
+                )
+                state_k0 = K.alloc_local((8,), "float32")
+                state_k1 = K.alloc_local((8,), "float32")
+                _wait_barrier(arena, protocol[2][0], ready_stage, ready_phase)
+                raw_w0 = K.alloc_local((4,), "uint32")
+                raw_w1 = K.alloc_local((4,), "uint32")
+                K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                    raw_w0[0],
+                    raw_w0[1],
+                    raw_w0[2],
+                    raw_w0[3],
+                    arena.ptr_to(
+                        [_raw_io_byte(w_raw_base, raw_stage, frag_row, value_base + frag_col)]
+                    ),
+                )
+                K.ptx.ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                    raw_w1[0],
+                    raw_w1[1],
+                    raw_w1[2],
+                    raw_w1[3],
+                    arena.ptr_to(
+                        [_raw_io_byte(w_raw_base, raw_stage, frag_row, value_base + 16 + frag_col)]
+                    ),
+                )
+                with K.If(have_state), K.Then():
+                    _wait_barrier(arena, protocol[5][0], state_k_cursor.stage, state_k_cursor.phase)
+                    state_k_cursor.advance()
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[state_k0[i] for i in range(8)],
+                        K.cast(tmem_col + 192 + K.shift_left(row_id, K.int32(16)), "uint32"),
+                    )
+                    K.ptx["tcgen05.ld.sync.aligned.16x256b.x2.b32"](
+                        *[state_k1[i] for i in range(8)],
+                        K.cast(tmem_col + 192 + K.shift_left(row_id + 16, K.int32(16)), "uint32"),
+                    )
+
+                y0 = K.alloc_local((4,), "uint32")
+                y1 = K.alloc_local((4,), "uint32")
+                for reg in range(4):
+                    raw_matrix = (1 - reg // 2) * 2 + (reg & 1)
+                    frag_pair = (reg ^ 2) * 2
+                    state_pair0 = K.local_scalar("uint32", init=K.uint32(0))
+                    state_pair1 = K.local_scalar("uint32", init=K.uint32(0))
+                    with K.If(have_state), K.Then():
+                        K.assign(
+                            state_pair0,
+                            _pack_io_pair(state_k0[frag_pair], state_k0[frag_pair + 1], io_dtype),
+                        )
+                        K.assign(
+                            state_pair1,
+                            _pack_io_pair(state_k1[frag_pair], state_k1[frag_pair + 1], io_dtype),
+                        )
+                    product0 = K.local_scalar("uint32")
+                    product1 = K.local_scalar("uint32")
+                    _mul_io_pair(product0, raw_w0[raw_matrix], raw_v0[raw_matrix], io_dtype)
+                    _mul_io_pair(product1, raw_w1[raw_matrix], raw_v1[raw_matrix], io_dtype)
+                    _sub_io_pair(y0[reg], product0, state_pair0, io_dtype)
+                    _sub_io_pair(y1[reg], product1, state_pair1, io_dtype)
+                K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                    K.cast(tmem_col + 224 + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    y0[0],
+                    y0[1],
+                    y0[2],
+                    y0[3],
+                )
+                K.ptx["tcgen05.st.sync.aligned.16x128b.x2.b32"](
+                    K.cast(tmem_col + 224 + K.shift_left(tmem_row + 16, K.int32(16)), "uint32"),
+                    y1[0],
+                    y1[1],
+                    y1[2],
+                    y1[3],
+                )
+                K.ptx.tcgen05.wait__st.sync.aligned()
+                _arrive_barrier(arena, protocol[1][1], raw_stage)
+                _arrive_barrier(arena, protocol[2][1], raw_stage)
+                _arrive_barrier(arena, protocol[8][0])
+
+            def stage_u():
+                _wait_barrier(arena, protocol[6][0], u_acc_cursor.stage, u_acc_cursor.phase)
+                u_acc_cursor.advance()
+                values = K.alloc_local((16,), "float32")
+                K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                    *[values[i] for i in range(16)],
+                    K.cast(tmem_col + 208 + K.shift_left(row_id, K.int32(16)), "uint32"),
+                )
+                packed = K.alloc_local((8,), "uint32")
+                for column in range(8):
+                    source_pair = column ^ 4
+                    K.assign(
+                        packed[column],
+                        _pack_io_pair(
+                            values[source_pair * 2], values[source_pair * 2 + 1], io_dtype
+                        ),
+                    )
+                K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                    K.cast(tmem_col + 232 + K.shift_left(tmem_row, K.int32(16)), "uint32"),
+                    *[packed[i] for i in range(8)],
+                )
+                K.ptx.tcgen05.wait__st.sync.aligned()
+                _arrive_barrier(arena, protocol[9][0])
+
+            tile = K.local_scalar("int32", init=K.cta_id())
+            with K.While(tile < total_tiles):
+                item = _load_work_item(work_items, tile)
+                batch = item[0]
+                head = item[1]
+                wstart = item[2]
+                wend = item[3]
+                cstart = item[4]
+                bos = item[6]
+                eos = item[7]
+                sequence_length = eos - bos
+                sequence_chunks = (sequence_length + 15) // 16
+                num_chunks = wend - cstart
+                state_index = (
+                    (K.cast(batch, "int64") * n_heads_out + head) * 128 + value_dim
+                ) * 128
+
+                with K.If(num_chunks > 0), K.Then():
+                    if use_initial_state:
+                        for key_block in range(4):
+                            seed_values = K.alloc_local((32,), "float32")
+                            for key in range(32):
+                                K.assign(seed_values[key], K.float32(0.0))
+                            with K.If(cstart == 0), K.Then():
+                                _load_state_block_128b(
+                                    initial_state,
+                                    state_index + key_block * 32,
+                                    seed_values,
+                                    state_dtype,
+                                )
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x32.b32"](
+                                K.cast(
+                                    tmem_col + key_block * 32 + K.shift_left(row_id, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[seed_values[i] for i in range(32)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+
+                        # Preserve all eight source fragments across state-input
+                        # publication; checkpoints are staged only after the
+                        # epilogue has released the selected checkpoint slot.
+                        state_values = K.alloc_local((8, 16), "float32")
+                        for key_block in range(8):
+                            K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                                *[state_values[key_block, i] for i in range(16)],
+                                K.cast(
+                                    tmem_col + key_block * 16 + K.shift_left(row_id, K.int32(16)),
+                                    "uint32",
+                                ),
+                            )
+                        for key_block in range(8):
+                            packed = K.alloc_local((8,), "uint32")
+                            for column in range(8):
+                                source_pair = column ^ 4
+                                K.assign(
+                                    packed[column],
+                                    _pack_io_pair(
+                                        state_values[key_block, source_pair * 2],
+                                        state_values[key_block, source_pair * 2 + 1],
+                                        io_dtype,
+                                    ),
+                                )
+                            K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                                K.cast(
+                                    tmem_col
+                                    + 128
+                                    + key_block * 8
+                                    + K.shift_left(tmem_row, K.int32(16)),
+                                    "uint32",
+                                ),
+                                *[packed[i] for i in range(8)],
+                            )
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                        _arrive_barrier(arena, protocol[7][0])
+
+                        if checkpoints:
+                            cp_stage = K.local_scalar("int32", init=K.int32(0))
+                            K.ptx.mov.b32(cp_stage, checkpoint_done.stage)
+                            with K.If(wstart == 0), K.Then():
+                                _wait_barrier(
+                                    arena,
+                                    protocol[18][1],
+                                    checkpoint_done.stage,
+                                    checkpoint_done.phase,
+                                )
+                                checkpoint_done.advance()
+                                for key_block in range(8):
+                                    for half in range(2):
+                                        checkpoint_words = K.alloc_local((4,), "uint32")
+                                        for pair in range(4):
+                                            K.assign(
+                                                checkpoint_words[pair],
+                                                _pack_io_pair(
+                                                    state_values[key_block, half * 8 + pair * 2],
+                                                    state_values[
+                                                        key_block, half * 8 + pair * 2 + 1
+                                                    ],
+                                                    io_dtype,
+                                                ),
+                                            )
+                                        dk = key_block * 16 + half * 8
+                                        cp_element = (
+                                            (dk // 64) * 8192
+                                            + value_dim * 64
+                                            + _swizzle_xor_128b(value_dim, dk % 64, 2)
+                                        )
+                                        K.ptx.st.shared.v4.b32(
+                                            arena.ptr_to(
+                                                [
+                                                    checkpoint_base
+                                                    + cp_stage * 32768
+                                                    + cp_element * 2
+                                                ]
+                                            ),
+                                            checkpoint_words[0],
+                                            checkpoint_words[1],
+                                            checkpoint_words[2],
+                                            checkpoint_words[3],
+                                        )
+                                K.ptx.tcgen05.wait__ld.sync.aligned()
+                                K.ptx.fence.proxy.async_.shared__cta()
+                                _arrive_barrier(arena, protocol[18][0], cp_stage)
+                            _arrive_barrier(arena, protocol[16][0])
+                    elif checkpoints:
+                        with K.If(wstart == 0), K.Then():
+                            cp_stage = K.local_scalar("int32")
+                            K.ptx.mov.b32(cp_stage, checkpoint_done.stage)
+                            _wait_barrier(arena, protocol[18][1], cp_stage, checkpoint_done.phase)
+                            checkpoint_done.advance()
+                            for key_block in range(8):
+                                for half in range(2):
+                                    dk = key_block * 16 + half * 8
+                                    cp_element = (
+                                        (dk // 64) * 8192
+                                        + value_dim * 64
+                                        + _swizzle_xor_128b(value_dim, dk % 64, 2)
+                                    )
+                                    K.ptx.st.shared.v4.b32(
+                                        arena.ptr_to(
+                                            [checkpoint_base + cp_stage * 32768 + cp_element * 2]
+                                        ),
+                                        K.uint32(0),
+                                        K.uint32(0),
+                                        K.uint32(0),
+                                        K.uint32(0),
+                                    )
+                            K.ptx.fence.proxy.async_.shared__cta()
+                            _arrive_barrier(arena, protocol[18][0], cp_stage)
+
+                    checkpoint_chunks = K.local_scalar("int32", init=K.int32(1))
+                    checkpoint_mod = K.local_scalar("int32", init=K.int32(0))
+                    if checkpoints:
+                        K.assign(checkpoint_chunks, checkpoint_every_n // 16)
+                        K.assign(checkpoint_mod, (cstart + 1) % checkpoint_chunks)
+
+                    if peel_cg1_first_chunk:
+                        raw_stage = raw_cursor.stage
+                        ready_stage = raw_ready_cursor.stage
+                        ready_phase = raw_ready_cursor.phase
+                        if use_initial_state:
+                            stage_y(K.bool(True), raw_stage, ready_stage, ready_phase)
+                        else:
+                            stage_y(K.bool(False), raw_stage, ready_stage, ready_phase)
+                        stage_u()
+                        _wait_barrier(
+                            arena, protocol[12][0], k_restore_cursor.stage, k_restore_cursor.phase
+                        )
+                        k_restore_cursor.advance()
+                        raw_cursor.advance()
+                        raw_ready_cursor.advance()
+                        recurrent_chunks = num_chunks - 1
+                        first_recurrent_chunk = 1
+                    else:
+                        recurrent_chunks = num_chunks
+                        first_recurrent_chunk = 0
+
+                    with K.serial(recurrent_chunks, unroll=False) as recurrent_chunk:
+                        local_chunk = recurrent_chunk + first_recurrent_chunk
+                        serial = serial_base + local_chunk
+                        raw_stage = raw_cursor.stage
+                        ready_stage = raw_ready_cursor.stage
+                        ready_phase = raw_ready_cursor.phase
+
+                        def stage_recurrent_prefix():
+                            do_checkpoint = K.local_scalar("bool", init=K.bool(False))
+                            cp_stage = K.local_scalar("int32", init=K.int32(0))
+                            if checkpoints:
+                                K.assign(
+                                    do_checkpoint,
+                                    K.And(checkpoint_mod == 0, cstart + local_chunk >= wstart),
+                                )
+                                K.assign(checkpoint_mod, checkpoint_mod + 1)
+                                with K.If(checkpoint_mod == checkpoint_chunks), K.Then():
+                                    K.assign(checkpoint_mod, K.int32(0))
+
+                            # Eight x16 reads feed only the packed state operand.
+                            state_values = K.alloc_local((8, 16), "float32")
+                            for key_block in range(8):
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x16.b32"](
+                                    *[state_values[key_block, i] for i in range(16)],
+                                    K.cast(
+                                        tmem_col
+                                        + key_block * 16
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                            for key_block in range(8):
+                                packed = K.alloc_local((8,), "uint32")
+                                for column in range(8):
+                                    source_pair = column ^ 4
+                                    K.assign(
+                                        packed[column],
+                                        _pack_io_pair(
+                                            state_values[key_block, source_pair * 2],
+                                            state_values[key_block, source_pair * 2 + 1],
+                                            io_dtype,
+                                        ),
+                                    )
+                                K.ptx["tcgen05.st.sync.aligned.32x32b.x8.b32"](
+                                    K.cast(
+                                        tmem_col
+                                        + 128
+                                        + key_block * 8
+                                        + K.shift_left(tmem_row, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                    *[packed[i] for i in range(8)],
+                                )
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                            _arrive_barrier(arena, protocol[7][0])
+
+                            if checkpoints:
+                                # The source waits for the checkpoint slot only
+                                # after publishing state_inp, then deliberately
+                                # re-reads four x32 state fragments.
+                                with K.If(do_checkpoint), K.Then():
+                                    K.ptx.mov.b32(cp_stage, checkpoint_done.stage)
+                                    _wait_barrier(
+                                        arena, protocol[18][1], cp_stage, checkpoint_done.phase
+                                    )
+                                    checkpoint_done.advance()
+                                    for key_base in range(4):
+                                        checkpoint_values = K.alloc_local((32,), "float32")
+                                        K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                            *[checkpoint_values[i] for i in range(32)],
+                                            K.cast(
+                                                tmem_col
+                                                + key_base * 32
+                                                + K.shift_left(row_id, K.int32(16)),
+                                                "uint32",
+                                            ),
+                                        )
+                                        for group8 in range(4):
+                                            cp_words = K.alloc_local((4,), "uint32")
+                                            for pair in range(4):
+                                                K.assign(
+                                                    cp_words[pair],
+                                                    _pack_io_pair(
+                                                        checkpoint_values[group8 * 8 + pair * 2],
+                                                        checkpoint_values[
+                                                            group8 * 8 + pair * 2 + 1
+                                                        ],
+                                                        io_dtype,
+                                                    ),
+                                                )
+                                            dk = key_base * 32 + group8 * 8
+                                            cp_element = (
+                                                (dk // 64) * 8192
+                                                + value_dim * 64
+                                                + _swizzle_xor_128b(value_dim, dk % 64, 2)
+                                            )
+                                            K.ptx.st.shared.v4.b32(
+                                                arena.ptr_to(
+                                                    [
+                                                        checkpoint_base
+                                                        + cp_stage * 32768
+                                                        + cp_element * 2
+                                                    ]
+                                                ),
+                                                cp_words[0],
+                                                cp_words[1],
+                                                cp_words[2],
+                                                cp_words[3],
+                                            )
+                                    K.ptx.tcgen05.wait__ld.sync.aligned()
+                                _arrive_barrier(arena, protocol[16][0])
+                                with K.If(do_checkpoint), K.Then():
+                                    K.ptx.fence.proxy.async_.shared__cta()
+                                    _arrive_barrier(arena, protocol[18][0], cp_stage)
+
+                        if peel_cg1_first_chunk:
+                            stage_recurrent_prefix()
+                            stage_y(K.bool(True), raw_stage, ready_stage, ready_phase)
+                        else:
+                            with K.If(local_chunk > 0), K.Then():
+                                stage_recurrent_prefix()
+                            have_state = K.bool(True) if use_initial_state else local_chunk > 0
+                            stage_y(have_state, raw_stage, ready_stage, ready_phase)
+                        stage_u()
+                        _wait_barrier(
+                            arena, protocol[12][0], k_restore_cursor.stage, k_restore_cursor.phase
+                        )
+                        k_restore_cursor.advance()
+                        raw_cursor.advance()
+                        raw_ready_cursor.advance()
+
+                    if store_final_state:
+                        with K.If(wend == sequence_chunks), K.Then():
+                            for key_block in range(4):
+                                values = K.alloc_local((32,), "float32")
+                                K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                                    *[values[i] for i in range(32)],
+                                    K.cast(
+                                        tmem_col
+                                        + key_block * 32
+                                        + K.shift_left(row_id, K.int32(16)),
+                                        "uint32",
+                                    ),
+                                )
+                                if state_dtype == "float32":
+                                    for vector in range(8):
+                                        key = vector * 4
+                                        K.ptx.st.global_.v4.f32(
+                                            final_state.ptr_to(
+                                                [state_index + key_block * 32 + key]
+                                            ),
+                                            values[key],
+                                            values[key + 1],
+                                            values[key + 2],
+                                            values[key + 3],
+                                        )
+                                else:
+                                    for vector in range(4):
+                                        key = vector * 8
+                                        words = K.alloc_local((4,), "uint32")
+                                        for pair in range(4):
+                                            K.assign(
+                                                words[pair],
+                                                _pack_io_pair(
+                                                    values[key + pair * 2],
+                                                    values[key + pair * 2 + 1],
+                                                    "bfloat16",
+                                                ),
+                                            )
+                                        K.ptx.st.global_.v4.b32(
+                                            final_state.ptr_to(
+                                                [state_index + key_block * 32 + key]
+                                            ),
+                                            words[0],
+                                            words[1],
+                                            words[2],
+                                            words[3],
+                                        )
+                if store_final_state:
+                    with K.If(sequence_length == 0), K.Then():
+                        for key in range(128):
+                            value = K.local_scalar("float32", init=K.float32(0.0))
+                            if use_initial_state:
+                                K.assign(
+                                    value,
+                                    _load_state_value(
+                                        initial_state, state_index + key, state_dtype
+                                    ),
+                                )
+                            _store_state_value(final_state, state_index + key, value, state_dtype)
+
+                K.assign(serial_base, serial_base + num_chunks)
+                if dynamic_scheduler:
+                    _wait_barrier(
+                        arena, protocol[19][0], sched_consumer.stage, sched_consumer.phase
+                    )
+                    K.ptx.ld.shared.s32(tile, arena.ptr_to([sched_base + sched_consumer.stage * 4]))
+                    with K.If(_elected()), K.Then():
+                        _arrive_barrier(arena, protocol[19][1], sched_consumer.stage)
+                    sched_consumer.advance()
+                else:
+                    K.assign(tile, tile + num_sms)
+            _arrive_barrier(arena, protocol[17][0])
+
+    return main
+
+
+def _normalized_config(config):
+    config = {key: value for key, value in config.items() if key != "label"}
+    config.setdefault("seq_lens", (64,))
+    config["seq_lens"] = tuple(int(value) for value in config["seq_lens"])
+    config.setdefault("heads", 1)
+    config.setdefault("k_heads", config["heads"])
+    config.setdefault("v_heads", config["heads"])
+    config.setdefault("io_dtype", "bfloat16")
+    config.setdefault("state_dtype", "float32")
+    config.setdefault("cu_dtype", "int32")
+    config.setdefault("num_sms", 148)
+    if "checkpoint_every_n_tokens" not in config:
+        config["checkpoint_every_n_tokens"] = config.pop("checkpoint", 0)
+    config.setdefault("gate_lower_bound", -5.0)
+    config.setdefault("use_initial_state", False)
+    config.setdefault("store_final_state", True)
+    config.setdefault("l2norm", False)
+    config.setdefault("safe_gate", False)
+    config.setdefault("beta_sigmoid", False)
+    config.setdefault("dynamic_scheduler", False)
+    config.setdefault("split", False)
+    config.setdefault("run_order", True)
+    config.setdefault("order_generate", not config["split"])
+
+    if config["io_dtype"] not in ("bfloat16", "float16"):
+        raise ValueError("io_dtype must be 'bfloat16' or 'float16'")
+    if config["state_dtype"] not in ("float32", "bfloat16"):
+        raise ValueError("state_dtype must be 'float32' or 'bfloat16'")
+    if config["cu_dtype"] not in ("int32", "int64"):
+        raise ValueError("cu_dtype must be 'int32' or 'int64'")
+    if any(length < 0 for length in config["seq_lens"]):
+        raise ValueError("sequence lengths must be nonnegative")
+    if sum(config["seq_lens"]) == 0:
+        raise ValueError("at least one sequence must be nonempty for TensorMap encoding")
+    heads = int(config["heads"])
+    if heads <= 0:
+        raise ValueError("heads must be positive")
+    for name in ("k_heads", "v_heads"):
+        value = int(config[name])
+        if value <= 0 or heads % value != 0:
+            raise ValueError(f"{name}={value} must be a positive divisor of heads={heads}")
+    cadence = int(config["checkpoint_every_n_tokens"])
+    if cadence < 0 or cadence % _BT != 0:
+        raise ValueError("checkpoint cadence must be zero or a positive multiple of 16")
+    if cadence not in (0, 16, 32, 48):
+        raise ValueError("validated checkpoint cadences are 0, 16, 32, and 48")
+    if not (cadence or config["store_final_state"]):
+        raise ValueError("the checkpoint series or the final state is required")
+    if not (config["use_initial_state"] or config["store_final_state"]):
+        if config["state_dtype"] != "float32":
+            raise ValueError("state_dtype is float32 when neither state tensor is present")
+    if config["split"] and config["order_generate"]:
+        raise ValueError("split work rows require scratch ordering")
+    if not config["run_order"]:
+        raise ValueError("the frozen two-launch ABI always runs the order prologue")
+    if int(config["num_sms"]) <= 0:
+        raise ValueError("num_sms must be positive")
+    return config
+
+
+def _work_rows(seq_lens, heads, *, split):
+    rows = []
+    token_begin = 0
+    for batch, sequence_length in enumerate(seq_lens):
+        chunks = (sequence_length + _BT - 1) // _BT
+        token_end = token_begin + sequence_length
+        for head in range(heads):
+            if split and chunks >= 4:
+                midpoint = chunks // 2
+                rows.append((batch, head, 0, midpoint, 0, midpoint, token_begin, token_end))
+                rows.append((batch, head, midpoint, chunks, 0, chunks, token_begin, token_end))
+            else:
+                rows.append((batch, head, 0, chunks, 0, chunks, token_begin, token_end))
+        token_begin = token_end
+    return rows
+
+
+def get_kernel(**config):
+    """Return the source-ordered prologue and persistent main kernels."""
+    config = _normalized_config(config)
+    num_ctas = int(config["num_sms"])
+    checkpoints = int(config["checkpoint_every_n_tokens"]) > 0
+    prologue = _make_prologue(
+        run_order=True,
+        order_generate=bool(config["order_generate"]),
+        dynamic_scheduler=True,
+        n_heads_out=int(config["heads"]),
+        checkpoints=checkpoints,
+        cu_dtype=config["cu_dtype"],
+    )
+    main = _make_main(
+        num_sms=num_ctas,
+        io_dtype=config["io_dtype"],
+        state_dtype=config["state_dtype"],
+        cu_dtype=config["cu_dtype"],
+        use_initial_state=bool(config["use_initial_state"]),
+        store_final_state=bool(config["store_final_state"]),
+        checkpoints=checkpoints,
+        peel_cg1_first_chunk=True,
+        l2norm=bool(config["l2norm"]),
+        safe_gate=bool(config["safe_gate"]),
+        gate_scale_log2=float(config["gate_lower_bound"]) * _LOG2_E,
+        beta_sigmoid=bool(config["beta_sigmoid"]),
+        dynamic_scheduler=bool(config["dynamic_scheduler"]),
+        k_ratio=int(config["heads"]) // int(config["k_heads"]),
+        v_ratio=int(config["heads"]) // int(config["v_heads"]),
+        n_heads_out=int(config["heads"]),
+        full_tiles=all(length % _BT == 0 for length in config["seq_lens"]),
+    )
+    return [prologue.func, main.func]
+
+
+class _AlignedTensorMap:
+    """Host-owned 64-byte-aligned storage for one by-value TensorMap."""
+
+    def __init__(self, words):
+        import ctypes
+
+        if len(words) != _TENSOR_MAP_WORDS:
+            raise ValueError(f"TensorMap needs 16 uint64 words, got {len(words)}")
+        self._storage = ctypes.create_string_buffer(_TENSOR_MAP_BYTES + 63)
+        base = ctypes.addressof(self._storage)
+        self.ptr = ctypes.c_void_p((base + 63) & ~63)
+        payload = (ctypes.c_uint64 * _TENSOR_MAP_WORDS).from_address(self.ptr.value)
+        for index, word in enumerate(words):
+            payload[index] = int(word)
+
+
+def _aligned_i64(torch, size, alignment=128):
+    if size % 8:
+        raise ValueError(f"workspace size must be divisible by 8, got {size}")
+    owner = torch.empty(size + alignment - 1, dtype=torch.uint8, device="cuda")
+    offset = (-owner.data_ptr()) % alignment
+    view = owner[offset : offset + size].view(torch.int64)
+    if view.data_ptr() % alignment:
+        raise AssertionError("failed to construct an aligned TensorMap workspace")
+    return owner, view
+
+
+def _checkpoint_count(seq_lens, cadence):
+    if not cadence:
+        return 0
+    return sum(0 if length == 0 else (length - 1) // cadence + 1 for length in seq_lens)
+
+
+def _prepare_work_tables(torch, config):
+    base = torch.tensor(
+        _work_rows(config["seq_lens"], config["heads"], split=config["split"]),
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    def one_side():
+        sched_all = torch.zeros(4, dtype=torch.int32, device="cuda")
+        return {
+            "work_items": torch.empty_like(base),
+            "work_count": torch.tensor([base.shape[0]], dtype=torch.int32, device="cuda"),
+            "staging": None if config["order_generate"] else base.clone(),
+            "sched_all": sched_all,
+            "scheduler": sched_all[:1] if config["dynamic_scheduler"] else None,
+        }
+
+    return {"tirx": one_side(), "source": one_side()}
+
+
+def _new_outputs(torch, config):
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    result = {}
+    if config["store_final_state"]:
+        result["final_state"] = torch.full(
+            (len(config["seq_lens"]), config["heads"], _DV, _DK),
+            float("nan"),
+            dtype=state_t,
+            device="cuda",
+        )
+    checkpoint_count = _checkpoint_count(config["seq_lens"], config["checkpoint_every_n_tokens"])
+    if checkpoint_count:
+        result["checkpoints"] = torch.full(
+            (checkpoint_count, config["heads"], _DV, _DK), float("nan"), dtype=io_t, device="cuda"
+        )
+    return result
+
+
+def _prepare_data(config):
+    import torch
+
+    config = _normalized_config(config)
+    torch.manual_seed(20260902)
+    total_tokens = sum(config["seq_lens"])
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    k = (0.2 * torch.randn(total_tokens, config["k_heads"], _DK, device="cuda")).to(io_t)
+    v = (0.2 * torch.randn(total_tokens, config["v_heads"], _DV, device="cuda")).to(io_t)
+    gate = torch.empty(total_tokens, config["heads"], _DK, dtype=torch.float32, device="cuda")
+    if config["safe_gate"]:
+        gate.normal_(std=0.2)
+    else:
+        gate.uniform_(-0.08, -0.01)
+    beta = (0.3 * torch.randn(total_tokens, config["heads"], _DK, device="cuda")).to(io_t)
+    if not config["beta_sigmoid"]:
+        beta = beta.sigmoid()
+    w = torch.sigmoid(0.3 * torch.randn(total_tokens, config["heads"], _DV, device="cuda")).to(io_t)
+    cu_t = torch.int64 if config["cu_dtype"] == "int64" else torch.int32
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(config["seq_lens"]).cumsum(0).tolist()], dtype=cu_t, device="cuda"
+    )
+    a_log = (
+        0.1 * torch.randn(config["heads"], dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    dt_bias = (
+        -4.0 + 0.1 * torch.randn(config["heads"], _DK, dtype=torch.float32, device="cuda")
+        if config["safe_gate"]
+        else None
+    )
+    initial_state = (
+        (0.01 * torch.randn(len(config["seq_lens"]), config["heads"], _DV, _DK, device="cuda")).to(
+            state_t
+        )
+        if config["use_initial_state"]
+        else None
+    )
+    outputs = {"tirx": _new_outputs(torch, config), "source": _new_outputs(torch, config)}
+    workspace_bytes = _TENSOR_MAP_BYTES * _TENSOR_MAP_ARRAYS * len(config["seq_lens"])
+    tirx_owner, tirx_workspace = _aligned_i64(torch, workspace_bytes)
+    source_owner, source_workspace = _aligned_i64(torch, workspace_bytes)
+    return {
+        "config": config,
+        "k": k,
+        "v": v,
+        "gate": gate,
+        "beta": beta,
+        "w": w,
+        "cu_seqlens": cu_seqlens,
+        "a_log": a_log,
+        "dt_bias": dt_bias,
+        "initial_state": initial_state,
+        "tirx": outputs["tirx"],
+        "source": outputs["source"],
+        "work": _prepare_work_tables(torch, config),
+        "tirx_workspace": tirx_workspace,
+        "source_workspace": source_workspace,
+        "_workspace_owners": (tirx_owner, source_owner),
+    }
+
+
+def prepare_data(**config):
+    """Allocate one shared input set and independent source/TIRx outputs."""
+    return _prepare_data(config)
+
+
+def _encode_tiled_map(tensor, dimensions, strides, box):
+    import torch
+    from cuda.bindings import driver as cuda
+
+    if tensor.dtype == torch.float16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT16
+    elif tensor.dtype == torch.bfloat16:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_BFLOAT16
+    elif tensor.dtype == torch.float32:
+        data_type = cuda.CUtensorMapDataType.CU_TENSOR_MAP_DATA_TYPE_FLOAT32
+    else:
+        raise TypeError(f"unsupported TensorMap dtype {tensor.dtype}")
+    u64 = cuda.cuuint64_t
+    u32 = cuda.cuuint32_t
+    result, tensor_map = cuda.cuTensorMapEncodeTiled(
+        data_type,
+        len(dimensions),
+        tensor.data_ptr(),
+        [u64(int(value)) for value in dimensions],
+        [u64(int(value)) for value in strides],
+        [u32(int(value)) for value in box],
+        [u32(1) for _ in dimensions],
+        cuda.CUtensorMapInterleave.CU_TENSOR_MAP_INTERLEAVE_NONE,
+        cuda.CUtensorMapSwizzle.CU_TENSOR_MAP_SWIZZLE_128B,
+        cuda.CUtensorMapL2promotion.CU_TENSOR_MAP_L2_PROMOTION_NONE,
+        cuda.CUtensorMapFloatOOBfill.CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    )
+    if result != cuda.CUresult.CUDA_SUCCESS:
+        raise RuntimeError(f"cuTensorMapEncodeTiled failed with {result}")
+    return _AlignedTensorMap([int(word) for word in tensor_map.opaque])
+
+
+def _base_tensor_maps(data, side):
+    config = data["config"]
+    total_tokens = data["k"].shape[0]
+
+    def headed(tensor, channels, heads, box_channels):
+        return _encode_tiled_map(
+            tensor,
+            (channels, heads, total_tokens),
+            (tensor.stride(1) * tensor.element_size(), tensor.stride(0) * tensor.element_size()),
+            (box_channels, 1, _BT),
+        )
+
+    maps = [
+        headed(data["k"], _DK, config["k_heads"], 64),
+        headed(data["v"], _DV, config["v_heads"], 64),
+        headed(data["gate"], _DK, config["heads"], 32),
+        headed(data["beta"], _DK, config["heads"], 64),
+        headed(data["w"], _DV, config["heads"], 64),
+    ]
+    checkpoints = data[side].get("checkpoints")
+    if checkpoints is None:
+        maps.append(maps[-1])
+    else:
+        maps.append(
+            _encode_tiled_map(
+                checkpoints,
+                (_DK, _DV, checkpoints.shape[0], config["heads"]),
+                (
+                    checkpoints.stride(2) * checkpoints.element_size(),
+                    checkpoints.stride(0) * checkpoints.element_size(),
+                    checkpoints.stride(1) * checkpoints.element_size(),
+                ),
+                (64, _DV, 1, 1),
+            )
+        )
+    return maps
+
+
+def _tirx_launch(executables, data):
+    import torch
+
+    config = data["config"]
+    prologue, main = executables
+    maps = _base_tensor_maps(data, "tirx")
+    work = data["work"]["tirx"]
+    output = data["tirx"]
+    io_t = torch.float16 if config["io_dtype"] == "float16" else torch.bfloat16
+    state_t = torch.bfloat16 if config["state_dtype"] == "bfloat16" else torch.float32
+    dummy_i32 = torch.zeros(8, dtype=torch.int32, device="cuda")
+    dummy_io = torch.zeros(1, dtype=io_t, device="cuda")
+    dummy_state = torch.zeros(1, dtype=state_t, device="cuda")
+    dummy_a_log = torch.zeros(config["heads"], dtype=torch.float32, device="cuda")
+    dummy_dt_bias = torch.zeros(config["heads"], _DK, dtype=torch.float32, device="cuda")
+    checkpoint = output.get("checkpoints", dummy_io)
+
+    def launch(*, prologue_only=False):
+        prologue(
+            *(tensor_map.ptr for tensor_map in maps),
+            data["tirx_workspace"],
+            data["cu_seqlens"],
+            data["k"].view(torch.uint8).reshape(-1),
+            data["v"].view(torch.uint8).reshape(-1),
+            data["gate"].view(torch.uint8).reshape(-1),
+            data["beta"].view(torch.uint8).reshape(-1),
+            data["w"].view(torch.uint8).reshape(-1),
+            checkpoint.view(torch.uint8).reshape(-1),
+            work["staging"].reshape(-1) if work["staging"] is not None else dummy_i32,
+            work["work_count"],
+            work["work_items"].reshape(-1),
+            work["sched_all"],
+            len(config["seq_lens"]),
+            data["k"].stride(0) * data["k"].element_size(),
+            data["v"].stride(0) * data["v"].element_size(),
+            data["gate"].stride(0) * data["gate"].element_size(),
+            data["beta"].stride(0) * data["beta"].element_size(),
+            data["w"].stride(0) * data["w"].element_size(),
+            checkpoint.stride(0) * checkpoint.element_size() if checkpoint.ndim > 1 else 0,
+            int(config["checkpoint_every_n_tokens"]),
+        )
+        if prologue_only:
+            return
+        main(
+            data["tirx_workspace"],
+            len(config["seq_lens"]),
+            data["k"].reshape(-1),
+            data["v"].reshape(-1),
+            data["gate"].reshape(-1),
+            data["a_log"] if data["a_log"] is not None else dummy_a_log,
+            (
+                data["dt_bias"].reshape(-1)
+                if data["dt_bias"] is not None
+                else dummy_dt_bias.reshape(-1)
+            ),
+            data["beta"].reshape(-1),
+            data["w"].reshape(-1),
+            data["cu_seqlens"],
+            (
+                data["initial_state"].reshape(-1)
+                if data["initial_state"] is not None
+                else dummy_state
+            ),
+            output.get("final_state", dummy_state).reshape(-1),
+            work["work_items"].reshape(-1),
+            work["work_count"],
+            work["scheduler"] if work["scheduler"] is not None else dummy_i32,
+            int(config["checkpoint_every_n_tokens"]),
+        )
+
+    launch._keep_alive = (maps, dummy_i32, dummy_io, dummy_state, dummy_a_log, dummy_dt_bias)
+    return launch
+
+
+def _load_reference_source():
+    from tirx_kernels.cudnn._reference import load_reference_module
+
+    return load_reference_module("cudnn.linear_attention.frost.kernel.gdn2_recompute_f16")
+
+
+def _source_launch(data):
+    import torch
+
+    source = _load_reference_source()
+    config = data["config"]
+    output = data["source"]
+    work = data["work"]["source"]
+    stream = int(torch.cuda.current_stream().cuda_stream)
+
+    def launch():
+        source.chunk_gdn2_recompute_sm100(
+            data["k"],
+            data["v"],
+            data["gate"],
+            data["beta"],
+            data["w"],
+            data["cu_seqlens"],
+            data["initial_state"],
+            output.get("final_state"),
+            checkpoint_every_n_tokens=int(config["checkpoint_every_n_tokens"]),
+            output_state_checkpoints=output.get("checkpoints"),
+            use_qk_l2norm_in_kernel=bool(config["l2norm"]),
+            safe_gate=bool(config["safe_gate"]),
+            gate_lower_bound=float(config["gate_lower_bound"]),
+            a_log=data["a_log"],
+            dt_bias=data["dt_bias"],
+            use_beta_sigmoid=bool(config["beta_sigmoid"]),
+            work_items=work["work_items"],
+            work_count=work["work_count"],
+            sched_ctr=work["scheduler"],
+            sched_all=work["sched_all"],
+            work_item_scratch=work["staging"],
+            order_in_prologue=True,
+            tensormap_workspace=data["source_workspace"],
+            stream=stream,
+        )
+
+    return launch
+
+
+def _validate_outputs(data, *, sources):
+    import torch
+
+    if "tirx" not in sources or "source" not in sources:
+        return
+    failures = {}
+    for name, actual in data["tirx"].items():
+        expected = data["source"][name]
+        if actual.shape != expected.shape or actual.dtype != expected.dtype:
+            failures[name] = {
+                "actual": (tuple(actual.shape), str(actual.dtype)),
+                "expected": (tuple(expected.shape), str(expected.dtype)),
+            }
+            continue
+        if not torch.equal(actual, expected):
+            actual_f = actual.float()
+            expected_f = expected.float()
+            finite = torch.isfinite(actual_f) & torch.isfinite(expected_f)
+            mismatch = int((actual != expected).sum().item())
+            max_abs = (
+                float((actual_f[finite] - expected_f[finite]).abs().max().item())
+                if bool(finite.any())
+                else float("nan")
+            )
+            failures[name] = {"mismatched": mismatch, "max_abs": max_abs}
+    if failures:
+        raise AssertionError(
+            f"GDN2 recompute exact validation failed for {data['config']}: {failures}; "
+            "required rtol=0, atol=0, equal_nan=False"
+        )
+
+
+def run_test(**config):
+    """Compare TIRx with the upstream kernel on identical inputs."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    config = _normalized_config(config)
+    data = _prepare_data(config)
+    executables = [compile_kernel(func) for func in get_kernel(**config)]
+    tirx_launch = _tirx_launch(executables, data)
+    source_launch = _source_launch(data)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    _validate_outputs(data, sources=("tirx", "source"))
+    return {"tokens": sum(config["seq_lens"]), "heads": config["heads"]}
+
+
+def prepare_bench(**config):
+    """Compile the two TIRx launches without importing torch or touching CUDA."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    config = _normalized_config(config)
+    state = {
+        "config": config,
+        "executables": [compile_kernel(func) for func in get_kernel(**config)],
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    """Validate once, then expose the exact two-launch paths to bench_suite."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = _normalized_config({**prepared["config"], **kwargs})
+    data = _prepare_data(config)
+    tirx_launch = _tirx_launch(prepared["executables"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    if external_references_enabled():
+        source_launch = _source_launch(data)
+        source_launch()
+        torch.cuda.synchronize()
+        _validate_outputs(data, sources=("tirx", "source"))
+        references = {"cudnn_frontend": lambda: source_launch}
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/fastcu/__init__.py
+++ b/tirx_kernels/fastcu/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""TIRx ports of fast.cu kernels."""

--- a/tirx_kernels/fastcu/nvfp4_gemm_gb300.py
+++ b/tirx_kernels/fastcu/nvfp4_gemm_gb300.py
@@ -1,0 +1,1423 @@
+# This file is a TIRx port of code from fast.cu
+# (https://github.com/pranjalssh/fast.cu @ 2dfe5e26aecfd9e5f27bf9d5837deea01acda24b), Copyright (c) 2024 Pranjal Shankhdhar
+# SPDX-License-Identifier: Apache-2.0 AND MIT
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""GB300 NVFP4 GEMM port of fast.cu ``gb300/nvfp4/gemm9.cuh``."""
+
+import ctypes
+import functools
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import tirx_kernels.kern as K
+import tvm
+
+KERNEL_META = {
+    "name": "fastcu_nvfp4_gemm_gb300",
+    "category": "fastcu",
+    "runtime_cuda_archs": ["sm_103a"],
+}
+
+SOURCE_COMMIT = "2dfe5e26aecfd9e5f27bf9d5837deea01acda24b"
+SOURCE_SHA256 = "b9ec1b3f07ed934728499421b7a90bb7f31cbc179960fd2707ecefbf2ec8606c"
+_SOURCE_RELATIVE = Path("gb300/nvfp4/gemm9.cuh")
+_REFERENCE_ADAPTER = Path(__file__).with_name("nvfp4_gemm_gb300_reference.cu")
+
+CONFIGS = [
+    {"M": 128, "N": 256, "K": 16, "label": "minimum_k64_single"},
+    {"M": 256, "N": 256, "K": 32, "label": "minimum_k64_pair"},
+    {"M": 257, "N": 264, "K": 48, "label": "mn_boundary_k96"},
+    {"M": 768, "N": 512, "K": 1136, "label": "ragged_k16"},
+    {"M": 768, "N": 512, "K": 1280, "label": "k64_pair"},
+    {"M": 768, "N": 512, "K": 1024, "label": "k64_single"},
+    {"M": 768, "N": 512, "K": 1120, "label": "k64_inactive"},
+    {"M": 768, "N": 512, "K": 1152, "label": "aligned"},
+    *[
+        {"M": size, "N": size, "K": size, "label": f"square_{size}"}
+        for size in (1024, 2048, 4096, 8192, 16384)
+    ],
+]
+
+BENCH_CONFIGS = [
+    {"M": size, "N": size, "K": size, "label": f"square_{size}"}
+    for size in (1024, 2048, 4096, 8192, 16384)
+]
+
+_NUM_CLUSTERS = 76
+_SMEM_BYTES = 230400
+_AB_READY = 0
+_AB_FREE = 48
+_SF_READY = 96
+_SF_FREE = 152
+_ACC_READY = 208
+_ACC_FREE = 216
+_DEALLOC = 224
+_TMEM_ADDR = 232
+_A_BASE = 1024
+_B_BASE = 99328
+_SFA_BASE = 197632
+_SFB_BASE = 208896
+_AB_STRIDE = 16384
+_SFA_STRIDE = 1536
+_SFB_STRIDE = 3072
+_TRY_WAIT_TICKS = 10000000
+
+_TMA_3D_MCAST = (
+    "cp.async.bulk.tensor.3d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2"
+)
+_TMA_3D = "cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::complete_tx::bytes.cta_group::2"
+_TMA_4D_MCAST = (
+    "cp.async.bulk.tensor.4d.shared::cluster.global"
+    ".mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2"
+)
+_TCGEN05_CP = "tcgen05.cp.cta_group::2.32x128b.warpx4"
+_TCGEN05_MMA = "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X"
+_TCGEN05_COMMIT = (
+    "tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64"
+)
+_TMEM_LD_X32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+
+
+def _ring_next(slot, phase, size):
+    wrap = K.local_scalar("uint32", init=K.cast(slot == size - 1, "uint32"))
+    next_slot = K.local_scalar("int32", init=K.Select(wrap != 0, K.int32(0), slot + 1))
+    next_phase = K.local_scalar("uint32", init=phase ^ wrap)
+    return next_slot, next_phase
+
+
+def _ring_prev(slot, phase, size):
+    at_zero = K.local_scalar("uint32", init=K.cast(slot == 0, "uint32"))
+    prev_slot = K.local_scalar("int32", init=K.Select(at_zero != 0, K.int32(size - 1), slot - 1))
+    prev_phase = K.local_scalar("uint32", init=K.Select(at_zero != 0, phase, phase ^ K.uint32(1)))
+    return prev_slot, prev_phase
+
+
+def _wait_plain(barrier, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _wait_acquire_cta(barrier, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _bit_or64(*values):
+    value = K.uint64(0)
+    for item in values:
+        value = K.bitwise_or(value, K.cast(item, "uint64"))
+    return value
+
+
+def _ab_desc(smbase, region, slot, atom):
+    base = smbase + K.uint32(region) + K.cast(slot * _AB_STRIDE, "uint32")
+    addr = K.cast(
+        K.bitwise_and(K.shift_right(base, K.uint32(4)), K.uint32(0x7FC0)) + K.uint32(atom), "uint64"
+    )
+    lbo = K.cast(K.bitwise_and(K.shift_left(base, K.uint32(12)), K.uint32(0x7FC00000)), "uint64")
+    return _bit_or64(K.uint64(0x4010404000000000), addr, lbo)
+
+
+def _ab_desc_straddle(smbase, region, addr_slot, lbo_slot, atom):
+    d_addr = _ab_desc(smbase, region, addr_slot, atom)
+    d_lbo = _ab_desc(smbase, region, lbo_slot, 0)
+    return _bit_or64(
+        K.bitwise_and(d_addr, K.bitwise_not(K.uint64(0x00000000FFFF0000))),
+        K.bitwise_and(d_lbo, K.uint64(0x00000000FFFF0000)),
+    )
+
+
+def _ab_desc_k64(smbase, region, slot, atom):
+    return K.bitwise_and(
+        _ab_desc(smbase, region, slot, atom), K.bitwise_not(K.uint64(0x00100000FFFF0000))
+    )
+
+
+def _ab_desc_low(smbase, region, slot, atom):
+    """Low word of the source K96 shared-memory operand descriptor."""
+    base = smbase + K.uint32(region) + K.cast(slot * _AB_STRIDE, "uint32")
+    return K.bitwise_or(
+        K.bitwise_and(K.shift_right(base, K.uint32(4)), K.uint32(0x7FC0)) + K.uint32(atom),
+        K.bitwise_and(K.shift_left(base, K.uint32(12)), K.uint32(0x7FC00000)),
+    )
+
+
+def _ab_desc_low_straddle(smbase, region, addr_slot, lbo_slot, atom):
+    addr = _ab_desc_low(smbase, region, addr_slot, atom)
+    lbo = _ab_desc_low(smbase, region, lbo_slot, 0)
+    return K.bitwise_or(
+        K.bitwise_and(addr, K.uint32(0x0000FFFF)), K.bitwise_and(lbo, K.uint32(0xFFFF0000))
+    )
+
+
+def _join_desc(high, low):
+    return K.bitwise_or(K.shift_left(K.cast(high, "uint64"), K.uint32(32)), K.cast(low, "uint64"))
+
+
+def _sf_cp_desc(smbase, region, slot, slot_units, tile):
+    base = smbase + K.uint32(region)
+    addr = K.cast(K.bitwise_and(K.shift_right(base, K.uint32(4)), K.uint32(0x3FC0)), "uint64")
+    desc = _bit_or64(K.uint64(0x400800010000), addr)
+    return desc + K.cast(slot * slot_units + tile * 32, "uint64")
+
+
+def _sf_id_bits(sfa, sfb):
+    return K.bitwise_or(
+        K.bitwise_and(K.shift_right(sfa, K.uint32(1)), K.uint32(0x60000000)),
+        K.bitwise_and(K.shift_right(sfb, K.uint32(26)), K.uint32(48)),
+    )
+
+
+def _half_from_word(word, half):
+    shifted = K.shift_right(word, K.cast(half * 16, "uint32"))
+    return K.cast(K.bitwise_and(shifted, K.uint32(0xFFFF)), "uint16")
+
+
+def _udiv(x, divisor):
+    """Truncating division for values known nonnegative in the source contract."""
+    return K.cast(K.cast(x, "uint32") // K.cast(divisor, "uint32"), "int32")
+
+
+def _umod(x, divisor):
+    """Remainder paired with :func:`_udiv`, without signed floor fixup."""
+    return K.cast(K.cast(x, "uint32") % K.cast(divisor, "uint32"), "int32")
+
+
+def _uceil(x, divisor):
+    """Ceiling division for a nonnegative value and positive divisor."""
+    du = K.cast(divisor, "uint32")
+    return K.cast((K.cast(x, "uint32") + du - K.uint32(1)) // du, "int32")
+
+
+@functools.lru_cache(maxsize=1)
+def make_kernel():
+    """Build the fixed-topology r9 kernel with runtime M/N/K."""
+
+    @K.kernel(warps=7, arch="sm_103a", min_blocks_per_sm=1, grid=(2, 1, _NUM_CLUSTERS))
+    def fastcu_nvfp4_gemm_gb300_kernel(
+        A_tmap: K.TensorMap,
+        B_tmap: K.TensorMap,
+        SFA_tmap: K.TensorMap,
+        SFB_tmap: K.TensorMap,
+        C: K.gptr[K.f16],
+        M: K.i32,
+        N: K.i32,
+        K_dim: K.i32,
+        route_table: K.gptr[K.i32],
+        sm_side: K.gptr[K.i32],
+        cluster_side: K.gptr[K.i32],
+        placement_errors: K.gptr[K.u32],
+    ):
+        crank = K.cta_id_in_cluster([2], preferred=[2])
+        _, _, cluster_id = K.cta_id()
+        tid = K.thread_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+        m_pair = K.cast(crank, "int32") & K.int32(1)
+
+        roles = K.specialize(chain_dispatch=True)
+        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3])
+        mma_role = roles.role("mma", warps=[4], when=m_pair == 0)
+        ab_role = roles.role("ab_tma", warps=[5])
+        sf_role = roles.role("sf_tma", warps=[6])
+
+        smem = K.alloc_buffer((_SMEM_BYTES,), K.u8, scope="shared.dyn", align=1024)
+        smbase = K.local_scalar("uint32", init=K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+
+        cluster_grid_m = K.local_scalar("int32", init=_uceil(M, K.int32(256)))
+        grid_n = K.local_scalar("int32", init=_uceil(N, K.int32(256)))
+        total_tiles = K.local_scalar("int32", init=cluster_grid_m * grid_n)
+        full_groups = K.local_scalar("int32", init=_udiv(K_dim, K.int32(768)))
+        k_rem = K.local_scalar("int32", init=K_dim - full_groups * 768)
+        tail_cells = K.local_scalar("int32", init=_uceil(k_rem, K.int32(96)))
+        t_sf = K.local_scalar("int32", init=_uceil(tail_cells, K.int32(2)))
+        num_groups = K.local_scalar("int32", init=full_groups + K.cast(tail_cells != 0, "int32"))
+        k_rem_mod96 = K.local_scalar("int32", init=_umod(k_rem, K.int32(96)))
+        b64_try = K.local_scalar(
+            "int32",
+            init=K.Select(
+                k_rem_mod96 == 64, K.int32(1), K.Select(k_rem_mod96 == 32, K.int32(2), K.int32(0))
+            ),
+        )
+        a64 = K.local_scalar("int32", init=tail_cells - b64_try)
+        b64 = K.local_scalar(
+            "int32",
+            init=K.Select(
+                (b64_try != 0)
+                & (_umod(k_rem, K.int32(32)) == 0)
+                & (a64 >= 0)
+                & (_umod(a64, K.int32(2)) == 0),
+                b64_try,
+                K.int32(0),
+            ),
+        )
+        t_win = K.local_scalar(
+            "int32",
+            init=K.Select(b64 != 0, _uceil(_udiv(k_rem, K.int32(2)), K.int32(128)), K.int32(3)),
+        )
+
+        smid = K.local_scalar("uint32", init=K.cuda.mov_sreg(32, "smid"))
+        with K.If(tid == 0), K.Then():
+            actual_side = K.local_scalar("int32")
+            planned_side = K.local_scalar("int32")
+            K.ptx.ld.global_.nc.s32(actual_side, sm_side.ptr_to([smid]))
+            K.ptx.ld.global_.nc.s32(planned_side, cluster_side.ptr_to([cluster_id]))
+            with K.If(actual_side != planned_side), K.Then():
+                old = K.local_scalar("uint32")
+                K.ptx.atom.global_.add.u32(old, placement_errors.ptr_to([0]), K.uint32(1))
+
+        with K.If((warp == 0) & (lane == 0)), K.Then():
+            for stage in range(6):
+                K.ptx.mbarrier.init.shared.b64(
+                    K.ptr_byte_offset(smem.ptr_to([0]), _AB_READY + stage * 8, "uint64"),
+                    K.uint32(1),
+                )
+                K.ptx.mbarrier.init.shared.b64(
+                    K.ptr_byte_offset(smem.ptr_to([0]), _AB_FREE + stage * 8, "uint64"), K.uint32(1)
+                )
+            for stage in range(7):
+                K.ptx.mbarrier.init.shared.b64(
+                    K.ptr_byte_offset(smem.ptr_to([0]), _SF_READY + stage * 8, "uint64"),
+                    K.uint32(1),
+                )
+                K.ptx.mbarrier.init.shared.b64(
+                    K.ptr_byte_offset(smem.ptr_to([0]), _SF_FREE + stage * 8, "uint64"), K.uint32(1)
+                )
+            K.ptx.mbarrier.init.shared.b64(
+                K.ptr_byte_offset(smem.ptr_to([0]), _ACC_READY, "uint64"), K.uint32(1)
+            )
+            K.ptx.mbarrier.init.shared.b64(
+                K.ptr_byte_offset(smem.ptr_to([0]), _ACC_FREE, "uint64"), K.uint32(8)
+            )
+            K.ptx.mbarrier.init.shared.b64(
+                K.ptr_byte_offset(smem.ptr_to([0]), _DEALLOC, "uint64"), K.uint32(32)
+            )
+            K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.barrier.cluster.arrive.release.aligned()
+        K.ptx.barrier.cluster.wait.acquire.aligned()
+
+        taddr = K.local_scalar("uint32", init=K.uint32(0))
+        with K.If(warp <= 4), K.Then():
+            with K.If(warp == 0), K.Then():
+                K.ptx["tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32"](
+                    smbase + K.uint32(_TMEM_ADDR), K.uint32(512)
+                )
+            K.ptx.bar.sync(K.uint32(2), K.uint32(160))
+            K.ptx.ld.shared.b32(taddr, K.ptr_byte_offset(smem.ptr_to([0]), _TMEM_ADDR, "uint32"))
+
+        with ab_role:
+            with K.If(K.cuda.elect_sync() != K.uint32(0)), K.Then():
+                slot = K.local_scalar("int32", init=K.int32(0))
+                phase = K.local_scalar("uint32", init=K.uint32(1))
+                work = K.local_scalar("int32", init=cluster_id)
+                with K.While(work < total_tiles):
+                    tile = K.local_scalar("int32")
+                    K.ptx.ld.global_.ca.s32(tile, route_table.ptr_to([work]))
+                    m_row = K.local_scalar("int32", init=_umod(tile, cluster_grid_m))
+                    n_group = K.local_scalar("int32", init=_udiv(tile, cluster_grid_m))
+                    m_block = K.local_scalar("int32", init=m_row * 2 + m_pair)
+                    n_block = K.local_scalar("int32", init=n_group * 2 + m_pair)
+                    group = K.local_scalar("int32", init=K.int32(0))
+                    with K.While(group < num_groups):
+                        for sub in range(3):
+                            with K.If((group < full_groups) | (sub < t_win)), K.Then():
+                                _wait_acquire_cta(
+                                    smbase + K.uint32(_AB_FREE) + K.cast(slot * 8, "uint32"), phase
+                                )
+                                mbar = K.bitwise_and(
+                                    smbase + K.uint32(_AB_READY) + K.cast(slot * 8, "uint32"),
+                                    K.uint32(0xFEFFFFFF),
+                                )
+                                with K.If(m_pair == 0), K.Then():
+                                    K.ptx["mbarrier.arrive.expect_tx.release.cta.shared::cta.b64"](
+                                        mbar, K.uint32(65536)
+                                    )
+                                x = group * 384 + sub * 128
+                                a_dst = (
+                                    smbase + K.uint32(_A_BASE) + K.cast(slot * _AB_STRIDE, "uint32")
+                                )
+                                b_dst = (
+                                    smbase + K.uint32(_B_BASE) + K.cast(slot * _AB_STRIDE, "uint32")
+                                )
+                                K.ptx[_TMA_3D_MCAST](
+                                    a_dst,
+                                    K.address_of(A_tmap),
+                                    K.cast(x, "int32"),
+                                    K.cast(m_block * 128, "int32"),
+                                    K.int32(0),
+                                    mbar,
+                                    K.cast(K.int32(1) << m_pair, "uint16"),
+                                )
+                                K.ptx[_TMA_3D](
+                                    b_dst,
+                                    K.address_of(B_tmap),
+                                    K.cast(x, "int32"),
+                                    K.cast(n_block * 128, "int32"),
+                                    K.int32(0),
+                                    mbar,
+                                )
+                                next_slot, next_phase = _ring_next(slot, phase, 6)
+                                K.assign(slot, next_slot)
+                                K.assign(phase, next_phase)
+                        K.assign(group, group + 1)
+                    K.assign(work, work + _NUM_CLUSTERS)
+                last_slot, last_phase = _ring_prev(slot, phase, 6)
+                _wait_acquire_cta(
+                    smbase + K.uint32(_AB_FREE) + K.cast(last_slot * 8, "uint32"), last_phase
+                )
+                with K.If(m_pair == 0), K.Then():
+                    mbar = K.bitwise_and(
+                        smbase + K.uint32(_AB_READY) + K.cast(last_slot * 8, "uint32"),
+                        K.uint32(0xFEFFFFFF),
+                    )
+                    K.ptx["mbarrier.arrive.expect_tx.release.cta.shared::cta.b64"](
+                        mbar, K.uint32(65536)
+                    )
+
+        with sf_role:
+            with K.If(K.cuda.elect_sync() != K.uint32(0)), K.Then():
+                slot = K.local_scalar("int32", init=K.int32(0))
+                phase = K.local_scalar("uint32", init=K.uint32(1))
+                work = K.local_scalar("int32", init=cluster_id)
+                with K.While(work < total_tiles):
+                    tile = K.local_scalar("int32")
+                    K.ptx.ld.global_.ca.s32(tile, route_table.ptr_to([work]))
+                    m_row = K.local_scalar("int32", init=_umod(tile, cluster_grid_m))
+                    n_group = K.local_scalar("int32", init=_udiv(tile, cluster_grid_m))
+                    m_block = K.local_scalar("int32", init=m_row * 2 + m_pair)
+                    group = K.local_scalar("int32", init=K.int32(0))
+                    with K.While(group < num_groups):
+                        for sub in range(4):
+                            with K.If((group < full_groups) | (sub < t_sf)), K.Then():
+                                _wait_acquire_cta(
+                                    smbase + K.uint32(_SF_FREE) + K.cast(slot * 8, "uint32"), phase
+                                )
+                                mbar = K.bitwise_and(
+                                    smbase + K.uint32(_SF_READY) + K.cast(slot * 8, "uint32"),
+                                    K.uint32(0xFEFFFFFF),
+                                )
+                                with K.If(m_pair == 0), K.Then():
+                                    K.ptx["mbarrier.arrive.expect_tx.release.cta.shared::cta.b64"](
+                                        mbar, K.uint32(9216)
+                                    )
+                                sf_group = (group * 4 + sub) * 3
+                                sfa_dst = (
+                                    smbase
+                                    + K.uint32(_SFA_BASE)
+                                    + K.cast(slot * _SFA_STRIDE, "uint32")
+                                )
+                                sfb_dst = (
+                                    smbase
+                                    + K.uint32(_SFB_BASE)
+                                    + K.cast(slot * _SFB_STRIDE + m_pair * 1536, "uint32")
+                                )
+                                K.ptx[_TMA_4D_MCAST](
+                                    sfa_dst,
+                                    K.address_of(SFA_tmap),
+                                    K.int32(0),
+                                    K.int32(0),
+                                    K.cast(sf_group, "int32"),
+                                    K.cast(m_block, "int32"),
+                                    mbar,
+                                    K.cast(K.int32(1) << m_pair, "uint16"),
+                                )
+                                K.ptx[_TMA_4D_MCAST](
+                                    sfb_dst,
+                                    K.address_of(SFB_tmap),
+                                    K.int32(0),
+                                    K.int32(0),
+                                    K.cast(sf_group, "int32"),
+                                    K.cast(n_group * 2 + m_pair, "int32"),
+                                    mbar,
+                                    K.uint16(3),
+                                )
+                                next_slot, next_phase = _ring_next(slot, phase, 7)
+                                K.assign(slot, next_slot)
+                                K.assign(phase, next_phase)
+                        K.assign(group, group + 1)
+                    K.assign(work, work + _NUM_CLUSTERS)
+                last_slot, last_phase = _ring_prev(slot, phase, 7)
+                _wait_acquire_cta(
+                    smbase + K.uint32(_SF_FREE) + K.cast(last_slot * 8, "uint32"), last_phase
+                )
+                with K.If(m_pair == 0), K.Then():
+                    mbar = K.bitwise_and(
+                        smbase + K.uint32(_SF_READY) + K.cast(last_slot * 8, "uint32"),
+                        K.uint32(0xFEFFFFFF),
+                    )
+                    K.ptx["mbarrier.arrive.expect_tx.release.cta.shared::cta.b64"](
+                        mbar, K.uint32(9216)
+                    )
+
+        with mma_role:
+            with K.If(K.cuda.elect_sync() != K.uint32(0)), K.Then():
+                d_phase = K.local_scalar("uint32", init=K.uint32(1))
+                ab_slot = K.local_scalar("int32", init=K.int32(0))
+                ab_phase = K.local_scalar("uint32", init=K.uint32(0))
+                sf_slot = K.local_scalar("int32", init=K.int32(0))
+                sf_phase = K.local_scalar("uint32", init=K.uint32(0))
+                work = K.local_scalar("int32", init=cluster_id)
+
+                # gemm9 hoists these invariant descriptor halves and TMEM
+                # addresses out of its persistent tile loop. Keeping the same
+                # shape here prevents repeated 64-bit reconstruction between
+                # dependent tcgen05 issues.
+                sfa_src = K.local_scalar("uint64", init=_sf_cp_desc(smbase, _SFA_BASE, 0, 0, 0))
+                sfb_src = K.local_scalar("uint64", init=_sf_cp_desc(smbase, _SFB_BASE, 0, 0, 0))
+                sfa_t0 = K.local_scalar("uint32", init=taddr + K.uint32(476))
+                sfa_t1 = K.local_scalar("uint32", init=taddr + K.uint32(480))
+                sfb_t0 = K.local_scalar("uint32", init=taddr + K.uint32(488))
+                sfb_t1 = K.local_scalar("uint32", init=taddr + K.uint32(496))
+                sfa_w1 = K.local_scalar("uint32", init=K.bitwise_or(sfa_t1, K.uint32(0x80000000)))
+                sfb_w1 = K.local_scalar("uint32", init=K.bitwise_or(sfb_t1, K.uint32(0x80000000)))
+                idesc_w0 = K.local_scalar(
+                    "uint32", init=K.bitwise_or(K.uint32(0x90400480), _sf_id_bits(sfa_t0, sfb_t0))
+                )
+                idesc_w1 = K.local_scalar(
+                    "uint32", init=K.bitwise_or(K.uint32(0x90400480), _sf_id_bits(sfa_w1, sfb_w1))
+                )
+
+                def stage_scale(slot, phase):
+                    _wait_plain(smbase + K.uint32(_SF_READY) + K.cast(slot * 8, "uint32"), phase)
+                    copies = (
+                        (_SFA_BASE, 0, 96, 476),
+                        (_SFA_BASE, 1, 96, 480),
+                        (_SFA_BASE, 2, 96, 484),
+                        (_SFB_BASE, 0, 192, 488),
+                        (_SFB_BASE, 3, 192, 492),
+                        (_SFB_BASE, 1, 192, 496),
+                        (_SFB_BASE, 4, 192, 500),
+                        (_SFB_BASE, 2, 192, 504),
+                        (_SFB_BASE, 5, 192, 508),
+                    )
+                    for region, tile, stride, dst in copies:
+                        src = sfa_src if region == _SFA_BASE else sfb_src
+                        K.ptx[_TCGEN05_CP](
+                            taddr + K.uint32(dst), src + K.cast(slot * stride + tile * 32, "uint64")
+                        )
+                    K.ptx[_TCGEN05_COMMIT](
+                        smbase + K.uint32(_SF_FREE) + K.cast(slot * 8, "uint32"), K.uint16(3)
+                    )
+                    return _ring_next(slot, phase, 7)
+
+                def commit_ab(slot):
+                    K.ptx[_TCGEN05_COMMIT](
+                        smbase + K.uint32(_AB_FREE) + K.cast(slot * 8, "uint32"), K.uint16(3)
+                    )
+
+                def issue96(cell, W0, W1, W2, d_tmem, accum, issue_pred=None):
+                    if cell == 0:
+                        da = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _A_BASE, W0, 0))
+                        db = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _B_BASE, W0, 0))
+                    elif cell == 1:
+                        da = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _A_BASE, W0, 3))
+                        db = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _B_BASE, W0, 3))
+                    elif cell == 2:
+                        da = _join_desc(
+                            K.uint32(0x40104040), _ab_desc_low_straddle(smbase, _A_BASE, W0, W1, 6)
+                        )
+                        db = _join_desc(
+                            K.uint32(0x40104040), _ab_desc_low_straddle(smbase, _B_BASE, W0, W1, 6)
+                        )
+                    elif cell == 3:
+                        da = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _A_BASE, W1, 1))
+                        db = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _B_BASE, W1, 1))
+                    elif cell == 4:
+                        da = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _A_BASE, W1, 4))
+                        db = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _B_BASE, W1, 4))
+                    elif cell == 5:
+                        da = _join_desc(
+                            K.uint32(0x40104040), _ab_desc_low_straddle(smbase, _A_BASE, W1, W2, 7)
+                        )
+                        db = _join_desc(
+                            K.uint32(0x40104040), _ab_desc_low_straddle(smbase, _B_BASE, W1, W2, 7)
+                        )
+                    elif cell == 6:
+                        da = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _A_BASE, W2, 2))
+                        db = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _B_BASE, W2, 2))
+                    else:
+                        da = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _A_BASE, W2, 5))
+                        db = _join_desc(K.uint32(0x40104040), _ab_desc_low(smbase, _B_BASE, W2, 5))
+                    if cell % 2 == 0:
+                        sfa = sfa_t0
+                        sfb = sfb_t0
+                        idesc = idesc_w0
+                    else:
+                        sfa = sfa_w1
+                        sfb = sfb_w1
+                        idesc = idesc_w1
+                    args = (
+                        d_tmem,
+                        da,
+                        db,
+                        idesc,
+                        sfa,
+                        sfb,
+                        K.ptx.pred(K.cast(accum != 0, "uint32")),
+                    )
+                    if issue_pred is None:
+                        K.ptx[_TCGEN05_MMA](*args)
+                    else:
+                        with K.If(issue_pred), K.Then():
+                            K.ptx[_TCGEN05_MMA](*args)
+
+                def issue64(slot, atom, word, d_tmem, accum):
+                    da = _join_desc(
+                        K.uint32(0x40004040),
+                        K.bitwise_and(
+                            _ab_desc_low(smbase, _A_BASE, slot, atom), K.uint32(0x0000FFFF)
+                        ),
+                    )
+                    db = _join_desc(
+                        K.uint32(0x40004040),
+                        K.bitwise_and(
+                            _ab_desc_low(smbase, _B_BASE, slot, atom), K.uint32(0x0000FFFF)
+                        ),
+                    )
+                    if word == 0:
+                        sfa = sfa_t0
+                        sfb = sfb_t0
+                    else:
+                        sfa = sfa_t1
+                        sfb = sfb_t1
+                    idesc = K.bitwise_or(K.uint32(0x10400480), _sf_id_bits(sfa, sfb))
+                    K.ptx[_TCGEN05_MMA](
+                        d_tmem, da, db, idesc, sfa, sfb, K.ptx.pred(K.cast(accum != 0, "uint32"))
+                    )
+
+                def issue_k64_variant(a_count, b_count, d_tmem, accum, need_wait, acc_wait):
+                    W0 = K.local_scalar("int32", init=ab_slot)
+                    ph0 = K.local_scalar("uint32", init=ab_phase)
+                    W1, ph1 = _ring_next(W0, ph0, 6)
+                    W2, ph2 = _ring_next(W1, ph1, 6)
+                    n_cells = a_count + b_count
+                    t_windows = (a_count * 96 + b_count * 64 + 255) // 256
+
+                    specs = []
+                    for cell in range(a_count):
+                        specs.append(("k96", cell))
+                    if a_count == 0:
+                        specs.append(("k64", W0, 0, 0))
+                        if b_count == 2:
+                            specs.append(("k64", W0, 2, 1))
+                    elif a_count == 2:
+                        specs.append(("k64", W0, 6, 0))
+                        if b_count == 2:
+                            specs.append(("k64", W1, 0, 1))
+                    elif a_count == 4:
+                        specs.append(("k64", W1, 4, 0))
+                        if b_count == 2:
+                            specs.append(("k64", W1, 6, 1))
+                    else:
+                        specs.append(("k64", W2, 2, 0))
+                        if b_count == 2:
+                            specs.append(("k64", W2, 4, 1))
+
+                    def issue_at(index):
+                        if index < len(specs):
+                            spec = specs[index]
+                            if spec[0] == "k96":
+                                issue96(spec[1], W0, W1, W2, d_tmem, accum)
+                            else:
+                                issue64(spec[1], spec[2], spec[3], d_tmem, accum)
+                            K.assign(accum, K.uint32(1))
+
+                    ns, np = stage_scale(sf_slot, sf_phase)
+                    K.assign(sf_slot, ns)
+                    K.assign(sf_phase, np)
+                    _wait_plain(smbase + K.uint32(_AB_READY) + K.cast(W0 * 8, "uint32"), ph0)
+                    with K.If(need_wait != 0), K.Then():
+                        _wait_plain(smbase + K.uint32(_ACC_FREE), acc_wait)
+                        K.assign(need_wait, K.uint32(0))
+                    issue_at(0)
+                    issue_at(1)
+
+                    if n_cells > 2:
+                        ns, np = stage_scale(sf_slot, sf_phase)
+                        K.assign(sf_slot, ns)
+                        K.assign(sf_phase, np)
+                    if t_windows >= 2:
+                        _wait_plain(smbase + K.uint32(_AB_READY) + K.cast(W1 * 8, "uint32"), ph1)
+                    issue_at(2)
+                    commit_ab(W0)
+                    issue_at(3)
+
+                    if n_cells > 4:
+                        ns, np = stage_scale(sf_slot, sf_phase)
+                        K.assign(sf_slot, ns)
+                        K.assign(sf_phase, np)
+                    issue_at(4)
+                    if t_windows >= 3:
+                        _wait_plain(smbase + K.uint32(_AB_READY) + K.cast(W2 * 8, "uint32"), ph2)
+                    if t_windows == 1:
+                        K.assign(ab_slot, W1)
+                        K.assign(ab_phase, ph1)
+                    elif t_windows == 2:
+                        K.assign(ab_slot, W2)
+                        K.assign(ab_phase, ph2)
+                    else:
+                        ns_ab, np_ab = _ring_next(W2, ph2, 6)
+                        K.assign(ab_slot, ns_ab)
+                        K.assign(ab_phase, np_ab)
+                    issue_at(5)
+
+                    if n_cells > 6:
+                        ns, np = stage_scale(sf_slot, sf_phase)
+                        K.assign(sf_slot, ns)
+                        K.assign(sf_phase, np)
+                    if t_windows >= 2:
+                        commit_ab(W1)
+                    issue_at(6)
+                    issue_at(7)
+                    if t_windows >= 3:
+                        commit_ab(W2)
+
+                with K.While(work < total_tiles):
+                    acc_wait = K.local_scalar("uint32", init=d_phase)
+                    K.assign(d_phase, d_phase ^ K.uint32(1))
+                    d_tmem = taddr + d_phase * K.uint32(220)
+                    accum = K.local_scalar("uint32", init=K.uint32(0))
+                    need_wait = K.local_scalar("uint32", init=K.uint32(1))
+                    group = K.local_scalar("int32", init=K.int32(0))
+
+                    with K.While(group < full_groups):
+                        W0 = K.local_scalar("int32", init=ab_slot)
+                        ph0 = K.local_scalar("uint32", init=ab_phase)
+                        W1, ph1 = _ring_next(W0, ph0, 6)
+                        W2, ph2 = _ring_next(W1, ph1, 6)
+
+                        ns, np = stage_scale(sf_slot, sf_phase)
+                        K.assign(sf_slot, ns)
+                        K.assign(sf_phase, np)
+                        _wait_plain(smbase + K.uint32(_AB_READY) + K.cast(W0 * 8, "uint32"), ph0)
+                        with K.If(need_wait != 0), K.Then():
+                            _wait_plain(smbase + K.uint32(_ACC_FREE), acc_wait)
+                            K.assign(need_wait, K.uint32(0))
+                        issue96(0, W0, W1, W2, d_tmem, accum)
+                        K.assign(accum, K.uint32(1))
+                        issue96(1, W0, W1, W2, d_tmem, accum)
+
+                        ns, np = stage_scale(sf_slot, sf_phase)
+                        K.assign(sf_slot, ns)
+                        K.assign(sf_phase, np)
+                        _wait_plain(smbase + K.uint32(_AB_READY) + K.cast(W1 * 8, "uint32"), ph1)
+                        issue96(2, W0, W1, W2, d_tmem, accum)
+                        commit_ab(W0)
+                        issue96(3, W0, W1, W2, d_tmem, accum)
+
+                        ns, np = stage_scale(sf_slot, sf_phase)
+                        K.assign(sf_slot, ns)
+                        K.assign(sf_phase, np)
+                        issue96(4, W0, W1, W2, d_tmem, accum)
+                        _wait_plain(smbase + K.uint32(_AB_READY) + K.cast(W2 * 8, "uint32"), ph2)
+                        ns_ab, np_ab = _ring_next(W2, ph2, 6)
+                        K.assign(ab_slot, ns_ab)
+                        K.assign(ab_phase, np_ab)
+                        issue96(5, W0, W1, W2, d_tmem, accum)
+
+                        ns, np = stage_scale(sf_slot, sf_phase)
+                        K.assign(sf_slot, ns)
+                        K.assign(sf_phase, np)
+                        commit_ab(W1)
+                        issue96(6, W0, W1, W2, d_tmem, accum)
+                        issue96(7, W0, W1, W2, d_tmem, accum)
+                        commit_ab(W2)
+                        K.assign(group, group + 1)
+
+                    with K.If(tail_cells != 0), K.Then():
+                        with K.If(b64 != 0), K.Then():
+                            for ac in (0, 2, 4, 6):
+                                for bc in (1, 2):
+                                    with K.If((a64 == ac) & (b64 == bc)), K.Then():
+                                        issue_k64_variant(
+                                            ac, bc, d_tmem, accum, need_wait, acc_wait
+                                        )
+                        with K.If(b64 == 0), K.Then():
+                            W0 = K.local_scalar("int32", init=ab_slot)
+                            ph0 = K.local_scalar("uint32", init=ab_phase)
+                            W1, ph1 = _ring_next(W0, ph0, 6)
+                            W2, ph2 = _ring_next(W1, ph1, 6)
+
+                            ns, np = stage_scale(sf_slot, sf_phase)
+                            K.assign(sf_slot, ns)
+                            K.assign(sf_phase, np)
+                            _wait_plain(
+                                smbase + K.uint32(_AB_READY) + K.cast(W0 * 8, "uint32"), ph0
+                            )
+                            with K.If(need_wait != 0), K.Then():
+                                _wait_plain(smbase + K.uint32(_ACC_FREE), acc_wait)
+                                K.assign(need_wait, K.uint32(0))
+                            issue96(0, W0, W1, W2, d_tmem, accum)
+                            K.assign(accum, K.uint32(1))
+                            issue96(1, W0, W1, W2, d_tmem, accum, issue_pred=tail_cells >= 2)
+
+                            with K.If(tail_cells > 2), K.Then():
+                                ns, np = stage_scale(sf_slot, sf_phase)
+                                K.assign(sf_slot, ns)
+                                K.assign(sf_phase, np)
+                            _wait_plain(
+                                smbase + K.uint32(_AB_READY) + K.cast(W1 * 8, "uint32"), ph1
+                            )
+                            issue96(2, W0, W1, W2, d_tmem, accum, issue_pred=tail_cells >= 3)
+                            commit_ab(W0)
+                            issue96(3, W0, W1, W2, d_tmem, accum, issue_pred=tail_cells >= 4)
+
+                            with K.If(tail_cells > 4), K.Then():
+                                ns, np = stage_scale(sf_slot, sf_phase)
+                                K.assign(sf_slot, ns)
+                                K.assign(sf_phase, np)
+                            issue96(4, W0, W1, W2, d_tmem, accum, issue_pred=tail_cells >= 5)
+                            _wait_plain(
+                                smbase + K.uint32(_AB_READY) + K.cast(W2 * 8, "uint32"), ph2
+                            )
+                            ns_ab, np_ab = _ring_next(W2, ph2, 6)
+                            K.assign(ab_slot, ns_ab)
+                            K.assign(ab_phase, np_ab)
+                            issue96(5, W0, W1, W2, d_tmem, accum, issue_pred=tail_cells >= 6)
+
+                            with K.If(tail_cells > 6), K.Then():
+                                ns, np = stage_scale(sf_slot, sf_phase)
+                                K.assign(sf_slot, ns)
+                                K.assign(sf_phase, np)
+                            commit_ab(W1)
+                            issue96(6, W0, W1, W2, d_tmem, accum, issue_pred=tail_cells >= 7)
+                            issue96(7, W0, W1, W2, d_tmem, accum, issue_pred=tail_cells >= 8)
+                            commit_ab(W2)
+
+                    K.ptx[_TCGEN05_COMMIT](smbase + K.uint32(_ACC_READY), K.uint16(3))
+                    K.assign(work, work + _NUM_CLUSTERS)
+                _wait_plain(smbase + K.uint32(_ACC_FREE), d_phase)
+
+        with epilogue_role:
+            d_buffer = K.local_scalar("int32", init=K.int32(0))
+            acc_phase = K.local_scalar("uint32", init=K.uint32(0))
+            work = K.local_scalar("int32", init=cluster_id)
+            values = K.alloc_local((32,), "float32")
+            packed = K.alloc_local((16,), "uint32")
+            taddr_lane = K.local_scalar(
+                "uint32", init=K.shift_left(K.cast(warp * 32, "uint32"), K.uint32(16))
+            )
+            even_crank = K.local_scalar(
+                "uint32", init=K.bitwise_and(K.cast(crank, "uint32"), K.uint32(0xFFFFFFFE))
+            )
+            with K.While(work < total_tiles):
+                tile_lane = K.local_scalar("int32")
+                K.ptx.ld.global_.ca.s32(tile_lane, route_table.ptr_to([work]))
+                tile = K.local_scalar("uint32")
+                K.ptx.redux_sync.min.u32(tile, K.cast(tile_lane, "uint32"), K.uint32(0xFFFFFFFF))
+                m_row = K.local_scalar("int32", init=_umod(tile, cluster_grid_m))
+                n_group = K.local_scalar("int32", init=_udiv(tile, cluster_grid_m))
+                off_n = K.local_scalar("int32", init=n_group * 256)
+                _wait_plain(smbase + K.uint32(_ACC_READY), acc_phase)
+                K.assign(acc_phase, acc_phase ^ K.uint32(1))
+                tmem_base = K.local_scalar("uint32", init=taddr + K.cast(d_buffer * 220, "uint32"))
+                row = K.local_scalar("int32", init=(m_row * 2 + m_pair) * 128 + warp * 32 + lane)
+                row_in = K.local_scalar("uint32", init=K.cast(row < M, "uint32"))
+                row_base = K.local_scalar("int64", init=K.cast(row, "int64") * N)
+                c_addr = K.reinterpret("uint64", C.ptr_to([0]))
+                aligned = K.local_scalar(
+                    "uint32",
+                    init=K.cast(
+                        (K.bitwise_and(row_base, K.int32(15)) == 0)
+                        & (K.bitwise_and(c_addr, K.uint64(31)) == 0),
+                        "uint32",
+                    ),
+                )
+                with K.serial(0, 8) as k:
+                    band = K.Select(d_buffer == 0, 7 - k, k)
+                    load_addr = tmem_base + K.cast(band * 32, "uint32") + taddr_lane
+                    K.ptx[_TMEM_LD_X32](*[values[i] for i in range(32)], load_addr)
+                    with K.If(k == 1), K.Then():
+                        mapped_free = K.local_scalar("uint32")
+                        K.ptx.mapa.shared__cluster.u32(
+                            mapped_free, smbase + K.uint32(_ACC_FREE), even_crank
+                        )
+                        K.ptx.tcgen05.wait__ld.sync.aligned()
+                        K.ptx["mbarrier.arrive.release.cta.shared::cluster.b64"](
+                            mapped_free, K.uint32(1), pred=K.cast(lane == 0, "uint32")
+                        )
+                    with K.If(row_in != 0), K.Then():
+                        for pair in range(16):
+                            K.ptx.cvt.rn.f16x2.f32(
+                                packed[pair], values[pair * 2 + 1], values[pair * 2]
+                            )
+                        col = K.local_scalar("int32", init=off_n + band * 32)
+                        with K.If(aligned != 0), K.Then():
+                            for q in range(2):
+                                c16 = col + q * 16
+                                with K.If(c16 + 16 <= N), K.Then():
+                                    K.ptx["st.global.L1::no_allocate.L2::evict_first.v8.b32"](
+                                        C.ptr_to([row_base + c16]),
+                                        *[packed[q * 8 + i] for i in range(8)],
+                                    )
+                                with K.If(c16 + 16 > N), K.Then():
+                                    for p in range(2):
+                                        c8 = c16 + p * 8
+                                        with K.If(c8 + 8 <= N), K.Then():
+                                            K.ptx["st.global.L1::no_allocate.v4.b32"](
+                                                C.ptr_to([row_base + c8]),
+                                                *[packed[q * 8 + p * 4 + i] for i in range(4)],
+                                            )
+                                        with K.If(c8 + 8 > N), K.Then():
+                                            for h in range(8):
+                                                word = q * 8 + p * 4 + h // 2
+                                                K.ptx.st.global_.b16(
+                                                    C.ptr_to([row_base + c8 + h]),
+                                                    _half_from_word(packed[word], h % 2),
+                                                    pred=K.cast(c8 + h < N, "uint32"),
+                                                )
+                        with K.If(aligned == 0), K.Then():
+                            for q in range(4):
+                                c8 = col + q * 8
+                                with K.If(c8 + 8 <= N), K.Then():
+                                    K.ptx["st.global.L1::no_allocate.v4.b32"](
+                                        C.ptr_to([row_base + c8]),
+                                        *[packed[q * 4 + i] for i in range(4)],
+                                    )
+                                with K.If(c8 + 8 > N), K.Then():
+                                    for h in range(8):
+                                        word = q * 4 + h // 2
+                                        K.ptx.st.global_.b16(
+                                            C.ptr_to([row_base + c8 + h]),
+                                            _half_from_word(packed[word], h % 2),
+                                            pred=K.cast(c8 + h < N, "uint32"),
+                                        )
+                K.assign(d_buffer, K.int32(1) - d_buffer)
+                K.assign(work, work + _NUM_CLUSTERS)
+
+            K.ptx.bar.sync(K.uint32(3), K.uint32(128))
+            with K.If(warp == 0), K.Then():
+                K.ptx["tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned"]()
+                remote_dealloc = K.local_scalar("uint32")
+                K.ptx.mapa.shared__cluster.u32(
+                    remote_dealloc,
+                    smbase + K.uint32(_DEALLOC),
+                    K.cast(crank, "uint32") ^ K.uint32(1),
+                )
+                K.ptx["mbarrier.arrive.release.cta.shared::cluster.b64"](
+                    remote_dealloc, K.uint32(1)
+                )
+                _wait_acquire_cta(smbase + K.uint32(_DEALLOC), K.uint32(0))
+                K.ptx["tcgen05.dealloc.cta_group::2.sync.aligned.b32"](taddr, K.uint32(512))
+
+    return fastcu_nvfp4_gemm_gb300_kernel
+
+
+SWIZZLE_NONE = 0
+SWIZZLE_128B = 3
+
+
+class _AlignedTensorMap:
+    __slots__ = ("_storage", "ptr")
+
+    def __init__(self):
+        self._storage = ctypes.create_string_buffer(192)
+        base = ctypes.addressof(self._storage)
+        self.ptr = ctypes.c_void_p((base + 63) & ~63)
+
+
+def _encode_tiled(dtype, tensor, *, dims, strides_bytes, box, swizzle):
+    descriptor = _AlignedTensorMap()
+    tvm.get_global_func("runtime.cuTensorMapEncodeTiled")(
+        descriptor.ptr,
+        dtype,
+        len(dims),
+        ctypes.c_void_p(int(tensor.data_ptr())),
+        *dims,
+        *strides_bytes,
+        *box,
+        *((1,) * len(dims)),
+        0,
+        swizzle,
+        0,
+        0,
+    )
+    return descriptor
+
+
+def _build_tensor_maps(M, N, K_dim, A, B, SFA, SFB):
+    row_bytes = K_dim // 2
+    row_stride = (row_bytes + 15) & ~15
+    sf_inner = ((K_dim + 63) // 64) * 4
+    return [
+        _encode_tiled(
+            "uint8",
+            A,
+            dims=(row_bytes, M, 1),
+            strides_bytes=(row_stride, M * row_stride),
+            box=(128, 128, 1),
+            swizzle=SWIZZLE_128B,
+        ),
+        _encode_tiled(
+            "uint8",
+            B,
+            dims=(row_bytes, N, 1),
+            strides_bytes=(row_stride, N * row_stride),
+            box=(128, 128, 1),
+            swizzle=SWIZZLE_128B,
+        ),
+        _encode_tiled(
+            "uint8",
+            SFA,
+            dims=(128, 4, sf_inner // 4, (M + 127) // 128),
+            strides_bytes=(128, 512, sf_inner * 128),
+            box=(128, 4, 3, 1),
+            swizzle=SWIZZLE_NONE,
+        ),
+        _encode_tiled(
+            "uint8",
+            SFB,
+            dims=(128, 4, sf_inner // 4, (N + 127) // 128),
+            strides_bytes=(128, 512, sf_inner * 128),
+            box=(128, 4, 3, 1),
+            swizzle=SWIZZLE_NONE,
+        ),
+    ]
+
+
+def _fastcu_source_root() -> Path:
+    override = os.environ.get("FASTCU_PATH")
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates = (
+        (Path(override),)
+        if override
+        else (
+            repo_root / ".reference-deps" / "fast-cu",
+            Path("/root-vol/aarch64-ws/kernel-libs/gb300/fast.cu"),
+        )
+    )
+    for root in candidates:
+        source = root / _SOURCE_RELATIVE
+        if not source.is_file():
+            continue
+        actual = hashlib.sha256(source.read_bytes()).hexdigest()
+        if actual != SOURCE_SHA256:
+            raise RuntimeError(f"frozen fast.cu source hash mismatch: {source} sha256={actual}")
+        try:
+            commit = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        except (OSError, subprocess.CalledProcessError) as error:
+            raise RuntimeError(f"cannot verify fast.cu checkout {root}: {error}") from error
+        if commit != SOURCE_COMMIT:
+            raise RuntimeError(f"frozen fast.cu checkout mismatch: {root} commit={commit}")
+        return root
+    tried = ", ".join(str(root) for root in candidates)
+    raise RuntimeError(f"frozen fast.cu source is unavailable; tried: {tried}")
+
+
+@functools.lru_cache(maxsize=1)
+def _reference_library():
+    import fcntl
+
+    source_root = _fastcu_source_root()
+    nvcc = os.environ.get("CUDACXX", "nvcc")
+    version = subprocess.run([nvcc, "--version"], check=True, capture_output=True, text=True).stdout
+    digest = hashlib.sha256(
+        _REFERENCE_ADAPTER.read_bytes()
+        + (source_root / _SOURCE_RELATIVE).read_bytes()
+        + version.encode()
+        + b"-lineinfo"
+    ).hexdigest()[:20]
+    cache_root = Path(os.environ.get("TIRX_BENCH_CACHE_DIR", "/tmp/tirx-kernels-cache"))
+    build_dir = cache_root / "fastcu" / "nvfp4_gemm_gb300"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    library_path = build_dir / f"reference-{digest}.so"
+    lock_path = build_dir / f"reference-{digest}.lock"
+    with lock_path.open("w") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        if not library_path.is_file():
+            temporary = build_dir / f"reference-{digest}-{os.getpid()}.tmp.so"
+            command = [
+                nvcc,
+                "-std=c++17",
+                "-O3",
+                "-DNDEBUG",
+                "-lineinfo",
+                "--shared",
+                "-Xcompiler=-fPIC",
+                "-gencode",
+                "arch=compute_103a,code=sm_103a",
+                f"-I{source_root / 'gb300' / 'nvfp4'}",
+                str(_REFERENCE_ADAPTER),
+                "-o",
+                str(temporary),
+                "-lcuda",
+                "-lcudart",
+            ]
+            try:
+                subprocess.run(command, check=True, capture_output=True, text=True)
+                os.replace(temporary, library_path)
+            except subprocess.CalledProcessError as error:
+                temporary.unlink(missing_ok=True)
+                raise RuntimeError(
+                    "fast.cu reference compilation failed:\n" + error.stdout + error.stderr
+                ) from error
+    lib = ctypes.CDLL(str(library_path))
+    pointer = ctypes.c_void_p
+    lib.fastcu_nvfp4_prepare_schedule.argtypes = [
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        pointer,
+        pointer,
+        pointer,
+        pointer,
+    ]
+    lib.fastcu_nvfp4_prepare_schedule.restype = ctypes.c_int
+    lib.fastcu_nvfp4_create.argtypes = [
+        pointer,
+        pointer,
+        pointer,
+        pointer,
+        pointer,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+    ]
+    lib.fastcu_nvfp4_create.restype = pointer
+    lib.fastcu_nvfp4_launch.argtypes = [pointer, pointer]
+    lib.fastcu_nvfp4_launch.restype = ctypes.c_int
+    lib.fastcu_nvfp4_source_placement_errors.argtypes = [ctypes.POINTER(ctypes.c_uint32)]
+    lib.fastcu_nvfp4_source_placement_errors.restype = ctypes.c_int
+    lib.fastcu_nvfp4_destroy.argtypes = [pointer]
+    lib.fastcu_nvfp4_destroy.restype = None
+    lib.fastcu_nvfp4_ptx_version.argtypes = []
+    lib.fastcu_nvfp4_ptx_version.restype = ctypes.c_int
+    if lib.fastcu_nvfp4_ptx_version() != 93:
+        raise RuntimeError("fast.cu reference was not built for PTX ISA 9.3")
+    return lib
+
+
+def _pack_vec16_scales(logical, outer, K_dim):
+    import torch
+
+    logical_inner = K_dim // 16
+    sf_inner = ((K_dim + 63) // 64) * 4
+    packed_outer = ((outer + 127) // 128) * 128
+    packed = torch.zeros(packed_outer * sf_inner, device=logical.device, dtype=torch.uint8)
+    o = torch.arange(outer, device=logical.device, dtype=torch.int64)[:, None]
+    j = torch.arange(logical_inner, device=logical.device, dtype=torch.int64)[None, :]
+    offset = (
+        ((j // 4) * 4 + (o // 128) * sf_inner) * 128
+        + (o % 32) * 16
+        + ((o % 128) // 32) * 4
+        + (j % 4)
+    )
+    packed[offset.reshape(-1)] = logical.reshape(-1)
+    return packed
+
+
+def prepare_data(M: int, N: int, K: int, **_: Any):
+    """Create deterministic source-format packed E2M1 and VEC16 scale buffers."""
+    import torch
+
+    if M <= 0 or N <= 0 or K <= 0 or K % 16:
+        raise ValueError("M and N must be positive; K must be a positive multiple of 16")
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed((M * 1000003 + N * 1009 + K) & 0x7FFFFFFF)
+    row_bytes = K // 2
+    row_stride = (row_bytes + 15) & ~15
+    A_host = torch.zeros((M, row_stride), dtype=torch.uint8)
+    B_host = torch.zeros((N, row_stride), dtype=torch.uint8)
+    A_host[:, :row_bytes] = torch.randint(0, 256, (M, row_bytes), generator=gen, dtype=torch.uint8)
+    B_host[:, :row_bytes] = torch.randint(0, 256, (N, row_bytes), generator=gen, dtype=torch.uint8)
+    scale_values = torch.tensor([0x30, 0x34, 0x38, 0x3C, 0x40, 0x28, 0x2C], dtype=torch.uint8)
+    A_sf_logical = scale_values[torch.randint(0, len(scale_values), (M, K // 16), generator=gen)]
+    B_sf_logical = scale_values[torch.randint(0, len(scale_values), (N, K // 16), generator=gen)]
+
+    def guarded_u8(value):
+        storage = torch.full((value.numel() + 256,), 0xA5, device="cuda", dtype=torch.uint8)
+        view = storage[: value.numel()].view(value.shape)
+        view.copy_(value)
+        return view, storage[value.numel() :]
+
+    A, A_guard = guarded_u8(A_host.cuda())
+    B, B_guard = guarded_u8(B_host.cuda())
+    SFA, SFA_guard = guarded_u8(_pack_vec16_scales(A_sf_logical.cuda(), M, K))
+    SFB, SFB_guard = guarded_u8(_pack_vec16_scales(B_sf_logical.cuda(), N, K))
+    C_storage = torch.full((M * N + 64,), 12345.0, device="cuda", dtype=torch.float16)
+    C_source_storage = torch.full_like(C_storage, 12345.0)
+    C = C_storage[: M * N]
+    C_source = C_source_storage[: M * N]
+    route = torch.zeros(4096, device="cuda", dtype=torch.int32)
+    total_tiles = ((M + 255) // 256) * ((N + 255) // 256)
+    route[:total_tiles] = torch.arange(total_tiles, device="cuda", dtype=torch.int32)
+    sm_side = torch.zeros(256, device="cuda", dtype=torch.int32)
+    cluster_side = torch.zeros(128, device="cuda", dtype=torch.int32)
+    placement = torch.zeros(1, device="cuda", dtype=torch.uint32)
+    return {
+        "A": A,
+        "B": B,
+        "SFA": SFA,
+        "SFB": SFB,
+        "C": C,
+        "C_source": C_source,
+        "route": route,
+        "sm_side": sm_side,
+        "cluster_side": cluster_side,
+        "placement": placement,
+        "guards": (
+            ("A", A_guard, 0xA5),
+            ("B", B_guard, 0xA5),
+            ("SFA", SFA_guard, 0xA5),
+            ("SFB", SFB_guard, 0xA5),
+            ("C", C_storage[M * N :], 12345.0),
+            ("C_source", C_source_storage[M * N :], 12345.0),
+        ),
+    }
+
+
+class _Runner:
+    def __init__(self):
+        previous = os.environ.get("TVM_CUDA_COMPILE_MODE")
+        previous_reg_level = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+        os.environ["TVM_CUDA_COMPILE_MODE"] = "nvcc"
+        if previous_reg_level is None:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = "4"
+        try:
+            self.lib = make_kernel().compile()
+        finally:
+            if previous is None:
+                os.environ.pop("TVM_CUDA_COMPILE_MODE", None)
+            else:
+                os.environ["TVM_CUDA_COMPILE_MODE"] = previous
+            if previous_reg_level is None:
+                os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+            else:
+                os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous_reg_level
+        self._maps = None
+        self._map_key = None
+
+    def __call__(self, data, M, N, K_dim):
+        key = tuple(int(data[name].data_ptr()) for name in ("A", "B", "SFA", "SFB"))
+        if key != self._map_key:
+            self._maps = _build_tensor_maps(
+                M, N, K_dim, data["A"], data["B"], data["SFA"], data["SFB"]
+            )
+            self._map_key = key
+        self.lib(
+            *[descriptor.ptr for descriptor in self._maps],
+            data["C"],
+            M,
+            N,
+            K_dim,
+            data["route"],
+            data["sm_side"],
+            data["cluster_side"],
+            data["placement"],
+        )
+        return data["C"].view(M, N)
+
+
+class _SourceRunner:
+    def __init__(self, data, M, N, K_dim):
+        import torch
+
+        self.lib = _reference_library()
+        stream = ctypes.c_void_p(torch.cuda.current_stream().cuda_stream)
+        status = self.lib.fastcu_nvfp4_prepare_schedule(
+            M,
+            N,
+            K_dim,
+            ctypes.c_void_p(data["route"].data_ptr()),
+            ctypes.c_void_p(data["sm_side"].data_ptr()),
+            ctypes.c_void_p(data["cluster_side"].data_ptr()),
+            stream,
+        )
+        if status != 0:
+            raise RuntimeError(f"fast.cu schedule preparation failed: CUDA error {status}")
+        self.handle = self.lib.fastcu_nvfp4_create(
+            *[
+                ctypes.c_void_p(data[name].data_ptr())
+                for name in ("A", "B", "SFA", "SFB", "C_source")
+            ],
+            M,
+            N,
+            K_dim,
+        )
+        if not self.handle:
+            raise RuntimeError("fast.cu reference handle creation failed")
+
+    def __call__(self):
+        import torch
+
+        stream = ctypes.c_void_p(torch.cuda.current_stream().cuda_stream)
+        status = self.lib.fastcu_nvfp4_launch(self.handle, stream)
+        if status != 0:
+            raise RuntimeError(f"fast.cu reference launch failed: CUDA error {status}")
+
+    def placement_errors(self):
+        value = ctypes.c_uint32()
+        status = self.lib.fastcu_nvfp4_source_placement_errors(ctypes.byref(value))
+        if status != 0:
+            raise RuntimeError(f"fast.cu placement readback failed: CUDA error {status}")
+        return value.value
+
+    def close(self):
+        if self.handle:
+            self.lib.fastcu_nvfp4_destroy(self.handle)
+            self.handle = None
+
+
+_RUNNER = None
+
+
+def _runner():
+    global _RUNNER
+    if _RUNNER is None:
+        _RUNNER = _Runner()
+    return _RUNNER
+
+
+def _check_guards(data):
+    import torch
+
+    for name, guard, expected in data["guards"]:
+        if not bool(torch.all(guard == expected).item()):
+            raise AssertionError(f"{name} allocation guard was modified")
+
+
+def _check_bitwise(data, M, N):
+    import torch
+
+    actual = data["C"].view(M, N)
+    expected = data["C_source"].view(M, N)
+    if not bool(torch.isfinite(actual).all()) or not bool(torch.isfinite(expected).all()):
+        raise AssertionError("source/TIRx output contains non-finite or poison values")
+    if torch.equal(actual, expected):
+        return {"bitwise": True, "max_abs_diff": 0.0}
+    difference = (actual.float() - expected.float()).abs()
+    worst = int(torch.argmax(difference).item())
+    raise AssertionError(
+        "fastcu_nvfp4_gemm_gb300 bitwise mismatch against frozen gemm9: "
+        f"differing={int((actual != expected).sum().item())}, "
+        f"max_abs_diff={float(difference.max().item())}, "
+        f"actual={float(actual.reshape(-1)[worst].item())}, "
+        f"expected={float(expected.reshape(-1)[worst].item())}, "
+        f"flat_index={worst}"
+    )
+
+
+def run_test(**config: Any):
+    """Compile and compare one deterministic configuration to frozen gemm9."""
+    import torch
+
+    M, N, K_dim = (int(config[name]) for name in ("M", "N", "K"))
+    data = prepare_data(M, N, K_dim)
+    data["C"].fill_(float("nan"))
+    data["C_source"].fill_(float("nan"))
+    source = _SourceRunner(data, M, N, K_dim)
+    try:
+        _runner()(data, M, N, K_dim)
+        source()
+        torch.cuda.synchronize()
+        if int(data["placement"].item()) != 0 or source.placement_errors() != 0:
+            raise AssertionError("source/TIRx placement audit failed")
+        result = _check_bitwise(data, M, N)
+        _check_guards(data)
+        data["C"].fill_(float("nan"))
+        _runner()(data, M, N, K_dim)
+        torch.cuda.synchronize()
+        if not torch.equal(data["C"], data["C_source"]):
+            raise AssertionError("TIRx repeat launch is not bitwise deterministic")
+        if int(data["placement"].item()) != 0:
+            raise AssertionError("TIRx repeat-launch placement audit failed")
+        _check_guards(data)
+        return result
+    finally:
+        source.close()
+
+
+def prepare_bench(**config: Any):
+    """Compile the TIRx kernel before GPU benchmark setup."""
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    M, N, K_dim = (int(config[name]) for name in ("M", "N", "K"))
+    state = {"config": {"M": M, "N": N, "K": K_dim}, "runner": _runner()}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **_):
+    """Benchmark one TIRx launch and optionally the pinned gemm9 launch."""
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    M, N, K_dim = (prepared["config"][name] for name in ("M", "N", "K"))
+    data = prepare_data(M, N, K_dim)
+    data["C"].fill_(float("nan"))
+    data["C_source"].fill_(float("nan"))
+    source = _SourceRunner(data, M, N, K_dim)
+
+    def tirx_launch():
+        return prepared["runner"](data, M, N, K_dim)
+
+    try:
+        tirx_launch()
+        with_source = external_references_enabled()
+        references = None
+        if with_source:
+            source()
+            references = {"fastcu_gemm9": lambda: source}
+        torch.cuda.synchronize()
+        if int(data["placement"].item()) != 0:
+            raise AssertionError("TIRx placement audit failed before timing")
+        if not bool(torch.isfinite(data["C"]).all()):
+            raise AssertionError("TIRx output contains non-finite or poison values")
+        if with_source:
+            if source.placement_errors() != 0:
+                raise AssertionError("source placement audit failed before timing")
+            _check_bitwise(data, M, N)
+        _check_guards(data)
+        result = bench(
+            {"tirx": tirx_launch},
+            references=references,
+            warmup=warmup,
+            repeat=repeat,
+            timer=timer,
+            rounds=rounds,
+            cooldown_s=cooldown_s,
+        )
+        torch.cuda.synchronize()
+        if int(data["placement"].item()) != 0:
+            raise AssertionError("TIRx placement audit failed during timing")
+        if with_source and source.placement_errors() != 0:
+            raise AssertionError("source placement audit failed during timing")
+        _check_guards(data)
+        return result
+    finally:
+        source.close()
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **config: Any):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "make_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/fastcu/nvfp4_gemm_gb300_reference.cu
+++ b/tirx_kernels/fastcu/nvfp4_gemm_gb300_reference.cu
@@ -1,0 +1,177 @@
+// This file is a TIRx port of code from fast.cu
+// (https://github.com/pranjalssh/fast.cu @
+// 2dfe5e26aecfd9e5f27bf9d5837deea01acda24b), Copyright (c) 2024 Pranjal
+// Shankhdhar SPDX-License-Identifier: Apache-2.0 AND MIT
+// SPDX-FileCopyrightText: Copyright TIRx authors
+
+#include "gemm9.cuh"
+
+#include <array>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+namespace {
+
+constexpr int kTableMode = 1;
+
+struct SourceHandle {
+  CUtensorMap a;
+  CUtensorMap b;
+  CUtensorMap sfa;
+  CUtensorMap sfb;
+  __half *c;
+  int m;
+  int n;
+  int k;
+  int clusters;
+};
+
+struct DevicePlan {
+  int sms = 0;
+  int clusters = 0;
+  bool ready = false;
+  l2side::RuntimeMap map;
+  sched::Census census;
+};
+
+DevicePlan &device_plan() {
+  static DevicePlan plan;
+  return plan;
+}
+
+void configure_source(DevicePlan &plan) {
+  if (plan.ready)
+    return;
+  int device = 0;
+  CUDA_CHECK(cudaGetDevice(&device));
+  cudaDeviceProp prop{};
+  CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+  plan.sms = prop.multiProcessorCount;
+  plan.clusters = plan.sms / nvfp4::CTA_GROUP;
+  if (plan.sms != 152 || plan.clusters != 76)
+    std::abort();
+  CUDA_CHECK(cudaFuncSetAttribute(nvfp4::nvfp4_gemm_kernel,
+                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                  int(sizeof(nvfp4::SmemCD))));
+  CUDA_CHECK(cudaFuncSetAttribute(nvfp4::l2a_cluster_probe,
+                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                  int(sizeof(nvfp4::SmemCD))));
+
+  constexpr uint64_t kProbeBytes = uint64_t(2) << 20;
+  void *raw = nullptr;
+  CUDA_CHECK(cudaMalloc(&raw, 2 * kProbeBytes));
+  char *arena = reinterpret_cast<char *>(
+      (reinterpret_cast<uintptr_t>(raw) + kProbeBytes - 1) &
+      ~(kProbeBytes - 1));
+  plan.map = l2side::probe_stable(arena, kProbeBytes, 3);
+  CUDA_CHECK(cudaFree(raw));
+  if (plan.map.nsm != plan.sms || plan.map.hash != l2side::kExpectedHash ||
+      plan.map.model_mismatches != 0) {
+    std::abort();
+  }
+
+  unsigned *d_smids = nullptr;
+  const size_t count = size_t(plan.clusters) * nvfp4::CTA_GROUP;
+  CUDA_CHECK(cudaMalloc(&d_smids, count * sizeof(unsigned)));
+  CUDA_CHECK(cudaMemset(d_smids, 0xff, count * sizeof(unsigned)));
+  nvfp4::l2a_cluster_probe<<<nvfp4::launch_grid(plan.clusters), nvfp4::TB_SIZE,
+                             sizeof(nvfp4::SmemCD)>>>(d_smids);
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+  std::vector<unsigned> smids(count);
+  CUDA_CHECK(cudaMemcpy(smids.data(), d_smids, count * sizeof(unsigned),
+                        cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaFree(d_smids));
+  plan.census = sched::classify_census(smids, plan.map, plan.sms);
+  plan.ready = true;
+}
+
+size_t operand_read_bytes(int m, int n, int k) {
+  const size_t row_stride = size_t((k / 2 + 15) & ~15);
+  const size_t sf_inner = size_t((k + 63) / 64) * 4;
+  const size_t sfa = size_t((m + 127) / 128) * 128 * sf_inner;
+  const size_t sfb = size_t((n + 127) / 128) * 128 * sf_inner;
+  return size_t(m + n) * row_stride + sfa + sfb;
+}
+
+std::vector<int> make_schedule(DevicePlan &plan, int m, int n, int k) {
+  const int mblocks = (m + nvfp4::CLUSTER_M - 1) / nvfp4::CLUSTER_M;
+  const int nblocks = (n + nvfp4::BLOCK_N - 1) / nvfp4::BLOCK_N;
+  const int total = mblocks * nblocks;
+  if (total > nvfp4::L2A_ROUTE_WORK_CAP)
+    std::abort();
+  const sched::ScheduleMode mode =
+      sched::pick_schedule(operand_read_bytes(m, n, k), mblocks, nblocks);
+  std::vector<int> table =
+      sched::build_schedule(plan.census, mblocks, nblocks, mode);
+  if (table.empty()) {
+    table.resize(total);
+    std::iota(table.begin(), table.end(), 0);
+  }
+  return table;
+}
+
+} // namespace
+
+extern "C" int fastcu_nvfp4_prepare_schedule(int m, int n, int k, int *route,
+                                             int *sm_side, int *cluster_side,
+                                             cudaStream_t stream) {
+  DevicePlan &plan = device_plan();
+  configure_source(plan);
+  std::vector<int> table = make_schedule(plan, m, n, k);
+  sched::upload_side_constants(plan.map, plan.census);
+  sched::upload_table(table, kTableMode);
+  std::array<int, nvfp4::L2A_ROUTE_WORK_CAP> route_full{};
+  std::copy(table.begin(), table.end(), route_full.begin());
+  std::array<int, nvfp4::L2A_CLUSTER_CAP> cluster_full{};
+  std::copy(plan.census.cluster_side.begin(), plan.census.cluster_side.end(),
+            cluster_full.begin());
+  CUDA_CHECK(cudaMemcpyAsync(route, route_full.data(), sizeof(route_full),
+                             cudaMemcpyHostToDevice, stream));
+  CUDA_CHECK(cudaMemcpyAsync(sm_side, plan.map.sm_side.data(),
+                             sizeof(plan.map.sm_side), cudaMemcpyHostToDevice,
+                             stream));
+  CUDA_CHECK(cudaMemcpyAsync(cluster_side, cluster_full.data(),
+                             sizeof(cluster_full), cudaMemcpyHostToDevice,
+                             stream));
+  return 0;
+}
+
+extern "C" void *fastcu_nvfp4_create(void *a, void *b, void *sfa, void *sfb,
+                                     void *c, int m, int n, int k) {
+  DevicePlan &plan = device_plan();
+  configure_source(plan);
+  auto *handle = new SourceHandle{};
+  const int row_stride = (k / 2 + 15) & ~15;
+  handle->a = host::make_ab_tmap(a, m, k, row_stride);
+  handle->b = host::make_ab_tmap(b, n, k, row_stride);
+  handle->sfa = host::make_sf_tmap(static_cast<uint8_t *>(sfa), m, k);
+  handle->sfb = host::make_sf_tmap(static_cast<uint8_t *>(sfb), n, k);
+  handle->c = static_cast<__half *>(c);
+  handle->m = m;
+  handle->n = n;
+  handle->k = k;
+  handle->clusters = plan.clusters;
+  return handle;
+}
+
+extern "C" int fastcu_nvfp4_launch(void *opaque, cudaStream_t stream) {
+  auto *handle = static_cast<SourceHandle *>(opaque);
+  nvfp4::nvfp4_gemm_kernel<<<nvfp4::launch_grid(handle->clusters),
+                             nvfp4::TB_SIZE, sizeof(nvfp4::SmemCD), stream>>>(
+      handle->a, handle->b, handle->sfa, handle->sfb, handle->c, handle->m,
+      handle->n, handle->k, kTableMode * nvfp4::L2A_ROUTE_WORK_CAP);
+  return int(cudaPeekAtLastError());
+}
+
+extern "C" int fastcu_nvfp4_source_placement_errors(unsigned *value) {
+  return int(cudaMemcpyFromSymbol(value, nvfp4::l2a_placement_errors,
+                                  sizeof(*value), 0, cudaMemcpyDeviceToHost));
+}
+
+extern "C" void fastcu_nvfp4_destroy(void *opaque) {
+  delete static_cast<SourceHandle *>(opaque);
+}
+
+extern "C" int fastcu_nvfp4_ptx_version() { return 93; }

--- a/tirx_kernels/flashattention/flash_attention4_fp4.py
+++ b/tirx_kernels/flashattention/flash_attention4_fp4.py
@@ -1,0 +1,2119 @@
+# This file is a TIRx port of code from flash-attention-fp4
+# (https://github.com/hao-ai-lab/flash-attention-fp4 @ 5aa37a9680f7b76a11799b5f4846100ed5a3e6d8),
+# Copyright (c) 2022, the respective contributors, as shown by
+# licenses/AUTHORS.flash-attention.txt
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Block-scaled FP4/MXFP8 FlashAttention-4 forward (SM103) with K-owned launch, roles,
+storage, and synchronization.
+
+Upstream source: flash_attn/cute/flash_fwd_sm100_fp4.py (class
+``FlashAttentionForwardSm100``), with the helpers it dispatches to:
+flash_attn/cute/blackwell_helpers.py (``gemm_ptx_partial_fp4``, ``tmem_ld_red_max``,
+``packed_float_to_e2m1`` / ``packed_float_to_ue4m3`` / ``packed_float_to_ue8m0``),
+flash_attn/cute/softmax.py (``SoftmaxSm100``), flash_attn/cute/mma_sm100_desc.py,
+flash_attn/cute/tile_scheduler.py, flash_attn/cute/block_info.py, flash_attn/cute/mask.py,
+flash_attn/cute/pack_gqa.py, and the dispatch in flash_attn/cute/interface.py.
+
+One traced kernel covers the six GB300 headline modes of the upstream README. ``qk_format``
+selects NVFP4 (E2M1 data, E4M3 scale per 16) or MXFP8 (E4M3 data, E8M0 scale per 32) for Q and
+K; ``pv_format`` selects a BF16, FP8 E4M3, NVFP4, or MXFP8 V (the last two also quantize the
+softmax output P on the fly). Head dim 128 for every mode, head dim 64 additionally for the
+NVFP4-QK modes with BF16 or FP8 V. GQA runs the unpacked path (``pack_gqa=False``): the upstream default packs Q heads, but
+the fork's FP4 kernel is numerically wrong there, so both sides use one Q head per tile.
+The SM103 defaults of the upstream tuning table are baked in: hardware ``tcgen05.ld.red``
+row max, no exp2 emulation, log-domain NVFP4 P quantization.
+"""
+
+# K.kernel consumes concrete annotations; postponed annotations would stringify them.
+import math
+import os
+from typing import Any
+
+import tirx_kernels.kern as K
+
+# ---------------------------------------------------------------------------------------------
+# Static specialization (orig: FlashAttentionForwardSm100.__init__ / _setup_attributes)
+# ---------------------------------------------------------------------------------------------
+
+BLK_M = 128  # m_block_size (orig:L129)
+BLK_N = 128  # n_block_size (orig:L130)
+Q_STAGE = 2  # two Q tiles per CTA (orig:L166)
+EPI_STAGE = 2  # orig:L370
+TMEM_COLS = 512  # orig:L219-220
+SMEM_BUDGET = 227 * 1024  # orig:L374
+BUFFER_ALIGN = 1024  # orig:L275
+NUM_WARPS = 16
+SOFTMAX0_WARPS = (0, 1, 2, 3)  # orig:L210
+SOFTMAX1_WARPS = (4, 5, 6, 7)  # orig:L211
+CORRECTION_WARPS = (8, 9, 10, 11)  # orig:L213
+MMA_WARP = 12  # orig:L215
+EPILOGUE_WARP = 13  # orig:L216
+LOAD_WARP = 14  # orig:L217
+EMPTY_WARP = 15  # orig:L218
+
+# (qk_format, pv_format) pairs that the upstream README benchmarks on GB300.
+MODES = [
+    ("nvfp4", "bf16"),
+    ("nvfp4", "fp8"),
+    ("nvfp4", "nvfp4"),
+    ("nvfp4", "mxfp8"),
+    ("mxfp8", "bf16"),
+    ("mxfp8", "fp8"),
+]
+
+_QK_WIDTH = {"nvfp4": 4, "mxfp8": 8}
+_QK_SF_VEC = {"nvfp4": 16, "mxfp8": 32}
+_PV_WIDTH = {"bf16": 16, "fp8": 8, "nvfp4": 4, "mxfp8": 8}
+_PV_SF_VEC = {"nvfp4": 16, "mxfp8": 32}  # only the quantized-PV formats carry P/V scales
+
+
+def _align_up(x, a):
+    return (x + a - 1) // a * a
+
+
+def ceildiv(a, b):
+    return (a + b - 1) // b
+
+
+class Spec:
+    """Everything ``__init__`` / ``_setup_attributes`` / ``__call__`` derive at trace time."""
+
+    def __init__(self, qk_format, pv_format, head_dim, is_causal, num_qo_heads, num_kv_heads):
+        if (qk_format, pv_format) not in MODES:
+            raise ValueError(f"unsupported mode {qk_format}+{pv_format}; supported: {MODES}")
+        if head_dim not in (64, 128):
+            raise ValueError("head_dim must be 64 or 128")
+        if head_dim == 64 and (qk_format, pv_format) not in (("nvfp4", "bf16"), ("nvfp4", "fp8")):
+            # orig README: head_dim >= sf_vec_size * 4 for every block-scaled operand.
+            raise ValueError("head_dim 64 is only supported for NVFP4 QK with BF16 or FP8 V")
+        if num_qo_heads % num_kv_heads:
+            raise ValueError("num_qo_heads must be a multiple of num_kv_heads")
+        self.qk_format = qk_format
+        self.pv_format = pv_format
+        self.head_dim = head_dim
+        self.head_dim_v = head_dim
+        self.is_causal = is_causal
+        self.qhead_per_kvhead = num_qo_heads // num_kv_heads
+        # The upstream interface defaults to pack_gqa=True for GQA (interface.py:432), but the
+        # fork's FP4 kernel is numerically wrong on that path (scale-factor indexing; measured
+        # cos_sim 0.94 vs fp64 where the unpacked path and the fork's BF16 kernel give 1.0000).
+        # Both sides therefore run the unpacked GQA path (pack_gqa=False): one Q head per tile,
+        # kv head = head // qhead_per_kvhead (orig:L2014-2016).
+        self.pack_gqa = False
+        # orig interface.py:955-960: persistent iff no causal/local/varlen/split.
+        self.is_persistent = not is_causal
+
+        self.quant_qk = True
+        self.quant_pv = pv_format in _PV_SF_VEC
+        self.q_width = self.k_width = _QK_WIDTH[qk_format]
+        self.v_width = _PV_WIDTH[pv_format]
+        self.o_width = 16
+        self.sf_vec_size = _QK_SF_VEC[qk_format]
+        self.sf_vec_size_pv = _PV_SF_VEC.get(pv_format, self.sf_vec_size)
+        self.sf_e8m0 = qk_format == "mxfp8"  # E8M0 QK scales, else E4M3
+        self.sf_pv_e8m0 = pv_format == "mxfp8"
+        self.p_width = self.v_width  # P is produced in V's dtype (orig:L2771)
+
+        # orig:L344-358 -- 256-bit MMA operand tile in K.
+        self.mma_inst_tile_k = head_dim // (64 if self.q_width == 4 else 32)
+        self.mma_inst_tile_k_pv = BLK_N // (64 if self.sf_vec_size_pv == 16 else 32)
+        # K per tcgen05.mma instruction for each GEMM.
+        self.qk_mma_k = 64 if self.q_width == 4 else 32
+        self.pv_mma_k = {16: 16, 8: 32, 4: 64}[self.v_width]
+        self.qk_k_tiles = head_dim // self.qk_mma_k
+        self.pv_k_tiles = BLK_N // self.pv_mma_k
+
+        # Register split (orig:L260-274). Warp 15 takes the warpgroup budget (48) instead of the
+        # upstream 24 because setmaxnreg must be warpgroup-uniform under K.specialize.
+        if head_dim < 96:
+            self.num_regs_softmax, self.num_regs_correction, self.num_regs_other = 200, 64, 48
+        else:
+            self.num_regs_softmax, self.num_regs_correction = 192, 80
+            self.num_regs_other = 512 - self.num_regs_softmax * 2 - self.num_regs_correction
+        assert self.num_regs_other == 48
+
+        # TMEM column map (orig:L243-258).
+        self.tmem_s_offset = [0, BLK_N]
+        self.tmem_o_offset = [2 * BLK_N + i * self.head_dim_v for i in range(Q_STAGE)]
+        self.tmem_total = self.tmem_o_offset[-1] + self.head_dim_v
+        assert self.tmem_total <= TMEM_COLS
+        self.tmem_s_to_p_offset = BLK_N // 2
+        self.tmem_p_offset = [s + self.tmem_s_to_p_offset for s in self.tmem_s_offset]
+        self.tmem_vec_offset = self.tmem_s_offset
+
+        self._setup_smem()
+        self.p_split = self.mbar_p_split(self.pv_k_tiles)
+        # TMEM P-store chunking (orig:L2790-2809): 32x32b repetition per tcgen05.st.
+        p_cols = BLK_N * self.p_width // 32
+        # bf16 P: repetition 16; every narrower P: 8. The upstream d<=64 fp8 default of 4 is
+        # overridden by the pinned FA4_FP8_PV_TMEM_STORE_REP=8 (orig:L2790-2801).
+        self.p_store_rep = 16 if self.v_width == 16 else 8
+        self.p_store_chunks = p_cols // self.p_store_rep
+        self.p_store_split = self.mbar_p_split(self.p_store_chunks)
+
+    def mbar_p_split(self, k):
+        """orig:L1105-1125 with the default FA4_*_P_SPLIT_NUM/DEN knobs."""
+        if self.v_width == 8 and k > 1:
+            return max(
+                1, min(k - 1, k * 3 // 4)
+            )  # FA4_FP8_PV_P_SPLIT_NUM/DEN = 3/4 at every head_dim
+        if self.v_width > 8:
+            return k // 4 * 3
+        return max(1, min(k - 1, k * 1 // 2))
+
+    def _setup_smem(self):
+        """orig:_setup_attributes L369-424 (kv_stage from the 227 KB budget)."""
+        d, dv = self.head_dim, self.head_dim_v
+        smem_mbar = 512
+        smem_tmem = 4
+        smem_sScale = _align_up(Q_STAGE * BLK_M * 2 * 4, BUFFER_ALIGN)
+        q_per_stage = BLK_M * d * self.q_width // 8
+        o_per_stage = BLK_M * dv * self.o_width // 8
+        smem_sO = _align_up(o_per_stage * EPI_STAGE, BUFFER_ALIGN)
+        smem_sQ = _align_up(q_per_stage * Q_STAGE, BUFFER_ALIGN)
+        sfq_per_stage = BLK_M * d // self.sf_vec_size
+        sfp_per_stage = BLK_M * dv // self.sf_vec_size_pv
+        smem_sSFQ = _align_up(sfq_per_stage * Q_STAGE, BUFFER_ALIGN)
+        smem_sSFP = _align_up(sfp_per_stage * Q_STAGE, BUFFER_ALIGN) if self.quant_pv else 0
+        smem_fixed = smem_mbar + smem_tmem + smem_sScale + smem_sO + smem_sQ + smem_sSFQ + smem_sSFP
+        k_per_stage = BLK_M * d * self.k_width // 8
+        v_per_stage = BLK_M * dv * self.v_width // 8
+        self.k_aliases_v = self.k_width < self.v_width  # orig:L1157
+        self.v_aliases_k = self.v_width == self.k_width  # orig:L1163
+        if self.v_aliases_k or self.k_aliases_v:
+            kv_per_stage = max(k_per_stage, v_per_stage)
+        else:
+            kv_per_stage = k_per_stage + v_per_stage
+        sfk_per_stage = BLK_N * d // self.sf_vec_size
+        sfv_per_stage = BLK_N * dv // self.sf_vec_size_pv
+        kv_per_stage += sfk_per_stage
+        fields = 3
+        if self.quant_pv:
+            kv_per_stage += sfv_per_stage
+            fields += 1
+        kv_per_stage += fields * 128
+        kv_stage = (SMEM_BUDGET - smem_fixed) // kv_per_stage
+        if not self.quant_pv and self.v_width == 8 and dv >= 128:
+            kv_stage = min(kv_stage, 4)  # fp8_pv_kv_stage_cap (orig:L417-424)
+        self.kv_stage = kv_stage
+        # Byte sizes of the SharedStorage fields (orig:L1139-1192).
+        self.q_stage_bytes = q_per_stage
+        self.k_stage_bytes = k_per_stage
+        self.v_stage_bytes = v_per_stage
+        self.o_stage_bytes = o_per_stage
+        self.sfq_stage_bytes = sfq_per_stage
+        self.sfk_stage_bytes = sfk_per_stage
+        self.sfp_stage_bytes = sfp_per_stage if self.quant_pv else 0
+        self.sfv_stage_bytes = sfv_per_stage if self.quant_pv else 0
+        self.tma_bytes_q = q_per_stage + sfq_per_stage
+        self.tma_bytes_k = k_per_stage + sfk_per_stage
+        self.tma_bytes_v = v_per_stage + (sfv_per_stage if self.quant_pv else 0)
+
+
+# ---------------------------------------------------------------------------------------------
+# Kernel (orig: FlashAttentionForwardSm100.kernel)
+# ---------------------------------------------------------------------------------------------
+
+# PTX spellings (one call is one instruction).
+TMA_G2S_4D = (
+    "cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+TMA_G2S_5D = (
+    "cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.L2::cache_hint"
+)
+TMA_S2G_4D = "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group.L2::cache_hint"
+TMA_PREFETCH_4D = "cp.async.bulk.prefetch.tensor.4d.L2.global.tile"
+# KV blocks prefetched into L2 ahead of the ring by the load warp (perf-gate addition, see
+# make_kernel): the ring holds at most kv_stage/2 blocks, which at kv_stage 3 (bf16 V with an
+# e4m3 K, 48 KB per block) does not cover a cold-L2 HBM fetch once the block time drops
+# below ~1.2 us. Measured mxfp8_bf16 b1 s4096 h24 cold-L2: 125.7 us -> see ledger it-004.
+KV_L2_PREFETCH_DISTANCE = 2  # applied only to rings of KV_L2_PREFETCH_MAX_STAGES or fewer slots
+# Deeper rings hide the latency themselves and the prefetch cost them 1-2% on long streams.
+KV_L2_PREFETCH_MAX_STAGES = 3
+TCGEN05_CP = "tcgen05.cp.cta_group::1.32x128b.warpx4"
+TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+TMEM_LD_RED_X32 = "tcgen05.ld.red.sync.aligned.32x32b.x32.max.f32"
+TMEM_LD_X16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+TMEM_ST_X16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
+MMA_MXF4NVF4_4X = "tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X"
+# `.block32` is the PTX 9.x spelling of `.scale_vec::1X`; the export writes the latter.
+MMA_MXF8F6F4_1X = "tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32"
+MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+MMA_F8F6F4 = "tcgen05.mma.cta_group::1.kind::f8f6f4"
+NEG_INF = float("-inf")
+L2_SIZE = 50 * 1024 * 1024  # tile_scheduler.py:428
+# instruction descriptors, taken verbatim from the export (`mov.b32 idesc, ...`)
+IDESC_QK_NVFP4 = 0x08201680
+IDESC_BLOCK32_BASE = 0x08A00000  # | k << 29 | k << 4 (a_sf_id / b_sf_id = k)
+IDESC_PV_BF16 = {128: 0x08210490, 64: 0x08110490}
+IDESC_PV_FP8 = {128: 0x08210010, 64: 0x08110010}
+IDESC_PV_NVFP4 = 0x08201680
+# cuTensorMapEncodeTiled enums
+_TMA_SWIZZLE = {0: 0, 32: 1, 64: 2, 128: 3}
+_TMA_L2_PROMOTION_128B = 2
+EXPECTED_KV_STAGE = {  # settled by the exports (fact 9 of the sketch)
+    ("nvfp4", "bf16", 128): 4,
+    ("nvfp4", "fp8", 128): 4,
+    ("nvfp4", "nvfp4", 128): 13,
+    ("nvfp4", "mxfp8", 128): 7,
+    ("mxfp8", "bf16", 128): 3,
+    ("mxfp8", "fp8", 128): 4,
+    ("nvfp4", "bf16", 64): 10,
+    ("nvfp4", "fp8", 64): 20,
+}
+
+
+def _l2_swizzle(seq_len_kv, head_dim, head_dim_v, element_size):
+    """tile_scheduler.py:426-434 (SingleTileLPTScheduler)."""
+    size_one_head = seq_len_kv * (head_dim + head_dim_v) * element_size
+    if L2_SIZE < size_one_head:
+        return 1
+    return 1 << math.floor(math.log2(L2_SIZE // size_one_head))
+
+
+def make_kernel(spec: Spec, batch_size, seq_len_q, seq_len_kv, num_qo_heads, num_kv_heads, num_sms):
+    """Trace the kernel for one specialization."""
+    import inspect
+
+    D, DV = spec.head_dim, spec.head_dim_v
+    gqa = spec.qhead_per_kvhead
+    heads = num_qo_heads  # unpacked GQA: one Q head per tile
+    num_m_blocks = ceildiv(seq_len_q, Q_STAGE * BLK_M)
+    num_tiles = batch_size * heads * num_m_blocks
+    grid = min(num_sms, num_tiles) if spec.is_persistent else num_tiles
+    is_causal = spec.is_causal
+    quant_pv = spec.quant_pv
+    pv_format, qk_format = spec.pv_format, spec.qk_format
+    kv_stage = spec.kv_stage
+    assert kv_stage == EXPECTED_KV_STAGE[(qk_format, pv_format, D)], (
+        kv_stage,
+        qk_format,
+        pv_format,
+        D,
+    )
+    QK_KT, PV_KT = spec.qk_k_tiles, spec.pv_k_tiles
+    SF_TILE_K = D // (4 * spec.sf_vec_size)
+    SF_TILE_K_PV = BLK_N // (4 * spec.sf_vec_size_pv) if quant_pv else 0
+    P_COLS = BLK_N * spec.p_width // 32
+    P_REP = spec.p_store_rep
+    P_CHUNKS = spec.p_store_chunks
+    P_SPLIT = spec.p_store_split
+    PV_SPLIT = spec.p_split
+    max_offset = {"nvfp4": math.log2(6.0), "mxfp8": math.log2(448.0)}.get(pv_format, 0.0)
+    rescale_threshold = 0.0 if quant_pv else 8.0
+    q_stage_bytes, k_stage_bytes, v_stage_bytes = (
+        spec.q_stage_bytes,
+        spec.k_stage_bytes,
+        spec.v_stage_bytes,
+    )
+    kv_slot_bytes = (
+        max(k_stage_bytes, v_stage_bytes) if (spec.k_aliases_v or spec.v_aliases_k) else None
+    )
+    o_stage_bytes = spec.o_stage_bytes
+    sfq_chunk_bytes = 512 * SF_TILE_K
+    kv_prefetch = KV_L2_PREFETCH_DISTANCE if kv_stage <= KV_L2_PREFETCH_MAX_STAGES else 0
+    sfv_chunk_bytes = 512 * SF_TILE_K_PV
+    # smem descriptor fields (16 B units); hi words match the export: 0x80004020 / 0xC0004010 / 0x40004040.
+    qk_row_bytes = D * spec.q_width // 8
+    QK_SWIZZLE = {32: 1, 64: 2, 128: 3}[qk_row_bytes]
+    QK_SBO = 8 * qk_row_bytes // 16
+    if pv_format in ("bf16", "fp8"):  # MN-major V: rows of min(DV, 64 bf16 | DV e4m3) elements
+        v_row_bytes = min(DV, 64) * 2 if pv_format == "bf16" else DV
+        v_k_step16 = (
+            spec.pv_mma_k * v_row_bytes // 16
+        )  # +0x80 (bf16), +0x100 / +0x80 (e4m3 d128 / d64)
+        # LBO (export `or.b32 lo, 1024 << 16` for bf16 d128): the 16 KB stride between the two 64-column
+        # swizzle-atom halves along N; a single-atom V (e4m3, or DV = 64) carries 0.
+        V_LBO = 1024 if (pv_format == "bf16" and DV == 128) else 0
+    else:  # K-major V: rows of 128 keys
+        v_row_bytes = BLK_N * spec.v_width // 8
+        v_k_step16 = 2  # 32 B per K tile
+        V_LBO = 1  # K-major swizzled: unused, written as 1 like Q/K (export `or.b32 lo, 65536`)
+    V_SWIZZLE = {32: 1, 64: 2, 128: 3}[v_row_bytes]
+    V_SBO = 8 * v_row_bytes // 16
+    v_half_bytes = 128 * 128 if pv_format == "bf16" else 0  # bf16 V: 64-column halves
+    # TMEM columns (:243-258, :1594-1700), allocation base asserted 0.
+    TMEM_S = spec.tmem_s_offset
+    TMEM_O = spec.tmem_o_offset
+    TMEM_P = spec.tmem_p_offset
+    TMEM_SFQ = [TMEM_S[1], TMEM_S[0]]
+    TMEM_SFK = [TMEM_S[1] + 4 * QK_KT, TMEM_S[0] + 4 * QK_KT]
+    TMEM_SFP = [TMEM_S[0], TMEM_S[1]]
+    TMEM_SFV = [TMEM_S[0] + 4 * SF_TILE_K_PV, TMEM_S[1] + 4 * SF_TILE_K_PV]
+    l2_swizzle = _l2_swizzle(seq_len_kv, D, DV, max(spec.k_width // 8, 1))
+    n_block_max_all = ceildiv(seq_len_kv, BLK_N)
+
+    params = [
+        ("tmap_q", K.TensorMap),
+        ("tmap_k", K.TensorMap),
+        ("tmap_v", K.TensorMap),
+        ("tmap_o", K.TensorMap),
+        ("tmap_sfq", K.TensorMap),
+        ("tmap_sfk", K.TensorMap),
+    ]
+    if quant_pv:
+        params.append(("tmap_sfv", K.TensorMap))
+    params.append(("softmax_scale_log2", K.f32))
+    names = tuple(n for n, _ in params)
+
+    def body(tmap_q, tmap_k, tmap_v, tmap_o, tmap_sfq, tmap_sfk, tmap_sfv, softmax_scale_log2):
+        warp = K.warp_id()
+        tid = K.thread_id()
+        tidx = tid & 127  # row within the warpgroup
+        warp_in_wg = warp & 3
+        lane_base = warp_in_wg * 32  # TMEM lane quarter of this warp
+
+        # ---- SharedStorage (:1139-1192), declaration order -----------------------------------
+        smem = K.smem_pool()
+        q_load = K.Pipeline(smem, Q_STAGE, full="tma", empty="tcgen05")
+        kv_load = K.Pipeline(smem, kv_stage, full="tma", empty="tcgen05")
+        P_full_O_rescaled = K.MBarrier(smem, 2)
+        P_full_O_rescaled.init(256)
+        S_full = K.TCGen05Bar(smem, 2)
+        S_full.init(1)
+        O_full = K.TCGen05Bar(smem, 2)
+        O_full.init(1)
+        softmax_corr = K.Pipeline(smem, 2, full="mbar", empty="mbar", init_full=128, init_empty=128)
+        corr_epi = K.Pipeline(smem, 2, full="mbar", empty="mbar", init_full=128, init_empty=32)
+        tmem_dealloc = K.MBarrier(smem, 1)
+        tmem_dealloc.init(384)
+        P_full_2 = K.MBarrier(smem, 2)
+        P_full_2.init(128)
+        sfqk_load = K.MBarrier(smem, 2)
+        sfqk_load.init(128)
+        tmem_holding = smem.alloc((1,), K.u32)
+        sScale = smem.alloc((Q_STAGE * BLK_M * 2,), K.f32, align=BUFFER_ALIGN)
+        sO = smem.alloc((EPI_STAGE * o_stage_bytes,), K.u8, align=BUFFER_ALIGN)
+        sQ = smem.alloc((Q_STAGE * q_stage_bytes,), K.u8, align=BUFFER_ALIGN)
+        if kv_slot_bytes is not None:
+            sKV = smem.alloc((kv_stage * kv_slot_bytes,), K.u8, align=BUFFER_ALIGN)
+            sK = sV = sKV
+        else:
+            sK = smem.alloc((kv_stage * k_stage_bytes,), K.u8, align=BUFFER_ALIGN)
+            sV = smem.alloc((kv_stage * v_stage_bytes,), K.u8, align=BUFFER_ALIGN)
+        sSFQ = smem.alloc((Q_STAGE * sfq_chunk_bytes,), K.u8, align=BUFFER_ALIGN)
+        sSFK = smem.alloc((kv_stage * sfq_chunk_bytes,), K.u8, align=BUFFER_ALIGN)
+        if quant_pv:
+            sSFP = smem.alloc((Q_STAGE * sfv_chunk_bytes,), K.u8, align=BUFFER_ALIGN)
+            sSFV = smem.alloc((kv_stage * sfv_chunk_bytes,), K.u8, align=BUFFER_ALIGN)
+
+        def k_slot_off(slot):
+            return slot * (kv_slot_bytes if kv_slot_bytes is not None else k_stage_bytes)
+
+        def v_slot_off(slot):
+            return slot * (kv_slot_bytes if kv_slot_bytes is not None else v_stage_bytes)
+
+        # ---- prologue (:1392-1514) -------------------------------------------------------------
+        with K.If(warp == 0), K.Then():
+            for tm in (tmap_q, tmap_k, tmap_v, tmap_o, tmap_sfq, tmap_sfk) + (
+                (tmap_sfv,) if quant_pv else ()
+            ):
+                K.ptx.prefetch.tensormap(K.address_of(tm))
+        K.ptx.fence.proxy.async_.shared__cta()
+        K.ptx.fence.mbarrier_init.release.cluster()
+        K.cuda.cta_sync()
+
+        # ---- shared helpers --------------------------------------------------------------------
+        def elected():
+            return K.cuda.elect_sync() != K.uint32(0)
+
+        def tmem(lane, col):
+            return K.cuda.get_tmem_addr(K.uint32(0), lane, col)
+
+        def smem_u32(ptr):
+            return K.cuda.cvta_generic_to_shared(ptr)
+
+        def n_block_max_of(m_block):
+            if not is_causal:
+                return n_block_max_all
+            n_idx = (m_block + 1) * (Q_STAGE * BLK_M) + (seq_len_kv - seq_len_q)
+            return K.min(n_block_max_all, ceildiv(n_idx, BLK_N))
+
+        def n_block_min_causal_of(m_block):
+            n_idx = m_block * (Q_STAGE * BLK_M) + (seq_len_kv - seq_len_q)
+            return K.max(0, n_idx // BLK_N)
+
+        def make_scheduler(prefix):
+            if is_causal:
+                return K.FlashAttentionLPTScheduler(
+                    prefix,
+                    num_batches=batch_size,
+                    num_heads=heads,
+                    num_m_blocks=num_m_blocks,
+                    l2_swizzle=l2_swizzle,
+                )
+            return K.FlashAttentionLinearScheduler(
+                prefix,
+                num_batches=batch_size,
+                num_heads=heads,
+                num_m_blocks=num_m_blocks,
+                num_ctas=grid,
+            )
+
+        def fma_f32x2(vals, idx, mul_lo, mul_hi, add_lo, add_hi):
+            """(vals[idx], vals[idx+1]) = fma.rn.f32x2((..), (mul), (add))."""
+            packed = K.local_scalar("uint64")
+            rhs = K.local_scalar("uint64")
+            addend = K.local_scalar("uint64")
+            K.ptx.mov.b64(packed, vals[idx], vals[idx + 1])
+            K.ptx.mov.b64(rhs, mul_lo, mul_hi)
+            K.ptx.mov.b64(addend, add_lo, add_hi)
+            K.ptx.fma.rn.f32x2(packed, packed, rhs, addend)
+            K.ptx.mov.b64(vals[idx], vals[idx + 1], packed)
+
+        def mul_f32x2(vals, idx, m):
+            packed = K.local_scalar("uint64")
+            rhs = K.local_scalar("uint64")
+            K.ptx.mov.b64(packed, vals[idx], vals[idx + 1])
+            K.ptx.mov.b64(rhs, m, m)
+            K.ptx.mul.rn.f32x2(packed, packed, rhs)
+            K.ptx.mov.b64(vals[idx], vals[idx + 1], packed)
+
+        def reduce_max(vals, base, n, init=None):
+            """utils.py:410-432 (3-input max tree over vals[base:base+n])."""
+            l = K.alloc_local([4], "float32")
+            if init is None:
+                K.ptx.max.f32(l[0], vals[base], vals[base + 1])
+            else:
+                K.ptx.max.f32(l[0], init, vals[base], vals[base + 1])
+            for j in range(1, 4):
+                K.ptx.max.f32(l[j], vals[base + 2 * j], vals[base + 2 * j + 1])
+            for i in range(8, n, 8):
+                for j in range(4):
+                    K.ptx.max.f32(l[j], l[j], vals[base + i + 2 * j], vals[base + i + 2 * j + 1])
+            out = K.local_scalar("float32")
+            K.ptx.max.f32(l[0], l[0], l[1])
+            K.ptx.max.f32(out, l[0], l[2], l[3])
+            return out
+
+        def reduce_sum(vals, base, n, init=None):
+            """utils.py:455-473 (packed add.rn.f32x2 tree over vals[base:base+n])."""
+            acc = K.alloc_local([8], "float32")
+            packed = K.local_scalar("uint64")
+            rhs = K.local_scalar("uint64")
+            for j in range(4):
+                K.assign(acc[2 * j], vals[base + 2 * j])
+                K.assign(acc[2 * j + 1], vals[base + 2 * j + 1])
+            if init is not None:
+                K.ptx.mov.b64(packed, init, K.float32(0.0))
+                K.ptx.mov.b64(rhs, vals[base], vals[base + 1])
+                K.ptx.add.rn.f32x2(packed, packed, rhs)
+                K.ptx.mov.b64(acc[0], acc[1], packed)
+            for i in range(8, n, 8):
+                for j in range(4):
+                    K.ptx.mov.b64(packed, acc[2 * j], acc[2 * j + 1])
+                    K.ptx.mov.b64(rhs, vals[base + i + 2 * j], vals[base + i + 2 * j + 1])
+                    K.ptx.add.rn.f32x2(packed, packed, rhs)
+                    K.ptx.mov.b64(acc[2 * j], acc[2 * j + 1], packed)
+            for lo, hi in ((0, 2), (4, 6), (0, 4)):
+                K.ptx.mov.b64(packed, acc[lo], acc[lo + 1])
+                K.ptx.mov.b64(rhs, acc[hi], acc[hi + 1])
+                K.ptx.add.rn.f32x2(packed, packed, rhs)
+                K.ptx.mov.b64(acc[lo], acc[lo + 1], packed)
+            out = K.local_scalar("float32")
+            K.ptx.add.f32(out, acc[0], acc[1])
+            return out
+
+        def pack_e4m3x4(word, f0, f1, f2, f3):
+            lo = K.local_scalar("uint16")
+            hi = K.local_scalar("uint16")
+            K.ptx.cvt.rn.satfinite.e4m3x2.f32(lo, f1, f0)
+            K.ptx.cvt.rn.satfinite.e4m3x2.f32(hi, f3, f2)
+            K.ptx.mov.b32(word, lo, hi)
+
+        def pack_ue8m0x4(word, f0, f1, f2, f3):
+            lo = K.local_scalar("uint16")
+            hi = K.local_scalar("uint16")
+            K.ptx.cvt.rz.satfinite.ue8m0x2.f32(lo, f1, f0)
+            K.ptx.cvt.rz.satfinite.ue8m0x2.f32(hi, f3, f2)
+            K.ptx.mov.b32(word, lo, hi)
+
+        def pack_e2m1x8(word, vals, base):
+            bytes_ = K.alloc_local([4], "uint8")
+            for j in range(4):
+                K.ptx.cvt.rn.satfinite.e2m1x2.f32(
+                    bytes_[j], vals[base + 2 * j + 1], vals[base + 2 * j]
+                )
+            K.assign(
+                word,
+                K.bitwise_or(
+                    K.bitwise_or(
+                        K.Cast("uint32", bytes_[0]),
+                        K.shift_left(K.Cast("uint32", bytes_[1]), K.uint32(8)),
+                    ),
+                    K.bitwise_or(
+                        K.shift_left(K.Cast("uint32", bytes_[2]), K.uint32(16)),
+                        K.shift_left(K.Cast("uint32", bytes_[3]), K.uint32(24)),
+                    ),
+                ),
+            )
+
+        # ---- roles (:1737-1963) ----------------------------------------------------------------
+        sp = K.specialize(chain_dispatch=True)
+        r_softmax = sp.role("softmax", warps=list(range(8)), regs=spec.num_regs_softmax)
+        r_correction = sp.role("correction", warps=[8, 9, 10, 11], regs=spec.num_regs_correction)
+        wg3 = sp.warpgroup("wg3", warps=range(12, 16), regs=spec.num_regs_other)
+        r_mma = sp.role("mma", warps=[MMA_WARP], group=wg3)
+        r_epi = sp.role("epilogue", warps=[EPILOGUE_WARP], group=wg3)
+        r_load = sp.role("load", warps=[LOAD_WARP], group=wg3)
+        r_idle = sp.role("idle", warps=[EMPTY_WARP], group=wg3)
+
+        with wg3:
+            with r_idle:
+                pass
+
+            # ============================ load warp 14 (:1967-2235) ===========================
+            with r_load:
+                q_phase = K.local_scalar("int32", init=1)
+                kv = K.PipelineState(kv_stage, phase=1)
+                sched = make_scheduler("sched_load")
+                sched.init(K.cta_id())
+                with K.While(sched.valid()):
+                    m_block = sched.m_block_idx
+                    head = sched.head_idx
+                    batch = sched.batch_idx
+                    kv_head = head // gqa
+                    n_max = K.local_scalar("int32", init=n_block_max_of(m_block))
+
+                    def sf_coords(block):
+                        # 5-D SF coordinates: the 128-row block index sits on dim 2 when a tile
+                        # spans two 512 B chunks and on dim 1 when it spans one (sketch, fact 7).
+                        if SF_TILE_K == 2:
+                            return (K.int32(0), K.int32(0), K.Cast("int32", block))
+                        return (K.int32(0), K.Cast("int32", block), K.int32(0))
+
+                    def load_q(stage):
+                        block = m_block * 2 + stage
+                        q_load.empty.wait(stage, q_phase)
+                        with K.If(elected()), K.Then():
+                            q_load.full.arrive(stage, tx_count=spec.tma_bytes_q)
+                        with K.If(elected()), K.Then():
+                            K.ptx[TMA_G2S_4D](
+                                sQ.ptr_to([stage * q_stage_bytes]),
+                                K.address_of(tmap_q),
+                                K.int32(0),
+                                K.Cast("int32", block * BLK_M),
+                                K.Cast("int32", head),
+                                K.Cast("int32", batch),
+                                smem_u32(q_load.full.ptr_to([stage])),
+                                K.uint64(0),
+                            )
+                        with K.If(elected()), K.Then():
+                            K.ptx[TMA_G2S_5D](
+                                sSFQ.ptr_to([stage * sfq_chunk_bytes]),
+                                K.address_of(tmap_sfq),
+                                *sf_coords(block),
+                                K.Cast("int32", head),
+                                K.Cast("int32", batch),
+                                smem_u32(q_load.full.ptr_to([stage])),
+                                K.uint64(0),
+                            )
+
+                    def prefetch_kv(n):
+                        """L2 prefetch of K/V block n (no smem): covers cold-L2 latency the ring cannot."""
+                        with K.If(elected()), K.Then():
+                            K.ptx[TMA_PREFETCH_4D](
+                                K.address_of(tmap_k),
+                                K.int32(0),
+                                K.Cast("int32", n * BLK_N),
+                                K.Cast("int32", kv_head),
+                                K.Cast("int32", batch),
+                            )
+                            if pv_format == "bf16":
+                                for half in range(DV // 64):
+                                    K.ptx[TMA_PREFETCH_4D](
+                                        K.address_of(tmap_v),
+                                        K.int32(64 * half),
+                                        K.Cast("int32", n * BLK_N),
+                                        K.Cast("int32", kv_head),
+                                        K.Cast("int32", batch),
+                                    )
+                            elif pv_format == "fp8":
+                                K.ptx[TMA_PREFETCH_4D](
+                                    K.address_of(tmap_v),
+                                    K.int32(0),
+                                    K.Cast("int32", n * BLK_N),
+                                    K.Cast("int32", kv_head),
+                                    K.Cast("int32", batch),
+                                )
+                            else:
+                                key_units = BLK_N // 2 if pv_format == "nvfp4" else BLK_N
+                                K.ptx[TMA_PREFETCH_4D](
+                                    K.address_of(tmap_v),
+                                    K.Cast("int32", n * key_units),
+                                    K.int32(0),
+                                    K.Cast("int32", kv_head),
+                                    K.Cast("int32", batch),
+                                )
+
+                    def load_k(n):
+                        slot = kv.stage
+                        kv_load.empty.wait(slot, kv.phase)
+                        with K.If(elected()), K.Then():
+                            kv_load.full.arrive(slot, tx_count=spec.tma_bytes_k)
+                        with K.If(elected()), K.Then():
+                            K.ptx[TMA_G2S_4D](
+                                sK.ptr_to([k_slot_off(slot)]),
+                                K.address_of(tmap_k),
+                                K.int32(0),
+                                K.Cast("int32", n * BLK_N),
+                                K.Cast("int32", kv_head),
+                                K.Cast("int32", batch),
+                                smem_u32(kv_load.full.ptr_to([slot])),
+                                K.uint64(0),
+                            )
+                        with K.If(elected()), K.Then():
+                            K.ptx[TMA_G2S_5D](
+                                sSFK.ptr_to([slot * sfq_chunk_bytes]),
+                                K.address_of(tmap_sfk),
+                                *sf_coords(n),
+                                K.Cast("int32", kv_head),
+                                K.Cast("int32", batch),
+                                smem_u32(kv_load.full.ptr_to([slot])),
+                                K.uint64(0),
+                            )
+                        kv.advance()
+
+                    def load_v(n):
+                        slot = kv.stage
+                        kv_load.empty.wait(slot, kv.phase)
+                        with K.If(elected()), K.Then():
+                            kv_load.full.arrive(slot, tx_count=spec.tma_bytes_v)
+                        if pv_format == "bf16":
+                            for half in range(DV // 64):
+                                with K.If(elected()), K.Then():
+                                    K.ptx[TMA_G2S_4D](
+                                        sV.ptr_to([v_slot_off(slot) + half * v_half_bytes]),
+                                        K.address_of(tmap_v),
+                                        K.int32(64 * half),
+                                        K.Cast("int32", n * BLK_N),
+                                        K.Cast("int32", kv_head),
+                                        K.Cast("int32", batch),
+                                        smem_u32(kv_load.full.ptr_to([slot])),
+                                        K.uint64(0),
+                                    )
+                        elif pv_format == "fp8":
+                            with K.If(elected()), K.Then():
+                                K.ptx[TMA_G2S_4D](
+                                    sV.ptr_to([v_slot_off(slot)]),
+                                    K.address_of(tmap_v),
+                                    K.int32(0),
+                                    K.Cast("int32", n * BLK_N),
+                                    K.Cast("int32", kv_head),
+                                    K.Cast("int32", batch),
+                                    smem_u32(kv_load.full.ptr_to([slot])),
+                                    K.uint64(0),
+                                )
+                        else:  # K-major V: the key block is the innermost coordinate (bytes for FP4)
+                            key_units = BLK_N // 2 if pv_format == "nvfp4" else BLK_N
+                            with K.If(elected()), K.Then():
+                                K.ptx[TMA_G2S_4D](
+                                    sV.ptr_to([v_slot_off(slot)]),
+                                    K.address_of(tmap_v),
+                                    K.Cast("int32", n * key_units),
+                                    K.int32(0),
+                                    K.Cast("int32", kv_head),
+                                    K.Cast("int32", batch),
+                                    smem_u32(kv_load.full.ptr_to([slot])),
+                                    K.uint64(0),
+                                )
+                            if pv_format == "nvfp4":
+                                sfv_coords = (K.int32(0), K.Cast("int32", n * 2), K.int32(0))
+                            else:
+                                sfv_coords = (K.int32(0), K.int32(0), K.Cast("int32", n))
+                            with K.If(elected()), K.Then():
+                                K.ptx[TMA_G2S_5D](
+                                    sSFV.ptr_to([slot * sfv_chunk_bytes]),
+                                    K.address_of(tmap_sfv),
+                                    *sfv_coords,
+                                    K.Cast("int32", kv_head),
+                                    K.Cast("int32", batch),
+                                    smem_u32(kv_load.full.ptr_to([slot])),
+                                    K.uint64(0),
+                                )
+                        kv.advance()
+
+                    if kv_prefetch:
+                        for d in range(1, kv_prefetch + 1):
+                            with K.If(n_max - d >= 0), K.Then():
+                                prefetch_kv(n_max - d)
+                    load_q(0)
+                    load_k(n_max - 1)
+                    load_q(1)
+                    K.assign(q_phase, q_phase ^ 1)
+                    load_v(n_max - 1)
+                    with K.serial(n_max - 1, unroll=False) as i:
+                        n = n_max - 2 - i
+                        if kv_prefetch:
+                            with K.If(n - kv_prefetch >= 0), K.Then():
+                                prefetch_kv(n - kv_prefetch)
+                        load_k(n)
+                        load_v(n)
+                    sched.next_tile()
+
+            # ============================ MMA warp 12 (:1787-1843, :2238-2722) ================
+            with r_mma:
+                K.ptx[TMEM_ALLOC](K.address_of(tmem_holding[0]), K.uint32(TMEM_COLS))
+                K.cuda.warp_sync()
+                tmem_base = K.local_scalar("uint32")
+                K.ptx.ld.shared.u32(tmem_base, tmem_holding.ptr_to([0]))
+                K.cuda.trap_when_assert_failed(tmem_base == K.uint32(0))
+
+                # hoisted, lo-uniform descriptors for stage/slot 0 (bh:1224-1554)
+                def make_desc(ptr, ldo, sdo, swizzle, uniform_lo=True):
+                    desc = K.SmemDescriptor()
+                    desc.init(ptr, ldo=ldo, sdo=sdo, swizzle=swizzle)
+                    if uniform_lo:
+                        desc.make_lo_uniform()
+                    return desc
+
+                desc_q = make_desc(sQ.ptr_to([0]), 1, QK_SBO, QK_SWIZZLE)
+                desc_k = make_desc(sK.ptr_to([0]), 1, QK_SBO, QK_SWIZZLE)
+                desc_v = make_desc(sV.ptr_to([0]), V_LBO, V_SBO, V_SWIZZLE)
+                desc_sfq = make_desc(sSFQ.ptr_to([0]), 0, 8, 0, uniform_lo=False)
+                desc_sfk = make_desc(sSFK.ptr_to([0]), 0, 8, 0, uniform_lo=False)
+                if quant_pv:
+                    desc_sfp = make_desc(sSFP.ptr_to([0]), 0, 8, 0, uniform_lo=False)
+                    desc_sfv = make_desc(sSFV.ptr_to([0]), 0, 8, 0, uniform_lo=False)
+
+                def desc_at(desc, off16):
+                    return desc.add_16B_offset(off16)
+
+                def cp_sf_chunks(desc, stride_bytes, slot, chunks, col_base):
+                    for c in range(chunks):
+                        with K.If(elected()), K.Then():
+                            K.ptx[TCGEN05_CP](
+                                K.uint32(col_base + 4 * c),
+                                desc_at(desc, slot * (stride_bytes // 16) + 32 * c),
+                            )
+
+                def gemm_qk(stage, slot):
+                    a_base = stage * (q_stage_bytes // 16)
+                    b_base = slot * (k_slot_off(1) // 16)
+                    for kt in range(QK_KT):
+                        with K.If(elected()), K.Then():
+                            if qk_format == "nvfp4":
+                                K.ptx[MMA_MXF4NVF4_4X](
+                                    K.uint32(TMEM_S[stage]),
+                                    desc_at(desc_q, a_base + 2 * kt),
+                                    desc_at(desc_k, b_base + 2 * kt),
+                                    K.uint32(IDESC_QK_NVFP4),
+                                    K.uint32(TMEM_SFQ[stage] + 4 * kt),
+                                    K.uint32(TMEM_SFK[stage] + 4 * kt),
+                                    kt != 0,
+                                )
+                            else:  # bh:1191-1220: per-K sf_id in the idesc and the SF address top bits
+                                K.ptx[MMA_MXF8F6F4_1X](
+                                    K.uint32(TMEM_S[stage]),
+                                    desc_at(desc_q, a_base + 2 * kt),
+                                    desc_at(desc_k, b_base + 2 * kt),
+                                    K.uint32(IDESC_BLOCK32_BASE | (kt << 29) | (kt << 4)),
+                                    K.uint32(TMEM_SFQ[stage] | (kt << 30)),
+                                    K.uint32(TMEM_SFK[stage] | (kt << 30)),
+                                    kt != 0,
+                                )
+
+                def gemm_pv(stage, slot, acc, p_phase):
+                    b_base = slot * (v_slot_off(1) // 16)
+
+                    def issue(kt):
+                        enable = True if kt != 0 else K.Cast("bool", acc)
+                        a_tmem = K.uint32(TMEM_P[stage] + 8 * kt)
+                        b_desc = desc_at(desc_v, b_base + v_k_step16 * kt)
+                        if pv_format == "bf16":
+                            K.ptx[MMA_F16](
+                                K.uint32(TMEM_O[stage]),
+                                a_tmem,
+                                b_desc,
+                                K.uint32(IDESC_PV_BF16[DV]),
+                                K.uint32(0),
+                                K.uint32(0),
+                                K.uint32(0),
+                                K.uint32(0),
+                                enable,
+                            )
+                        elif pv_format == "fp8":
+                            K.ptx[MMA_F8F6F4](
+                                K.uint32(TMEM_O[stage]),
+                                a_tmem,
+                                b_desc,
+                                K.uint32(IDESC_PV_FP8[DV]),
+                                K.uint32(0),
+                                K.uint32(0),
+                                K.uint32(0),
+                                K.uint32(0),
+                                enable,
+                            )
+                        elif pv_format == "nvfp4":
+                            K.ptx[MMA_MXF4NVF4_4X](
+                                K.uint32(TMEM_O[stage]),
+                                a_tmem,
+                                b_desc,
+                                K.uint32(IDESC_PV_NVFP4),
+                                K.uint32(TMEM_SFP[stage] + 4 * kt),
+                                K.uint32(TMEM_SFV[stage] + 4 * kt),
+                                enable,
+                            )
+                        else:  # mxfp8 PV (bh:1409-1554): static SF operands, sf_id = kt in the idesc
+                            K.ptx[MMA_MXF8F6F4_1X](
+                                K.uint32(TMEM_O[stage]),
+                                a_tmem,
+                                b_desc,
+                                K.uint32(IDESC_BLOCK32_BASE | (kt << 29) | (kt << 4)),
+                                K.uint32(TMEM_SFP[stage]),
+                                K.uint32(TMEM_SFV[stage]),
+                                enable,
+                            )
+
+                    for kt in range(PV_KT):
+                        if kt == PV_SPLIT:
+                            P_full_2.wait(stage, p_phase)
+                        with K.If(elected()), K.Then():
+                            issue(kt)
+
+                def cp_sfqk(stage, slot):
+                    cp_sf_chunks(desc_sfq, sfq_chunk_bytes, stage, SF_TILE_K, TMEM_SFQ[stage])
+                    cp_sf_chunks(desc_sfk, sfq_chunk_bytes, slot, SF_TILE_K, TMEM_SFK[stage])
+
+                def cp_sfpv(stage, slot):
+                    if quant_pv:
+                        cp_sf_chunks(
+                            desc_sfp, sfv_chunk_bytes, stage, SF_TILE_K_PV, TMEM_SFP[stage]
+                        )
+                        cp_sf_chunks(desc_sfv, sfv_chunk_bytes, slot, SF_TILE_K_PV, TMEM_SFV[stage])
+
+                q_phase = K.local_scalar("int32", init=0)
+                p_phase = K.local_scalar("int32", init=0)
+                sfqk_phase = K.local_scalar("int32", init=0)
+                kv = K.PipelineState(kv_stage, phase=0)
+                acc = K.local_scalar("int32", init=0)
+                sched = make_scheduler("sched_mma")
+                sched.init(K.cta_id())
+                with K.While(sched.valid()):
+                    m_block = sched.m_block_idx
+                    n_blocks = K.local_scalar("int32", init=n_block_max_of(m_block))
+                    K.assign(acc, 0)
+                    # QK0, QK1 on the newest block (:2423-2489)
+                    for stage in range(Q_STAGE):
+                        q_load.full.wait(stage, q_phase)
+                        if stage == 0:
+                            kv_load.full.wait(kv.stage, kv.phase)
+                        K.ptx.tcgen05.fence__after_thread_sync()
+                        sfqk_load.wait(stage, sfqk_phase)
+                        cp_sfqk(stage, kv.stage)
+                        gemm_qk(stage, kv.stage)
+                        with K.If(elected()), K.Then():
+                            S_full.arrive(stage)
+                    K.assign(q_phase, q_phase ^ 1)
+                    K.assign(sfqk_phase, sfqk_phase ^ 1)
+                    with K.If(elected()), K.Then():
+                        kv_load.empty.arrive(kv.stage)
+                    kv.advance()
+                    # steady loop (:2494-2637)
+                    with K.serial(n_blocks - 1, unroll=False) as _i:
+                        kv_load.full.wait(kv.stage, kv.phase)  # V_i
+                        v_slot = K.local_scalar("int32", init=kv.stage)
+                        for stage in range(Q_STAGE):
+                            P_full_O_rescaled.wait(stage, p_phase)
+                            cp_sfpv(stage, v_slot)
+                            gemm_pv(stage, v_slot, acc, p_phase)
+                            if stage == 1:
+                                with K.If(elected()), K.Then():
+                                    kv_load.empty.arrive(v_slot)
+                            if stage == 0:
+                                kv.advance()
+                                kv_load.full.wait(kv.stage, kv.phase)  # K_i
+                            K.ptx.tcgen05.fence__after_thread_sync()
+                            sfqk_load.wait(stage, sfqk_phase)
+                            cp_sfqk(stage, kv.stage)
+                            gemm_qk(stage, kv.stage)
+                            with K.If(elected()), K.Then():
+                                S_full.arrive(stage)
+                        with K.If(elected()), K.Then():
+                            kv_load.empty.arrive(kv.stage)
+                        kv.advance()
+                        K.assign(p_phase, p_phase ^ 1)
+                        K.assign(sfqk_phase, sfqk_phase ^ 1)
+                        K.assign(acc, 1)
+                    with K.If(elected()), K.Then():
+                        for stage in range(Q_STAGE):
+                            q_load.empty.arrive(stage)
+                    # tail PV (:2645-2716)
+                    kv_load.full.wait(kv.stage, kv.phase)
+                    for stage in range(Q_STAGE):
+                        P_full_O_rescaled.wait(stage, p_phase)
+                        cp_sfpv(stage, kv.stage)
+                        gemm_pv(stage, kv.stage, acc, p_phase)
+                        with K.If(elected()), K.Then():
+                            O_full.arrive(stage)
+                    K.assign(p_phase, p_phase ^ 1)
+                    with K.If(elected()), K.Then():
+                        kv_load.empty.arrive(kv.stage)
+                    kv.advance()
+                    sched.next_tile()
+                K.ptx[TMEM_RELINQUISH]()
+                tmem_dealloc.wait(0, 0)
+                dealloc = K.local_scalar("uint32")
+                K.ptx.ld.shared.u32(dealloc, tmem_holding.ptr_to([0]))
+                K.ptx[TMEM_DEALLOC](dealloc, K.uint32(TMEM_COLS))
+
+            # ============================ epilogue warp 13 (:4405-4510) =======================
+            with r_epi:
+                phase = K.local_scalar("int32", init=0)
+                sched = make_scheduler("sched_epi")
+                sched.init(K.cta_id())
+                with K.While(sched.valid()):
+                    m_block = sched.m_block_idx
+                    head = sched.head_idx
+                    batch = sched.batch_idx
+                    for stage in range(EPI_STAGE):
+                        corr_epi.full.wait(stage, phase)
+                        for half in range(DV // 64):
+                            K.ptx[TMA_S2G_4D](
+                                K.address_of(tmap_o),
+                                K.int32(64 * half),
+                                K.Cast("int32", (m_block * 2 + stage) * BLK_M),
+                                K.Cast("int32", head),
+                                K.Cast("int32", batch),
+                                sO.ptr_to([stage * o_stage_bytes + half * 16384]),
+                                K.uint64(0),
+                            )
+                        K.ptx.cp.async_.bulk.commit_group()
+                    K.ptx.cp.async_.bulk.wait_group.read(1)
+                    corr_epi.empty.arrive(0)
+                    K.ptx.cp.async_.bulk.wait_group.read(0)
+                    corr_epi.empty.arrive(1)
+                    K.assign(phase, phase ^ 1)
+                    sched.next_tile()
+
+        # ============================ softmax warpgroups 0..7 (:2727-3063, :3559-3883) ========
+        with r_softmax:
+            stage = K.uniform(warp >> 2)  # runtime stage: one body for both warpgroups
+            si_phase = K.local_scalar("int32", init=0)
+            corr_phase = K.local_scalar("int32", init=1)
+            row_max = K.local_scalar("float32")
+            row_sum = K.local_scalar("float32")
+            with K.If(stage == 1), K.Then():
+                sfqk_load.arrive(0)
+            s_col = stage * BLK_N  # S[stage] base column (128 * stage)
+            p_col = s_col + spec.tmem_s_to_p_offset
+            sched = make_scheduler("sched_softmax")
+            sched.init(K.cta_id())
+
+            def softmax_step(n, first, mask_seqlen, mask_causal, unmasked):
+                m_block = sched.m_block_idx
+                S_full.wait(stage, si_phase)
+                s = K.alloc_local([BLK_N], "float32")
+                tile_max = K.alloc_local([4], "float32")
+                for j in range(4):
+                    K.ptx[TMEM_LD_RED_X32](
+                        *[s[32 * j + i] for i in range(32)],
+                        tile_max[j],
+                        tmem(lane_base, s_col + 32 * j),
+                    )
+                K.ptx.tcgen05.wait__ld.sync.aligned()
+                sfqk_load.arrive(1 - stage)
+                if mask_seqlen or mask_causal:
+                    seqlen_limit = seq_len_kv - K.max(n, 0) * BLK_N
+                    if mask_causal:
+                        row = tidx + (m_block * 2 + stage) * BLK_M
+                        limit = row + (seq_len_kv - n * BLK_N - seq_len_q) + 1
+                        if mask_seqlen:
+                            limit = K.min(limit, seqlen_limit)
+                    else:
+                        limit = seqlen_limit
+                    lim = K.local_scalar("int32", init=limit)
+                    for c in range(4):
+                        bits = K.local_scalar("uint32")
+                        K.ptx.shr.u32(
+                            bits,
+                            K.uint32(0xFFFFFFFF),
+                            K.Cast("uint32", K.max((c + 1) * 32 - lim, 0)),
+                        )
+                        for i in range(32):
+                            keep = K.bitwise_and(bits, K.uint32(1 << i)) != K.uint32(0)
+                            K.ptx.mov.b32(
+                                s[32 * c + i], K.Select(keep, s[32 * c + i], K.float32(NEG_INF))
+                            )
+                new_max = K.local_scalar("float32")
+                if unmasked:
+                    hw = K.local_scalar("float32")
+                    K.ptx.max.f32(hw, tile_max[0], tile_max[1])
+                    K.ptx.max.f32(hw, hw, tile_max[2])
+                    K.ptx.max.f32(hw, hw, tile_max[3])
+                    K.ptx.max.f32(new_max, hw, row_max)
+                else:
+                    K.assign(new_max, reduce_max(s, 0, BLK_N, init=None if first else row_max))
+                safe = K.local_scalar(
+                    "float32", init=K.Select(new_max != K.float32(NEG_INF), new_max, K.float32(0.0))
+                )
+                acc_scale = K.local_scalar("float32")
+                if not first:
+                    acc_scale_ = K.local_scalar("float32")
+                    K.ptx.sub.f32(acc_scale_, row_max, safe)
+                    K.ptx.mul.f32(acc_scale_, acc_scale_, softmax_scale_log2)
+                    K.ptx.ex2.approx.ftz.f32(acc_scale, acc_scale_)
+                    if rescale_threshold > 0.0:
+                        keep_max = acc_scale_ >= K.float32(-rescale_threshold)
+                        K.assign(new_max, K.Select(keep_max, row_max, new_max))
+                        K.assign(safe, K.Select(keep_max, row_max, safe))
+                        K.assign(acc_scale, K.Select(keep_max, K.float32(1.0), acc_scale))
+                    K.ptx.st.shared.f32(sScale.ptr_to([tidx + stage * BLK_M]), acc_scale)
+                K.assign(row_max, new_max)
+                softmax_corr.full.arrive(stage)
+                # scale_subtract_rowmax (sm:271-285)
+                bias = K.local_scalar("float32")
+                K.ptx.mul.f32(bias, safe, softmax_scale_log2)
+                K.ptx.sub.f32(bias, K.float32(max_offset), bias)
+                for i in range(0, BLK_N, 2):
+                    fma_f32x2(s, i, softmax_scale_log2, softmax_scale_log2, bias, bias)
+                p_words = K.alloc_local([P_COLS], "uint32")
+                if pv_format == "bf16":
+                    for frag in range(4):
+                        for i in range(32):
+                            K.ptx.ex2.approx.ftz.f32(s[32 * frag + i], s[32 * frag + i])
+                        for i in range(16):
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                p_words[16 * frag + i],
+                                s[32 * frag + 2 * i + 1],
+                                s[32 * frag + 2 * i],
+                            )
+                elif pv_format == "fp8":
+                    for i in range(BLK_N):
+                        K.ptx.ex2.approx.ftz.f32(s[i], s[i])
+                    for i in range(32):
+                        pack_e4m3x4(p_words[i], s[4 * i], s[4 * i + 1], s[4 * i + 2], s[4 * i + 3])
+                else:  # _fused_log2_group_quant (:3171-3295)
+                    gsize = spec.sf_vec_size_pv
+                    ngroups = BLK_N // gsize
+                    sf = K.alloc_local([ngroups], "float32")
+                    row_acc = K.local_scalar("float32")
+                    for g in range(ngroups):
+                        m = K.local_scalar("float32")
+                        if unmasked and gsize == 32:
+                            K.ptx.fma.rn.f32(m, tile_max[g], softmax_scale_log2, bias)
+                        else:
+                            K.assign(m, reduce_max(s, g * gsize, gsize))
+                        b = K.local_scalar("float32")
+                        K.ptx.max.f32(b, m, K.float32(-100.0))
+                        K.ptx.add.f32(b, b, K.float32(-max_offset))
+                        if spec.sf_pv_e8m0:
+                            K.ptx.cvt.rpi.f32.f32(b, b)
+                        nb = K.local_scalar("float32")
+                        K.ptx.neg.f32(nb, b)
+                        for i in range(0, gsize, 2):
+                            fma_f32x2(s, g * gsize + i, K.float32(1.0), K.float32(1.0), nb, nb)
+                        for i in range(gsize):
+                            K.ptx.ex2.approx.ftz.f32(s[g * gsize + i], s[g * gsize + i])
+                        K.ptx.ex2.approx.ftz.f32(sf[g], b)
+                        gs = reduce_sum(s, g * gsize, gsize)
+                        K.ptx.fma.rn.f32(row_acc, sf[g], gs, K.float32(0.0) if g == 0 else row_acc)
+                        if pv_format == "nvfp4":
+                            for w in range(gsize // 8):
+                                pack_e2m1x8(p_words[g * (gsize // 8) + w], s, g * gsize + 8 * w)
+                        else:
+                            for w in range(gsize // 4):
+                                base = g * gsize + 4 * w
+                                pack_e4m3x4(
+                                    p_words[g * (gsize // 4) + w],
+                                    s[base],
+                                    s[base + 1],
+                                    s[base + 2],
+                                    s[base + 3],
+                                )
+                    if first:
+                        K.assign(row_sum, row_acc)
+                    else:
+                        K.ptx.fma.rn.f32(row_sum, row_sum, acc_scale, row_acc)
+                    for w in range(max(1, ngroups // 4)):
+                        sf_word = K.local_scalar("uint32")
+                        if spec.sf_pv_e8m0:
+                            pack_ue8m0x4(
+                                sf_word, sf[4 * w], sf[4 * w + 1], sf[4 * w + 2], sf[4 * w + 3]
+                            )
+                        else:
+                            pack_e4m3x4(
+                                sf_word, sf[4 * w], sf[4 * w + 1], sf[4 * w + 2], sf[4 * w + 3]
+                            )
+                        K.ptx.st.shared.b32(
+                            sSFP.ptr_to(
+                                [
+                                    stage * sfv_chunk_bytes
+                                    + K.lane_id() * 16
+                                    + warp_in_wg * 4
+                                    + 512 * w
+                                ]
+                            ),
+                            sf_word,
+                        )
+                    # The MMA warp reads sSFP through the async proxy (tcgen05.cp) after the P_full
+                    # arrive below. The upstream kernel issues no proxy fence here and is measurably
+                    # nondeterministic on multi-tile persistent shapes (its own back-to-back launches
+                    # differ); one fence per step orders the generic-proxy stores before that read.
+                    K.ptx.fence.proxy.async_.shared__cta()
+                # P -> TMEM with the split handoff (:3861-3870)
+                st = f"tcgen05.st.sync.aligned.32x32b.x{P_REP}.b32"
+                for c in range(P_SPLIT):
+                    K.ptx[st](
+                        tmem(lane_base, p_col + c * P_REP),
+                        *[p_words[c * P_REP + i] for i in range(P_REP)],
+                    )
+                K.ptx.tcgen05.wait__st.sync.aligned()
+                P_full_O_rescaled.arrive(stage)
+                for c in range(P_SPLIT, P_CHUNKS):
+                    K.ptx[st](
+                        tmem(lane_base, p_col + c * P_REP),
+                        *[p_words[c * P_REP + i] for i in range(P_REP)],
+                    )
+                K.ptx.tcgen05.wait__st.sync.aligned()
+                P_full_2.arrive(stage)
+                softmax_corr.empty.wait(stage, corr_phase)
+                if not quant_pv:
+                    if first:
+                        K.assign(row_sum, reduce_sum(s, 0, BLK_N))
+                    else:
+                        init = K.local_scalar("float32")
+                        K.ptx.mul.f32(init, row_sum, acc_scale)
+                        K.assign(row_sum, reduce_sum(s, 0, BLK_N, init=init))
+                K.assign(si_phase, si_phase ^ 1)
+                K.assign(corr_phase, corr_phase ^ 1)
+
+            with K.While(sched.valid()):
+                m_block = sched.m_block_idx
+                n_max = K.local_scalar("int32", init=n_block_max_of(m_block))
+                K.assign(row_max, K.float32(NEG_INF))
+                K.assign(row_sum, K.float32(0.0))
+                softmax_corr.empty.wait(stage, corr_phase)
+                K.assign(corr_phase, corr_phase ^ 1)
+                softmax_step(
+                    n_max - 1, first=True, mask_seqlen=True, mask_causal=is_causal, unmasked=False
+                )
+                if is_causal:
+                    n_min_causal = K.local_scalar("int32", init=n_block_min_causal_of(m_block))
+                    with K.serial(K.max(n_max - 1 - n_min_causal, 0), unroll=False) as i:
+                        softmax_step(
+                            n_max - 2 - i,
+                            first=False,
+                            mask_seqlen=False,
+                            mask_causal=True,
+                            unmasked=False,
+                        )
+                    with K.serial(K.min(n_max - 1, n_min_causal), unroll=False) as i:
+                        softmax_step(
+                            K.min(n_max - 1, n_min_causal) - 1 - i,
+                            first=False,
+                            mask_seqlen=False,
+                            mask_causal=True,
+                            unmasked=False,
+                        )
+                else:
+                    with K.serial(n_max - 1, unroll=False) as i:
+                        softmax_step(
+                            n_max - 2 - i,
+                            first=False,
+                            mask_seqlen=False,
+                            mask_causal=False,
+                            unmasked=True,
+                        )
+                K.ptx.st.shared.f32(sScale.ptr_to([tidx + stage * BLK_M]), row_sum)
+                softmax_corr.full.arrive(stage)
+                sched.next_tile()
+            tmem_dealloc.arrive(0)
+
+        # ============================ correction warpgroup 8..11 (:3885-4360) =================
+        with r_correction:
+            P_full_O_rescaled.arrive(0)
+            P_full_O_rescaled.arrive(1)
+            sc_phase = K.local_scalar("int32", init=0)
+            o_phase = K.local_scalar("int32", init=0)
+            ce_phase = K.local_scalar("int32", init=1)
+            sched = make_scheduler("sched_corr")
+            sched.init(K.cta_id())
+            with K.While(sched.valid()):
+                m_block = sched.m_block_idx
+                n_blocks = K.local_scalar("int32", init=n_block_max_of(m_block))
+                softmax_corr.full.wait(0, sc_phase)
+                softmax_corr.empty.arrive(0)
+                softmax_corr.full.wait(1, sc_phase)
+                K.assign(sc_phase, sc_phase ^ 1)
+                with K.serial(n_blocks - 1, unroll=False) as _i:
+                    for stage in range(Q_STAGE):
+                        softmax_corr.full.wait(stage, sc_phase)
+                        scale = K.local_scalar("float32")
+                        K.ptx.ld.shared.f32(scale, sScale.ptr_to([tidx + stage * BLK_M]))
+                        ballot = K.local_scalar("uint32")
+                        K.ptx.vote_sync.ballot.b32(
+                            ballot, K.ptx.pred(scale < K.float32(1.0)), K.uint32(0xFFFFFFFF)
+                        )
+                        with K.If(ballot != K.uint32(0)), K.Then():
+                            o = K.alloc_local([16], "float32")
+                            for t in range(DV // 16):
+                                addr = tmem(lane_base, TMEM_O[stage] + 16 * t)
+                                K.ptx[TMEM_LD_X16](*[o[i] for i in range(16)], addr)
+                                for j in range(0, 16, 2):
+                                    mul_f32x2(o, j, scale)
+                                K.ptx[TMEM_ST_X16](addr, *[o[i] for i in range(16)])
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                        P_full_O_rescaled.arrive(stage)
+                        softmax_corr.empty.arrive(1 - stage)
+                    K.assign(sc_phase, sc_phase ^ 1)
+                softmax_corr.empty.arrive(1)
+                for stage in range(Q_STAGE):
+                    softmax_corr.full.wait(stage, sc_phase)
+                    rs = K.local_scalar("float32")
+                    K.ptx.ld.shared.f32(rs, sScale.ptr_to([tidx + stage * BLK_M]))
+                    softmax_corr.empty.arrive(stage)
+                    inv = K.local_scalar("float32")
+                    K.ptx.rcp.approx.ftz.f32(
+                        inv, K.Select(rs != K.float32(0.0), rs, K.float32(1.0))
+                    )
+                    O_full.wait(stage, o_phase)
+                    corr_epi.empty.wait(stage, ce_phase)
+                    o = K.alloc_local([16], "float32")
+                    h = K.alloc_local([8], "uint32")
+                    row = tidx
+                    for t in range(DV // 16):
+                        K.ptx[TMEM_LD_X16](
+                            *[o[i] for i in range(16)], tmem(lane_base, TMEM_O[stage] + 16 * t)
+                        )
+                        for j in range(0, 16, 2):
+                            mul_f32x2(o, j, inv)
+                        for j in range(8):
+                            K.ptx.cvt.rn.bf16x2.f32(h[j], o[2 * j + 1], o[2 * j])
+                        for half in range(2):
+                            c = 16 * t + 8 * half
+                            off = (
+                                stage * o_stage_bytes
+                                + (c // 64) * 16384
+                                + (row // 8) * 1024
+                                + (row % 8) * 128
+                                + K.Cast(
+                                    "int32",
+                                    K.bitwise_xor(
+                                        K.Cast("uint32", (c % 64) // 8), K.Cast("uint32", row % 8)
+                                    ),
+                                )
+                                * 16
+                                + (c % 8) * 2
+                            )
+                            K.ptx.st.shared.v4.b32(
+                                sO.ptr_to([off]),
+                                h[4 * half],
+                                h[4 * half + 1],
+                                h[4 * half + 2],
+                                h[4 * half + 3],
+                            )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    corr_epi.full.arrive(stage)
+                    P_full_O_rescaled.arrive(stage)
+                K.assign(o_phase, o_phase ^ 1)
+                K.assign(sc_phase, sc_phase ^ 1)
+                K.assign(ce_phase, ce_phase ^ 1)
+                sched.next_tile()
+            tmem_dealloc.arrive(0)
+
+    def entry(*args):
+        values = dict(zip(names, args, strict=True))
+        body(
+            values["tmap_q"],
+            values["tmap_k"],
+            values["tmap_v"],
+            values["tmap_o"],
+            values["tmap_sfq"],
+            values["tmap_sfk"],
+            values.get("tmap_sfv"),
+            values["softmax_scale_log2"],
+        )
+
+    entry.__name__ = "flash_attention4_fp4"
+    entry.__signature__ = inspect.Signature(
+        [
+            inspect.Parameter(n, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=a)
+            for n, a in params
+        ]
+    )
+    return K.kernel(warps=NUM_WARPS, arch="sm_103a", min_blocks_per_sm=1, grid=grid)(entry)
+
+
+# ---------------------------------------------------------------------------------------------
+# Module contract
+# ---------------------------------------------------------------------------------------------
+
+KERNEL_META = {
+    "name": "flash_attention4_fp4",
+    "category": "flashattention",
+    "runtime_cuda_archs": ["sm_103a"],
+    "reference_requirements": (
+        {
+            "package": "flash-attn-4",
+            "git": {
+                "url": "https://github.com/hao-ai-lab/flash-attention-fp4.git",
+                "commit": "5aa37a9680f7b76a11799b5f4846100ed5a3e6d8",
+            },
+            "import": "flash_attn.cute",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.7.0", "import": "cutlass"},
+        {"package": "flashinfer-python", "specifier": ">=0.6.18", "import": "flashinfer"},
+    ),
+}
+
+
+def _cfg(qk, pv, b, sq, sk, h, kv, d, causal=False):
+    seq = f"s{sq}" if sq == sk else f"sq{sq}_sk{sk}"
+    return {
+        "qk_format": qk,
+        "pv_format": pv,
+        "batch_size": b,
+        "seq_len_q": sq,
+        "seq_len_kv": sk,
+        "num_qo_heads": h,
+        "num_kv_heads": kv,
+        "head_dim": d,
+        "is_causal": causal,
+        "label": f"{qk}_{pv}_b{b}_{seq}_h{h}kv{kv}_d{d}{'_causal' if causal else ''}",
+    }
+
+
+CONFIGS = [
+    # Core matrix: every mode x {noncausal, causal} x {MHA, GQA 4:1}.
+    *[
+        _cfg(qk, pv, 1, 1024, 1024, 32, kv, 128, causal)
+        for qk, pv in MODES
+        for causal in (False, True)
+        for kv in (32, 8)
+    ],
+    # KV ring wrap for the deep NVFP4-PV ring.
+    _cfg("nvfp4", "nvfp4", 1, 4096, 4096, 32, 32, 128),
+    _cfg("nvfp4", "nvfp4", 1, 4096, 4096, 32, 32, 128, True),
+    # multi-tile persistent schedule (512 tiles over 152 SMs) with a quantized P and E8M0 scales
+    _cfg("nvfp4", "mxfp8", 1, 4096, 4096, 32, 32, 128),
+    # Single 256-row / 128-column tile.
+    _cfg("nvfp4", "bf16", 1, 256, 256, 32, 32, 128),
+    _cfg("nvfp4", "nvfp4", 1, 256, 256, 32, 32, 128),
+    # Odd 128-row block counts (stage-1 Q tile fully out of range).
+    _cfg("nvfp4", "bf16", 1, 128, 128, 32, 32, 128),
+    _cfg("nvfp4", "bf16", 1, 384, 384, 32, 32, 128, True),
+    _cfg("nvfp4", "nvfp4", 1, 384, 384, 32, 32, 128),
+    # seq_len_q != seq_len_kv.
+    _cfg("nvfp4", "bf16", 1, 256, 1024, 32, 8, 128),
+    _cfg("nvfp4", "bf16", 1, 512, 1024, 32, 8, 128, True),
+    _cfg("nvfp4", "nvfp4", 1, 256, 2048, 32, 32, 128, True),
+    # batch > 1.
+    _cfg("nvfp4", "bf16", 2, 512, 512, 32, 8, 128, True),
+    _cfg("mxfp8", "fp8", 2, 512, 512, 32, 32, 128),
+    # head_dim 64.
+    *[
+        _cfg("nvfp4", pv, 1, 1024, 1024, 32, kv, 64, causal)
+        for pv in ("bf16", "fp8")
+        for causal in (False, True)
+        for kv in (32, 8)
+    ],
+]
+
+_HEADLINE = [
+    (1, 256, 16),
+    (1, 1024, 16),
+    (4, 4096, 16),
+    (1, 32768, 16),
+    (4, 4096, 32),
+    (1, 4096, 12),
+    (1, 32768, 12),
+    (1, 4096, 24),
+    (1, 32768, 24),
+]
+BENCH_CONFIGS = [
+    *[_cfg(qk, pv, b, s, s, h, h, 128) for qk, pv in MODES for b, s, h in _HEADLINE],
+    _cfg("nvfp4", "bf16", 1, 32768, 32768, 24, 24, 64),
+    _cfg("nvfp4", "fp8", 1, 32768, 32768, 24, 24, 64),
+    *[
+        _cfg(qk, pv, 1, s, s, 32, 8, 128, True)
+        for qk, pv in (("nvfp4", "bf16"), ("nvfp4", "fp8"), ("mxfp8", "fp8"))
+        for s in (1024, 2048, 4096, 8192, 16384, 32768)
+    ],
+]
+
+# Upstream env knobs that change the compiled program; pinned to the SM103 defaults the port
+# transcribes (orig:L282-335, L1105-1108, L2790-2794). Read at import by the fork, so they are
+# set before the first ``flash_attn.cute`` import.
+_UPSTREAM_KNOBS = {
+    "FA4_LDRED_ROWMAX": "1",
+    "FA4_FORCE_E2E": "0",
+    "FA4_FP4_PV_LOG2_QUANT": "1",
+    "FA4_FP8_PV_USE_EXPLICIT_PACK": "1",
+    "FA4_FP8_PV_USE_FUSED_PACK": "0",
+    "FA4_FP8_PV_PACK_STORE_PIPELINE": "0",
+    "FA4_FP4_PV_QUANT_STORE_PIPELINE": "0",
+    "FA4_FP8_PV_RANGE_UNROLL": "0",
+    "FA4_FP8_PV_P_LOG2_OFFSET": "0.0",
+    "FA4_FP8_PV_ZERO_FILL_REGS": "1",
+    "FA4_PROFILE_PIPELINE": "0",
+    "FA4_PROFILE_DETAIL": "0",
+    "FA4_MXFP8_USE_INLINE_PTX": "0",
+    "FA4_DEBUG_FORCE_GENERIC_MXFP8_QK": "0",
+    "FA4_SFQK_TMEM_SLOT": "s",
+    "FA4_FP8_PV_P_SPLIT_NUM": "3",
+    "FA4_FP8_PV_P_SPLIT_DEN": "4",
+    "FA4_FP4_PV_P_SPLIT_NUM": "1",
+    "FA4_FP4_PV_P_SPLIT_DEN": "2",
+    "FA4_FP8_PV_TMEM_STORE_REP": "8",
+    "FA4_FP4_PV_TMEM_STORE_REP": "8",
+}
+
+
+def _pin_upstream_knobs():
+    for key, value in _UPSTREAM_KNOBS.items():
+        os.environ[key] = value
+
+
+# ptxas --register-usage-level per (qk_format, pv_format, is_causal, single_wave). Measured on GB300
+# (bench_suite, reference-paired): the NVFP4-PV kernel on a single-wave, non-causal grid (every CTA
+# owns one tile) runs 15.5 us vs 18.5 us at level 10 for b1 s1024 h16 (levels 1-3 identical, 4-10
+# identical); the same level costs +28% once tiles are long (s4096+), so it is keyed on the regime.
+# Every other mode measured flat across levels 3-10 and keeps the checkout default 10.
+_REG_LEVEL_TABLE: dict = {("nvfp4", "nvfp4", False, True): "3"}
+
+
+def _select_reg_level(qk_format, pv_format, is_causal, single_wave):
+    override = os.environ.get("FA4FP4_REG_LEVEL", "")
+    if override:
+        return override
+    return _REG_LEVEL_TABLE.get((qk_format, pv_format, is_causal, single_wave), "10")
+
+
+def _check_shape(seq_len_q, seq_len_kv, num_qo_heads, num_kv_heads):
+    if seq_len_q % BLK_M or seq_len_kv % BLK_N:
+        raise ValueError("seq_len_q and seq_len_kv must be multiples of 128")
+    if num_qo_heads % num_kv_heads:
+        raise ValueError("num_qo_heads must be a multiple of num_kv_heads")
+
+
+def get_kernel(
+    qk_format,
+    pv_format,
+    batch_size,
+    seq_len_q,
+    seq_len_kv,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    is_causal=False,
+    **kwargs,
+):
+    from tirx_kernels.runner import hardware_num_sms
+
+    _check_shape(seq_len_q, seq_len_kv, num_qo_heads, num_kv_heads)
+    spec = Spec(qk_format, pv_format, head_dim, is_causal, num_qo_heads, num_kv_heads)
+    num_sms = hardware_num_sms()
+    num_tiles = batch_size * num_qo_heads * ceildiv(seq_len_q, Q_STAGE * BLK_M)
+    os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = _select_reg_level(
+        qk_format, pv_format, is_causal, num_tiles <= num_sms
+    )
+    return make_kernel(
+        spec, batch_size, seq_len_q, seq_len_kv, num_qo_heads, num_kv_heads, num_sms
+    ).func
+
+
+# ---------------------------------------------------------------------------------------------
+# Data preparation (orig: benchmarks/bench_fp4.py create_{nvfp4,mxfp8}_attention_tensors)
+# ---------------------------------------------------------------------------------------------
+
+
+def _swizzled_sf(sf_data, batch, seqlen, nheads, headdim, sf_vec_size):
+    """flashinfer 128x4-swizzled scale factors -> the upstream 7-D view (32,4,rest_m,4,rest_k,h,b).
+
+    Returns ``(storage, view)``: ``storage`` is the contiguous ``(b, h, rest_m, rest_k, 32, 4, 4)``
+    byte tensor the TIRx TensorMaps read, ``view`` is the permuted view the upstream interface takes.
+    """
+    rest_m = seqlen // BLK_M
+    rest_k = headdim // sf_vec_size // 4
+    sf = sf_data.reshape(batch * rest_m, nheads * (headdim // sf_vec_size) // 4, 32, 4, 4)
+    sf = sf.reshape(batch, rest_m, nheads, rest_k, 32, 4, 4)
+    storage = sf.permute(0, 2, 1, 3, 4, 5, 6).contiguous()
+    return storage, storage.permute(4, 5, 2, 6, 3, 1, 0)
+
+
+def _quantize_nvfp4(ref_bf16_2d):
+    import torch
+    from flashinfer.quantization import SfLayout, nvfp4_quantize
+
+    one = torch.ones(1, device=ref_bf16_2d.device, dtype=torch.float32)
+    return nvfp4_quantize(ref_bf16_2d, one, sfLayout=SfLayout.layout_128x4, do_shuffle=False)
+
+
+def _quantize_mxfp8(ref_bf16_2d):
+    import torch
+    from flashinfer.quantization import SfLayout, mxfp8_quantize
+
+    data, sf = mxfp8_quantize(ref_bf16_2d, sf_swizzle_layout=SfLayout.layout_128x4)
+    if data.dtype == torch.uint8:
+        data = data.view(torch.float8_e4m3fn)
+    return data, sf
+
+
+def prepare_data(
+    qk_format,
+    pv_format,
+    batch_size,
+    seq_len_q,
+    seq_len_kv,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    seed=0,
+    device="cuda",
+):
+    """Quantized inputs shared by the TIRx kernel and the upstream reference.
+
+    Everything here happens outside the timed closures. Both implementations read the same
+    bytes; only the outputs are separate.
+    """
+    import torch
+
+    torch.manual_seed(seed)
+    b, sq, sk, h, hk, d = batch_size, seq_len_q, seq_len_kv, num_qo_heads, num_kv_heads, head_dim
+    q_ref = torch.randn(b, sq, h, d, device=device, dtype=torch.float32)
+    k_ref = torch.randn(b, sk, hk, d, device=device, dtype=torch.float32)
+    v_ref = torch.randn(b, sk, hk, d, device=device, dtype=torch.float32)
+    quantize = _quantize_nvfp4 if qk_format == "nvfp4" else _quantize_mxfp8
+    sf_vec = _QK_SF_VEC[qk_format]
+
+    def qk(ref, seqlen, nheads):
+        data, sf = quantize(ref.to(torch.bfloat16).reshape(b * seqlen, nheads * d))
+        if qk_format == "nvfp4":
+            data = (
+                data.reshape(b, seqlen, nheads, d // 2)
+                .view(torch.uint8)
+                .view(torch.float4_e2m1fn_x2)
+            )
+        else:
+            data = data.reshape(b, seqlen, nheads, d)
+        storage, view = _swizzled_sf(sf, b, seqlen, nheads, d, sf_vec)
+        return data, storage, view, sf
+
+    q, q_sf_storage, q_sf, q_sf_raw = qk(q_ref, sq, h)
+    k, k_sf_storage, k_sf, k_sf_raw = qk(k_ref, sk, hk)
+
+    v_sf_storage = v_sf = v_sf_raw = None
+    if pv_format == "bf16":
+        v = v_ref.to(torch.bfloat16)
+    elif pv_format == "fp8":
+        v = v_ref.to(torch.bfloat16).to(torch.float8_e4m3fn)
+    else:
+        # K-major V: quantize (b*hk*d, sk) so seqlen is the contiguous, scaled dimension.
+        v_km = v_ref.to(torch.bfloat16).permute(0, 2, 3, 1).contiguous().reshape(b * hk * d, sk)
+        if pv_format == "nvfp4":
+            data, v_sf_raw = _quantize_nvfp4(v_km)
+            v = data.reshape(b, hk, d, sk // 2).view(torch.uint8).view(torch.float4_e2m1fn_x2)
+        else:
+            data, v_sf_raw = _quantize_mxfp8(v_km)
+            v = data.reshape(b, hk, d, sk).permute(
+                0, 3, 1, 2
+            )  # logical (b, s, hk, d), s contiguous
+        v_sf_storage, v_sf = _swizzled_sf(v_sf_raw, b * hk, d, 1, sk, _PV_SF_VEC[pv_format])
+
+    out_tirx = torch.empty(b, sq, h, d, device=device, dtype=torch.bfloat16)
+    out_ref = torch.empty_like(out_tirx)
+    return {
+        "q": q,
+        "k": k,
+        "v": v,
+        "q_sf": q_sf,
+        "k_sf": k_sf,
+        "v_sf": v_sf,
+        "q_sf_storage": q_sf_storage,
+        "k_sf_storage": k_sf_storage,
+        "v_sf_storage": v_sf_storage,
+        "q_sf_raw": q_sf_raw,
+        "k_sf_raw": k_sf_raw,
+        "v_sf_raw": v_sf_raw,
+        "q_ref": q_ref,
+        "k_ref": k_ref,
+        "v_ref": v_ref,
+        "out_tirx": out_tirx,
+        "out_ref": out_ref,
+        "softmax_scale": 1.0 / math.sqrt(d),
+    }
+
+
+# ---------------------------------------------------------------------------------------------
+# Upstream reference
+# ---------------------------------------------------------------------------------------------
+
+
+def _reference_kwargs(data, config):
+    return dict(
+        softmax_scale=data["softmax_scale"],
+        causal=config["is_causal"],
+        pack_gqa=False,  # see Spec: the upstream packed-GQA FP4 path is numerically wrong
+        mSFQ=data["q_sf"],
+        mSFK=data["k_sf"],
+        mSFV=data["v_sf"],
+        out=data["out_ref"],
+    )
+
+
+def run_reference(data, config):
+    """Run the upstream FP4 forward on ``data`` through its production dispatch."""
+    _pin_upstream_knobs()
+    from flash_attn.cute.interface import _flash_attn_fwd
+
+    out, _ = _flash_attn_fwd(data["q"], data["k"], data["v"], **_reference_kwargs(data, config))
+    return out
+
+
+def build_reference_launch(data, config):
+    """A no-argument closure that launches exactly the upstream kernel object.
+
+    The first production call compiles through the fork's own dispatch; the closure then
+    reuses the compiled ``tvm_ffi`` callable with the very same call arguments the interface
+    passes (interface.py:1002-1052), so the timed work is the kernel launch alone.
+    """
+    import torch
+
+    _pin_upstream_knobs()
+    from flash_attn.cute.interface import _flash_attn_fwd
+
+    kwargs = _reference_kwargs(data, config)
+    before = set(_flash_attn_fwd.compile_cache)
+    _flash_attn_fwd(data["q"], data["k"], data["v"], **kwargs)
+    torch.cuda.synchronize()
+    new_keys = set(_flash_attn_fwd.compile_cache) - before
+    if len(new_keys) != 1:
+        raise RuntimeError(f"expected one new compile key, got {len(new_keys)}")
+    (key,) = new_keys
+    compiled = _flash_attn_fwd.compile_cache[key]
+    captured = []
+
+    def capture(*args):
+        captured.append(args)
+        return compiled(*args)
+
+    _flash_attn_fwd.compile_cache[key] = capture
+    try:
+        _flash_attn_fwd(data["q"], data["k"], data["v"], **kwargs)
+    finally:
+        _flash_attn_fwd.compile_cache[key] = compiled
+    (call_args,) = captured
+
+    def launch():
+        compiled(*call_args)
+
+    launch._keep_alive = (call_args, data)
+    return launch
+
+
+# ---------------------------------------------------------------------------------------------
+# Correctness
+# ---------------------------------------------------------------------------------------------
+
+
+def _bf16_ulp_distance(a, b):
+    import torch
+
+    ia = a.view(torch.int16).to(torch.int32)
+    ib = b.view(torch.int16).to(torch.int32)
+    ia = torch.where(ia < 0, 0x8000 - ia, ia)
+    ib = torch.where(ib < 0, 0x8000 - ib, ib)
+    return (ia - ib).abs()
+
+
+_E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+def _sf_swizzled_index(rows, cols, sf_vec, device):
+    """Byte index into flashinfer's 128x4-swizzled scale buffer for each (row, k-group).
+
+    Row tiles of 128 x (4 groups) are 512-byte chunks laid out [row//128][group//4]; inside a
+    chunk the byte lives at (row%32)*16 + ((row%128)//32)*4 + group%4 -- the same
+    ``((32,4),(sf_vec,4)) : ((16,4),(0,1))`` atom the kernels read.
+    """
+    import torch
+
+    m = torch.arange(rows, device=device)[:, None]
+    kg = torch.arange(cols // sf_vec, device=device)[None, :]
+    num_k_tiles = (cols // sf_vec + 3) // 4
+    return (
+        ((m // 128) * num_k_tiles + kg // 4) * 512
+        + (m % 32) * 16
+        + ((m % 128) // 32) * 4
+        + (kg % 4)
+    )
+
+
+def _dequantize(qk_format, data_2d, sf_raw, sf_vec):
+    """Inverse of the flashinfer quantizers on their raw 2-D outputs (fp32 result on device).
+
+    Verified bit-identical to ``e2m1_and_ufp8sf_scale_to_float`` for NVFP4; the MXFP8 host
+    dequantizer of flashinfer 0.6.18 segfaults, so both formats are decoded here in torch.
+    """
+    import torch
+
+    rows = data_2d.shape[0]
+    device = data_2d.device
+    if qk_format == "nvfp4":
+        packed = data_2d.view(torch.uint8).reshape(rows, -1)
+        cols = packed.shape[1] * 2
+        nib = torch.stack([packed & 0xF, packed >> 4], dim=-1).reshape(rows, cols).to(torch.int64)
+        table = torch.tensor(_E2M1_VALUES, device=device)
+        vals = table[nib & 7] * torch.where(nib >= 8, -1.0, 1.0)
+        idx = _sf_swizzled_index(rows, cols, sf_vec, device)
+        sf = sf_raw.view(torch.uint8).flatten()[idx].view(torch.float8_e4m3fn).float()
+    else:
+        vals = data_2d.view(torch.float8_e4m3fn).reshape(rows, -1).float()
+        cols = vals.shape[1]
+        idx = _sf_swizzled_index(rows, cols, sf_vec, device)
+        e = sf_raw.view(torch.uint8).flatten()[idx].to(torch.int32)
+        sf = torch.where(e == 0, torch.zeros((), device=device), torch.exp2((e - 127).float()))
+    return vals * sf.repeat_interleave(sf_vec, dim=1)
+
+
+def dequantized_inputs(data, config):
+    """fp32 Q/K/V exactly as the kernels see them (block scales applied)."""
+
+    b, sq, sk = config["batch_size"], config["seq_len_q"], config["seq_len_kv"]
+    h, hk, d = config["num_qo_heads"], config["num_kv_heads"], config["head_dim"]
+    qk_format, pv_format = config["qk_format"], config["pv_format"]
+    sf_vec = _QK_SF_VEC[qk_format]
+    q = _dequantize(qk_format, data["q"].reshape(b * sq, -1), data["q_sf_raw"], sf_vec).reshape(
+        b, sq, h, d
+    )
+    k = _dequantize(qk_format, data["k"].reshape(b * sk, -1), data["k_sf_raw"], sf_vec).reshape(
+        b, sk, hk, d
+    )
+    if pv_format in ("bf16", "fp8"):
+        v = data["v"].float()
+    else:
+        fmt = "nvfp4" if pv_format == "nvfp4" else "mxfp8"
+        v_km = (
+            data["v"].reshape(b, hk, d, -1)
+            if pv_format == "nvfp4"
+            else data["v"].permute(0, 2, 3, 1)
+        )
+        v_km = v_km.reshape(b * hk * d, -1).contiguous()
+        v = _dequantize(fmt, v_km, data["v_sf_raw"], _PV_SF_VEC[pv_format]).reshape(b, hk, d, sk)
+        v = v.permute(0, 3, 1, 2)
+    return q, k, v.contiguous()
+
+
+def reference_attention_fp64(q, k, v, softmax_scale, is_causal):
+    """Plain attention in fp64 on already-dequantized inputs; GQA by head repetition."""
+    import torch
+
+    b, sq, h, d = q.shape
+    hk = k.shape[2]
+    q64 = q.double().permute(0, 2, 1, 3)
+    k64 = k.double().permute(0, 2, 1, 3).repeat_interleave(h // hk, dim=1)
+    v64 = v.double().permute(0, 2, 1, 3).repeat_interleave(h // hk, dim=1)
+    s = torch.matmul(q64, k64.transpose(-1, -2)) * softmax_scale
+    if is_causal:
+        sk = k.shape[1]
+        row = torch.arange(sq, device=q.device)[:, None]
+        col = torch.arange(sk, device=q.device)[None, :]
+        s = s.masked_fill(col > row + (sk - sq), float("-inf"))
+    p = torch.softmax(s, dim=-1)
+    return torch.matmul(p, v64).permute(0, 2, 1, 3)
+
+
+def _error_stats(out, ref64):
+    import torch
+
+    o = out.double()
+    err = (o - ref64).abs().max().item()
+    cos = torch.nn.functional.cosine_similarity(o.flatten(), ref64.flatten(), dim=0).item()
+    return err, cos
+
+
+# ---------------------------------------------------------------------------------------------
+# Host TensorMaps and launch binding
+# ---------------------------------------------------------------------------------------------
+
+
+class _AlignedTensorMap:
+    """Host storage for one 64-byte-aligned, 128-byte CUtensorMap."""
+
+    def __init__(self):
+        import ctypes
+
+        self._storage = ctypes.create_string_buffer(128 + 64)
+        base = ctypes.addressof(self._storage)
+        self.ptr = ctypes.c_void_p((base + 63) & ~63)
+
+
+def _encode_tensor_map(tensor, dtype, dims, strides, box, swizzle_bytes):
+    """cuTensorMapEncodeTiled: dims/box innermost first, strides in bytes for dims[1:]."""
+    import ctypes
+
+    import tvm
+
+    rank = len(dims)
+    assert len(strides) == rank - 1 and len(box) == rank
+    desc = _AlignedTensorMap()
+    tvm.get_global_func("runtime.cuTensorMapEncodeTiled")(
+        desc.ptr,
+        dtype,
+        rank,
+        ctypes.c_void_p(int(tensor.data_ptr())),
+        *dims,
+        *strides,
+        *box,
+        *((1,) * rank),
+        0,
+        _TMA_SWIZZLE[swizzle_bytes],
+        _TMA_L2_PROMOTION_128B,
+        0,
+    )
+    return desc
+
+
+def build_tensor_maps(spec: Spec, data, config):
+    """The kernel's TensorMap parameters, in declaration order (sketch: TensorMap table)."""
+    b, sq, sk = config["batch_size"], config["seq_len_q"], config["seq_len_kv"]
+    h, hk, d = config["num_qo_heads"], config["num_kv_heads"], config["head_dim"]
+    qk_bytes = d * spec.q_width // 8
+    qk_sw = qk_bytes if qk_bytes <= 128 else 128
+
+    def qk_map(t, s, nh):
+        return _encode_tensor_map(
+            t,
+            "uint8",
+            (qk_bytes, s, nh, b),
+            (nh * qk_bytes, qk_bytes, s * nh * qk_bytes),
+            (qk_bytes, BLK_M, 1, 1),
+            qk_sw,
+        )
+
+    def sf_map(storage, s, nh, sf_tile_k):
+        # storage bytes [b][h][s/128][chunks][512]; u16 elements, 256 per chunk
+        blocks = s // BLK_M
+        if sf_tile_k == 2:
+            dims = (256, 2, blocks, nh, b)
+            strides = (512, 1024, 1024 * blocks, 1024 * blocks * nh)
+            box = (256, 2, 1, 1, 1)
+        else:
+            dims = (256, blocks, 1, nh, b)
+            strides = (512, 512 * blocks, 512 * blocks, 512 * blocks * nh)
+            box = (256, 1, 1, 1, 1)
+        return _encode_tensor_map(storage, "uint16", dims, strides, box, 0)
+
+    sf_tile_k = d // (4 * spec.sf_vec_size)
+    maps = [qk_map(data["q"], sq, h), qk_map(data["k"], sk, hk)]
+    v = data["v"]
+    if spec.pv_format == "bf16":
+        maps.append(
+            _encode_tensor_map(
+                v,
+                "bfloat16",
+                (d, sk, hk, b),
+                (hk * d * 2, d * 2, sk * hk * d * 2),
+                (64, BLK_N, 1, 1),
+                128,
+            )
+        )
+    elif spec.pv_format == "fp8":
+        maps.append(
+            _encode_tensor_map(
+                v, "uint8", (d, sk, hk, b), (hk * d, d, sk * hk * d), (d, BLK_N, 1, 1), min(d, 128)
+            )
+        )
+    elif spec.pv_format == "nvfp4":  # storage (b, hk, d, sk/2) bytes
+        maps.append(
+            _encode_tensor_map(
+                v,
+                "uint8",
+                (sk // 2, d, hk, b),
+                (sk // 2, d * sk // 2, hk * d * sk // 2),
+                (64, BLK_N, 1, 1),
+                64,
+            )
+        )
+    else:  # mxfp8 K-major, storage (b, hk, d, sk) bytes
+        maps.append(
+            _encode_tensor_map(
+                v, "uint8", (sk, d, hk, b), (sk, d * sk, hk * d * sk), (BLK_N, BLK_N, 1, 1), 128
+            )
+        )
+    o = data["out_tirx"]
+    maps.append(
+        _encode_tensor_map(
+            o, "bfloat16", (d, sq, h, b), (h * d * 2, d * 2, sq * h * d * 2), (64, BLK_M, 1, 1), 128
+        )
+    )
+    maps.append(sf_map(data["q_sf_storage"], sq, h, sf_tile_k))
+    maps.append(sf_map(data["k_sf_storage"], sk, hk, sf_tile_k))
+    if spec.quant_pv:
+        # storage [b*hk][DV/128][sk/(4 sfv)] chunks
+        sfv = spec.sf_vec_size_pv
+        kchunks = sk // (4 * sfv)
+        dblocks = d // 128
+        if spec.pv_format == "nvfp4":
+            dims = (256, kchunks, dblocks, hk, b)
+            strides = (512, 512 * kchunks, 512 * kchunks * dblocks, 512 * kchunks * dblocks * hk)
+            box = (256, 2, 1, 1, 1)
+        else:
+            dims = (256, 1, kchunks, hk, b)
+            strides = (512, 512, 512 * kchunks * dblocks, 512 * kchunks * dblocks * hk)
+            box = (256, 1, 1, 1, 1)
+        maps.append(_encode_tensor_map(data["v_sf_storage"], "uint16", dims, strides, box, 0))
+    return maps
+
+
+def build_tirx_launch(executable, data, config):
+    """Bind the compiled kernel to one data set; returns a no-argument launch closure."""
+    spec = Spec(
+        config["qk_format"],
+        config["pv_format"],
+        config["head_dim"],
+        config["is_causal"],
+        config["num_qo_heads"],
+        config["num_kv_heads"],
+    )
+    maps = build_tensor_maps(spec, data, config)
+    scale_log2 = float(data["softmax_scale"] * math.log2(math.e))
+    argv = (*[m.ptr for m in maps], scale_log2)
+
+    def launch():
+        executable(*argv)
+
+    launch._keep_alive = (data, maps, argv)
+    return launch
+
+
+def run_test(
+    qk_format,
+    pv_format,
+    batch_size,
+    seq_len_q,
+    seq_len_kv,
+    num_qo_heads,
+    num_kv_heads,
+    head_dim,
+    is_causal=False,
+    **kwargs,
+):
+    """Compile, run, and verify against the upstream kernel on identical quantized bytes."""
+    from unittest import SkipTest
+
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 3):
+        raise SkipTest("flash_attention4_fp4 requires an SM103 (GB300) GPU")
+    config = dict(
+        qk_format=qk_format,
+        pv_format=pv_format,
+        batch_size=batch_size,
+        seq_len_q=seq_len_q,
+        seq_len_kv=seq_len_kv,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        is_causal=is_causal,
+    )
+    data = prepare_data(**{k: v for k, v in config.items() if k != "is_causal"})
+    executable = compile_kernel(get_kernel(**config))
+    launch = build_tirx_launch(executable, data, config)
+    launch()
+    torch.cuda.synchronize()
+    out = data["out_tirx"]
+    if not torch.isfinite(out).all():
+        raise AssertionError("output contains a non-finite value")
+    # Determinism of the port itself.
+    first = out.clone()
+    launch()
+    torch.cuda.synchronize()
+    if not torch.equal(out, first):
+        raise AssertionError("TIRx output differs between two identical launches")
+
+    # Primary gate: the upstream kernel on the same bytes must agree bit for bit. It is launched
+    # twice first: without a proxy fence between the softmax warps' sSFP store and the MMA warp's
+    # tcgen05.cp read, the upstream kernel is nondeterministic on multi-tile persistent shapes
+    # with a quantized P, and a racy reference cannot anchor a bitwise gate.
+    ref = run_reference(data, config).clone()
+    ref_again = run_reference(data, config)
+    torch.cuda.synchronize()
+    if not torch.isfinite(ref).all():
+        raise AssertionError("reference output contains a non-finite value")
+    if not torch.equal(ref, ref_again):
+        raise AssertionError(
+            f"upstream kernel is nondeterministic on {int((ref != ref_again).sum())} elements; "
+            "the upstream sSFP store lacks a proxy fence before the tcgen05.cp read"
+        )
+    if not torch.equal(out, ref):
+        ulps = _bf16_ulp_distance(out, ref)
+        mism = ulps != 0
+        rows = mism.any(dim=-1).nonzero()
+        raise AssertionError(
+            f"bitwise mismatch vs upstream: {int(mism.sum())} of {mism.numel()} elements, "
+            f"max {int(ulps.max())} bf16 ulp; first rows (b, s, h): {rows[:8].tolist()}"
+        )
+
+    # Structural oracle: both kernels against fp64 attention on the dequantized inputs.
+    q, k, v = dequantized_inputs(data, config)
+    ref64 = reference_attention_fp64(q, k, v, data["softmax_scale"], is_causal)
+    err_t, cos_t = _error_stats(out, ref64)
+    err_r, cos_r = _error_stats(ref, ref64)
+    if cos_r <= 0.98:
+        raise AssertionError(
+            f"upstream kernel vs fp64 cos_sim {cos_r:.5f} <= 0.98: input plumbing is wrong"
+        )
+    if err_t > err_r * (1 + 1e-3) + 1e-6 or cos_t < cos_r - 1e-6:
+        raise AssertionError(
+            f"TIRx err {err_t:.5g} / cos {cos_t:.6f} worse than upstream err {err_r:.5g} / cos {cos_r:.6f}"
+        )
+
+
+# ---------------------------------------------------------------------------------------------
+# Benchmark
+# ---------------------------------------------------------------------------------------------
+
+
+def prepare_bench(**kwargs: Any):
+    """Specialize and compile before the workload receives a GPU (CUDA stays uninitialized)."""
+    from tirx_kernels.runner import compile_kernel, hardware_num_sms, prepared_gpu_benchmark
+
+    state = {
+        "config": dict(kwargs),
+        "num_sms": hardware_num_sms(),
+        "executable": compile_kernel(get_kernel(**kwargs)),
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(
+    prepared,
+    *,
+    warmup=None,
+    repeat=None,
+    timer=None,  # None inherits proton: the CuTeDSL reference cannot be CUDA-graph captured.
+    **kwargs,
+):
+    import torch
+
+    from tirx_kernels.runner import bench
+
+    config = dict(prepared["config"])
+    if torch.cuda.get_device_properties(0).multi_processor_count != prepared["num_sms"]:
+        raise RuntimeError(
+            "the persistent grid was compiled for a different SM count; set TIRX_PREPARE_NUM_SMS"
+        )
+    data = prepare_data(**{k: v for k, v in config.items() if k != "is_causal"})
+    launch = build_tirx_launch(prepared["executable"], data, config)
+    return bench(
+        {"tirx": launch},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        references={"flashattn_fp4": lambda: build_reference_launch(data, config)},
+        **kwargs,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, **kwargs):
+    config = dict(kwargs)
+    protocol = {name: config.pop(name) for name in ("rounds", "cooldown_s") if name in config}
+    return prepare_bench(**config).run_gpu(warmup=warmup, repeat=repeat, timer=timer, **protocol)

--- a/tirx_kernels/flashinfer/cake_vsa/__init__.py
+++ b/tirx_kernels/flashinfer/cake_vsa/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Ports of the Cake video-sparse-attention kernels behind ``flashinfer.cake_vsa``."""

--- a/tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py
+++ b/tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py
@@ -1,0 +1,1766 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ c5365737), Copyright (c) 2026 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Cake VSA ``blk128_compact`` block-sparse attention forward for SM100a.
+
+Upstream sources (FlashInfer @ c5365737570a2a156d7cae0c4070fa3770ecc670):
+
+- ``csrc/cake_vsa/cake_vsa_blk128_compact_sm_100a.cu`` -- the device kernel
+  ``kernel_flashinfer_blackwell_vsa_blk128_seed_sm100`` (Cake source export,
+  last changed by upstream commit adc49a85, "perf(cake_vsa): refresh Blackwell
+  block-sparse WS kernel (#4804)").
+- ``csrc/cake_vsa/cake_vsa_blk128_compact_host.cpp`` -- the tvm-ffi launcher
+  that encodes the three 4-D SWIZZLE_128B tensor maps and launches
+  ``grid=(mb, num_qo_heads, 1)``, 512 threads, 134784 bytes of dynamic SMEM.
+- ``flashinfer/cake_vsa.py`` -- ``plan_cake_vsa``/``run_cake_vsa`` dispatch.
+  The ``blk128_compact`` profile is the route for bf16, head_dim 128, MHA
+  (``num_qo_heads == num_kv_heads``), 128x128 block masks, at most 64 selected
+  KV blocks per query block, and ``N < 16384 or num_qo_heads != 8``.
+
+Kernel structure (one CTA per ``(query block of 128 rows, head)``):
+
+- warp 15 loads Q with two 16 KB TMA transactions, ballot-compacts the CTA's
+  ``block_mask`` row into a shared list of selected KV block indices (shared by
+  the two 64-row softmax instances), then streams K and V tiles through a
+  three-stage 32 KB SMEM ring (order K0, K1, V0, V1 per selected block);
+- warp 12 issues every ``tcgen05.mma.cta_group::1.kind::f16``: eight K=16
+  steps for ``S = Q K^T`` (M=64, N=128) per instance into TMEM, then eight
+  steps for ``O += P V`` with P read from TMEM;
+- warps 0-7 (two instances of four warps) run the online softmax from TMEM:
+  row max, the ``2^-8`` rescale-skip decision, ``ex2.approx`` probabilities,
+  bf16 P written back in place, and per-row statistics in SMEM;
+- warps 8-11 rescale the TMEM O accumulator when a rescale was not skipped,
+  then normalize O, store bf16 output rows, and store the natural-log LSE.
+
+Every SMEM object lives in one rank-one byte arena addressed by explicit scalar
+offsets; no first-class layouts or tile primitives are used.
+"""
+
+import math
+from functools import lru_cache
+from typing import Any
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cake_vsa_blk128_compact_sm100",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "c5365737570a2a156d7cae0c4070fa3770ecc670",
+            },
+            "import": "flashinfer",
+        },
+    ),
+}
+# The upstream kernel is a prebuilt cubin loaded through FlashInfer's own tvm-ffi
+# launcher (``flashinfer.cake_vsa._load_module``); it does not use the CuTe DSL, and
+# tvm-ffi is a dependency of flashinfer-python itself, so only FlashInfer is pinned.
+
+# ---------------------------------------------------------------------------
+# Source contract constants (host.cpp / cake_vsa.py / the device kernel).
+# ---------------------------------------------------------------------------
+HEAD_DIM = 128
+BLOCK = 128  # R == C == 128 query/KV block size of this profile
+MAX_COMPACT_BLOCKS = 64  # ``union_blocks`` capacity per instance
+THREADS = 512
+NUM_WARPS = THREADS // 32
+SMEM_TOTAL = 134784
+TMEM_COLS = 512
+PROFILE = "blk128_compact"
+CUDA_ARCH = "sm_100a"
+_LN2 = math.log(2.0)
+
+# ``lse`` sentinel used when the caller does not request LSE: upstream passes a
+# one-element ``stats`` tensor that the kernel must leave untouched.
+_LSE_SENTINEL = 12345.25
+
+# Oracle tolerances (fp32 torch reference), frozen from the errors measured on
+# GB200 across CONFIGS with a 1.25-1.6x margin (the TIRx-vs-source comparison is
+# bitwise, so both implementations carry the same algorithmic error: bf16 P and
+# output rounding, ``ex2.approx``/``rcp.approx``/``lg2.approx``).  The upstream test
+# uses atol=rtol=1e-2.  ``max_rel_excess`` in the returned stats is the worst
+# error / (atol + rtol*|ref|) ratio.  The bf16 ULP checks apply to |ref| >= 0.125,
+# where one ULP is at least 2^-10.
+_ORACLE_OUT_ATOL = 1.5e-3
+_ORACLE_OUT_RTOL = 6e-3
+_ORACLE_LSE_ATOL = 2e-6
+_ORACLE_LSE_RTOL = 5e-7
+_ORACLE_ULP_MAX = 2
+_ORACLE_ULP_LE1_FRAC = 0.9999
+_ORACLE_ULP_LE2_FRAC = 1.0
+_ORACLE_ULP_MIN_REF = 0.125
+
+
+def _config(
+    label: str,
+    *,
+    M: int,
+    N: int,
+    num_heads: int,
+    pattern: str,
+    selected: int | None = None,
+    sel_lo: int | None = None,
+    sel_hi: int | None = None,
+    return_lse: bool = True,
+    q_amp: float = 1.0,
+    sm_scale: float | None = None,
+    return_temperature_lse: bool = False,
+    lse_temperature_scale: float = 1.0,
+    seed: int = 0,
+    oracle_atol: float = _ORACLE_OUT_ATOL,
+    oracle_rtol: float = _ORACLE_OUT_RTOL,
+    ulp_max: int = _ORACLE_ULP_MAX,
+    ulp_le1_frac: float = _ORACLE_ULP_LE1_FRAC,
+    ulp_le2_frac: float = _ORACLE_ULP_LE2_FRAC,
+) -> dict[str, Any]:
+    return {
+        "label": label,
+        "M": M,
+        "N": N,
+        "num_heads": num_heads,
+        "pattern": pattern,
+        "selected": selected,
+        "sel_lo": sel_lo,
+        "sel_hi": sel_hi,
+        "return_lse": return_lse,
+        "q_amp": q_amp,
+        "sm_scale": sm_scale,
+        "return_temperature_lse": return_temperature_lse,
+        "lse_temperature_scale": lse_temperature_scale,
+        "seed": seed,
+        "oracle_atol": oracle_atol,
+        "oracle_rtol": oracle_rtol,
+        "ulp_max": ulp_max,
+        "ulp_le1_frac": ulp_le1_frac,
+        "ulp_le2_frac": ulp_le2_frac,
+    }
+
+
+# Correctness matrix.  Every row stays inside the ``blk128_compact`` dispatch
+# domain (asserted by ``_assert_compact_route``).
+CONFIGS = [
+    # The upstream test row: mask columns (i*7 + row) % nb shared by all heads.
+    _config("m256_n512_h8_sel2_lse", M=256, N=512, num_heads=8, pattern="upstream", selected=2),
+    # One selected block per row, no LSE: the stats tensor must stay untouched.
+    _config(
+        "m1024_n1024_h8_sel1_nolse",
+        M=1024,
+        N=1024,
+        num_heads=8,
+        pattern="random",
+        selected=1,
+        return_lse=False,
+        seed=1,
+    ),
+    # Every one of the 64 KV blocks selected: the compact-list capacity.
+    _config("m2048_n8192_h8_sel64_lse", M=2048, N=8192, num_heads=8, pattern="dense", seed=2),
+    # nb=40 exercises the second ballot iteration (32 + 8 lanes) and per-row
+    # counts that differ between rows and heads.
+    _config(
+        "m1024_n5120_h4_selvar_lse",
+        M=1024,
+        N=5120,
+        num_heads=4,
+        pattern="random_var",
+        sel_lo=1,
+        sel_hi=40,
+        seed=3,
+    ),
+    # N == 16384 with num_heads != 8 stays on this route.
+    _config(
+        "m4096_n16384_h16_sel32_lse",
+        M=4096,
+        N=16384,
+        num_heads=16,
+        pattern="random",
+        selected=32,
+        seed=4,
+    ),
+    # Amplified Q and a non-default scale force the running max to move by more
+    # than 2^8 between blocks, so the O-rescale path executes.  Skipped rescales
+    # leave bf16 P values up to 2^8, so this regime carries a larger inherent
+    # error than the default tolerance (measured: 0.0188 max abs at |ref| 2.8).
+    _config(
+        "m2048_n4096_h8_selvar_qamp_lse",
+        M=2048,
+        N=4096,
+        num_heads=8,
+        pattern="random_var",
+        sel_lo=2,
+        sel_hi=16,
+        q_amp=6.0,
+        sm_scale=0.05,
+        seed=5,
+        oracle_atol=6.5e-3,
+        oracle_rtol=1e-2,
+        ulp_max=8,
+        ulp_le1_frac=0.995,
+        ulp_le2_frac=0.9998,
+    ),
+    # Single CTA.
+    _config(
+        "m128_n256_h1_sel2_lse", M=128, N=256, num_heads=1, pattern="random", selected=2, seed=6
+    ),
+    # One (head, query block) selects nothing: the kernel attends block 0 alone.
+    _config(
+        "m1024_n2048_h8_emptyrow_lse",
+        M=1024,
+        N=2048,
+        num_heads=8,
+        pattern="emptyrow",
+        selected=4,
+        seed=7,
+    ),
+    # Temperature LSE requested (upstream Python never sets it): exercises the
+    # second S read and the temperature statistics.
+    _config(
+        "m512_n1024_h4_sel3_templse",
+        M=512,
+        N=1024,
+        num_heads=4,
+        pattern="random",
+        selected=3,
+        return_temperature_lse=True,
+        lse_temperature_scale=0.7,
+        seed=8,
+    ),
+]
+
+# Benchmark matrix (uniform random masks with a fixed number of blocks per row).
+BENCH_CONFIGS = [
+    _config(
+        "m4096_n4096_h8_sel8",
+        M=4096,
+        N=4096,
+        num_heads=8,
+        pattern="random",
+        selected=8,
+        return_lse=False,
+        seed=100,
+    ),
+    _config(
+        "m16384_n16384_h16_sel16_lse",
+        M=16384,
+        N=16384,
+        num_heads=16,
+        pattern="random",
+        selected=16,
+        seed=101,
+    ),
+    _config(
+        "m32768_n32768_h24_sel32",
+        M=32768,
+        N=32768,
+        num_heads=24,
+        pattern="random",
+        selected=32,
+        return_lse=False,
+        seed=102,
+    ),
+    _config(
+        "m2048_n8192_h8_sel4",
+        M=2048,
+        N=8192,
+        num_heads=8,
+        pattern="random",
+        selected=4,
+        return_lse=False,
+        seed=103,
+    ),
+    _config("m8192_n8192_h8_sel64_lse", M=8192, N=8192, num_heads=8, pattern="dense", seed=104),
+    _config(
+        "m32768_n32768_h40_sel12",
+        M=32768,
+        N=32768,
+        num_heads=40,
+        pattern="random",
+        selected=12,
+        return_lse=False,
+        seed=105,
+    ),
+]
+
+
+def _without_label(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _validate_shape(M: int, N: int, num_heads: int) -> tuple[int, int]:
+    if M <= 0 or M % BLOCK != 0:
+        raise ValueError(f"M={M} must be a positive multiple of {BLOCK}")
+    if N <= 0 or N % BLOCK != 0:
+        raise ValueError(f"N={N} must be a positive multiple of {BLOCK}")
+    if num_heads <= 0:
+        raise ValueError(f"num_heads={num_heads} must be positive")
+    return M // BLOCK, N // BLOCK
+
+
+def _assert_compact_route(mask, *, N: int, num_heads: int, mb: int) -> None:
+    """Re-evaluate the upstream ``run_cake_vsa`` dispatch chain for this mask.
+
+    ``blk128_compact`` is reached only after the fp16, GQA, head-dim 64/96,
+    blk64, ultrasparse-BSR and longseq predicates all fail.  bf16, D=128 and MHA
+    are fixed by this module, so the remaining predicates are checked here.
+    """
+    counts = mask.sum(dim=-1)
+    max_selected = int(counts.max())
+    uniform = bool((counts == counts.flatten()[0]).all())
+    if mb >= 625 and num_heads == 8 and max_selected == 6 and uniform:
+        raise ValueError("mask would dispatch to the ultrasparse_bsr profile")
+    if N >= 16384 and num_heads == 8 and max_selected <= 192 and uniform:
+        raise ValueError("shape would dispatch to the longseq profile")
+    if max_selected > MAX_COMPACT_BLOCKS:
+        raise ValueError(f"max selected blocks {max_selected} exceeds {MAX_COMPACT_BLOCKS}")
+
+
+def _make_block_mask(
+    *,
+    num_heads: int,
+    mb: int,
+    nb: int,
+    pattern: str,
+    selected: int | None,
+    sel_lo: int | None,
+    sel_hi: int | None,
+    generator,
+):
+    """Build the ``(num_heads, mb, nb)`` boolean block mask for one config."""
+    import torch
+
+    mask = torch.zeros((num_heads, mb, nb), dtype=torch.bool)
+    if pattern == "dense":
+        mask[:] = True
+        return mask
+    if pattern == "upstream":
+        if selected is None:
+            raise ValueError("pattern 'upstream' needs 'selected'")
+        for row in range(mb):
+            columns = (torch.arange(selected) * 7 + row) % nb
+            mask[:, row, columns] = True
+        return mask
+    if pattern in {"random", "emptyrow"}:
+        if selected is None:
+            raise ValueError(f"pattern {pattern!r} needs 'selected'")
+        lo = hi = selected
+    elif pattern == "random_var":
+        if sel_lo is None or sel_hi is None:
+            raise ValueError("pattern 'random_var' needs 'sel_lo' and 'sel_hi'")
+        lo, hi = sel_lo, sel_hi
+    else:
+        raise ValueError(f"unknown mask pattern {pattern!r}")
+    if lo < 1 or hi > min(nb, MAX_COMPACT_BLOCKS) or lo > hi:
+        raise ValueError(f"selected range [{lo}, {hi}] invalid for nb={nb}")
+    for head in range(num_heads):
+        for row in range(mb):
+            count = lo if lo == hi else int(torch.randint(lo, hi + 1, (1,), generator=generator))
+            columns = torch.randperm(nb, generator=generator)[:count]
+            mask[head, row, columns] = True
+    if pattern == "emptyrow":
+        mask[min(1, num_heads - 1), min(2, mb - 1), :] = False
+    return mask
+
+
+def prepare_data(**config: Any) -> dict[str, Any]:
+    """Allocate logical inputs plus independent TIRx and source output buffers."""
+    import torch
+
+    config = _without_label(config)
+    M, N, num_heads = config["M"], config["N"], config["num_heads"]
+    mb, nb = _validate_shape(M, N, num_heads)
+    return_lse = bool(config["return_lse"])
+    return_tlse = bool(config["return_temperature_lse"])
+    sm_scale = config["sm_scale"]
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    generator = torch.Generator().manual_seed(int(config["seed"]))
+    device = torch.device("cuda")
+
+    q = torch.randn((M, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    q = (q * float(config["q_amp"])).to(torch.bfloat16).to(device)
+    k = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    k = k.to(torch.bfloat16).to(device)
+    v = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    v = v.to(torch.bfloat16).to(device)
+    mask = _make_block_mask(
+        num_heads=num_heads,
+        mb=mb,
+        nb=nb,
+        pattern=config["pattern"],
+        selected=config["selected"],
+        sel_lo=config["sel_lo"],
+        sel_hi=config["sel_hi"],
+        generator=generator,
+    )
+    if config["pattern"] != "emptyrow":
+        _assert_compact_route(mask, N=N, num_heads=num_heads, mb=mb)
+    block_mask = mask.to(device)
+
+    def outputs() -> dict[str, Any]:
+        out = torch.full(
+            (M, num_heads, HEAD_DIM), float("nan"), dtype=torch.bfloat16, device=device
+        )
+        if return_lse:
+            lse = torch.full((M, num_heads), float("nan"), dtype=torch.float32, device=device)
+        else:
+            lse = torch.full((1,), _LSE_SENTINEL, dtype=torch.float32, device=device)
+        if return_tlse:
+            tlse = torch.full((M, num_heads), float("nan"), dtype=torch.float32, device=device)
+        else:
+            tlse = lse  # upstream passes the same ``stats`` tensor for both slots
+        return {"out": out, "lse": lse, "tlse": tlse}
+
+    return {
+        "config": config,
+        "M": M,
+        "N": N,
+        "num_heads": num_heads,
+        "mb": mb,
+        "nb": nb,
+        "q": q,
+        "k": k,
+        "v": v,
+        "block_mask": block_mask,
+        "block_mask_u8": block_mask.view(torch.uint8),
+        "sm_scale": float(sm_scale),
+        "softmax_scale_log2": float(sm_scale) / _LN2,
+        "lse_temperature_scale": float(config["lse_temperature_scale"]),
+        "return_lse": return_lse,
+        "return_temperature_lse": return_tlse,
+        "tirx": outputs(),
+        "source": outputs(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# TIRx kernel
+# ---------------------------------------------------------------------------
+# cuTensorMapEncodeTiled enum values (CUtensorMapInterleave / Swizzle /
+# L2promotion / FloatOOBfill) as used by the upstream host launcher.
+_TMA_INTERLEAVE_NONE = 0
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_PROMOTION_NONE = 0
+_TMA_OOB_FILL_NONE = 0
+
+
+def _host_prelude(params):
+    """Encode the three upstream tensor maps from the runtime shape scalars.
+
+    Mirrors ``EncodeTma_q`` / ``EncodeTma_k`` / ``EncodeTma_v`` in the upstream
+    host launcher: rank-4 bf16 maps, 128-byte swizzle, no L2 promotion, no OOB
+    fill.  Q is ``{64, M, Hq, 2}`` with a ``{64, 64, 1, 2}`` box (one 16 KB
+    transaction covers both head-dim halves of 64 rows); K and V are
+    ``{64, N, 2, Hkv}`` with a ``{64, 64, 1, 1}`` box (8 KB per transaction).
+    """
+    mb = params["mb"]
+    nb = params["nb"]
+    num_q_heads = params["num_q_heads"]
+    num_kv_heads = params["num_kv_heads"]
+    elem_bytes = 2
+
+    def encode(tensor, dims, strides_bytes, box):
+        descriptor = K.stack_alloca("tensormap", 1)
+        K.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            descriptor,
+            "bfloat16",
+            4,
+            tensor.data,
+            *dims,
+            *strides_bytes,
+            *box,
+            1,
+            1,
+            1,
+            1,
+            _TMA_INTERLEAVE_NONE,
+            _TMA_SWIZZLE_128B,
+            _TMA_L2_PROMOTION_NONE,
+            _TMA_OOB_FILL_NONE,
+        )
+        return descriptor
+
+    q_map = encode(
+        params["q"],
+        (64, mb * BLOCK, num_q_heads, HEAD_DIM // 64),
+        (num_q_heads * HEAD_DIM * elem_bytes, HEAD_DIM * elem_bytes, 64 * elem_bytes),
+        (64, 64, 1, HEAD_DIM // 64),
+    )
+    kv_dims = (64, nb * BLOCK, HEAD_DIM // 64, num_kv_heads)
+    kv_strides = (num_kv_heads * HEAD_DIM * elem_bytes, 64 * elem_bytes, HEAD_DIM * elem_bytes)
+    kv_box = (64, 64, 1, 1)
+    k_map = encode(params["k"], kv_dims, kv_strides, kv_box)
+    v_map = encode(params["v"], kv_dims, kv_strides, kv_box)
+    return (q_map, k_map, v_map)
+
+
+# Byte offsets inside the 134784-byte dynamic SMEM arena (source macro table).
+_MBAR_Q_FULL = 0
+_MBAR_UNION_READY = 8
+_MBAR_KV_FULL = 16  # 3 stages
+_MBAR_KV_EMPTY = 40  # 3 stages
+_MBAR_S_FULL = 64  # 2 instances
+_MBAR_P_FULL = 80  # 2 instances
+_MBAR_CORR_SIG = 96  # 2 instances
+_MBAR_CORR_DONE = 112  # 2 instances
+_MBAR_O_FULL = 128  # 2 instances
+_MBAR_TMEM_DEALLOC = 144
+_SMEM_TMEM_MAILBOX = 152
+_SMEM_Q0 = 1024
+_SMEM_Q1 = 17408
+_SMEM_KV = 33792  # 3 x 32768, K and V share the ring
+_SMEM_KV_STAGE_BYTES = 32768
+_SMEM_SCALE = 132096  # 512 f32: acc_scale / row_sum / row_max / temperature_sum
+_SMEM_UNION_COUNT = 134144  # 2 i32
+_SMEM_UNION_BLOCKS = 134152  # 2 x 64 i32
+# (offset, arrival count) in source order: q_full, union_ready, kv_full x3, kv_empty x3,
+# s_full x2, p_full x2, corr_sig x2, corr_done x2, o_full x2, tmem_dealloc.
+_MBARRIER_INIT = (
+    (_MBAR_Q_FULL, 1),
+    (_MBAR_UNION_READY, 32),
+    (_MBAR_KV_FULL, 1),
+    (_MBAR_KV_FULL + 8, 1),
+    (_MBAR_KV_FULL + 16, 1),
+    (_MBAR_KV_EMPTY, 1),
+    (_MBAR_KV_EMPTY + 8, 1),
+    (_MBAR_KV_EMPTY + 16, 1),
+    (_MBAR_S_FULL, 1),
+    (_MBAR_S_FULL + 8, 1),
+    (_MBAR_P_FULL, 256),
+    (_MBAR_P_FULL + 8, 256),
+    (_MBAR_CORR_SIG, 128),
+    (_MBAR_CORR_SIG + 8, 128),
+    (_MBAR_CORR_DONE, 128),
+    (_MBAR_CORR_DONE + 8, 128),
+    (_MBAR_O_FULL, 1),
+    (_MBAR_O_FULL + 8, 1),
+    (_MBAR_TMEM_DEALLOC, 128),
+)
+# TMEM column bases per softmax instance: S (128 columns; P overwrites the upper 64
+# in place) and the O accumulator (128 columns).
+_TMEM_SCORES = (0, 256)
+_TMEM_OUTPUT = (128, 384)
+_TMEM_P_OFFSET = 64
+# UMMA descriptor words and instruction descriptors (source immediates).
+_DESC_HI = 0x40004040  # SBO 1024 B, base-offset bit, 128 B swizzle
+_QK_IDESC = 0x04200490  # bf16 x bf16 -> f32, M=64, N=128, K-major A and B
+_PV_IDESC = 0x04210490  # same with MN-major B (V is token-major)
+_QK_A_STEPS = (2, 2, 2, 506, 2, 2, 2)  # Q low-word walk over K=128 (bytes/16)
+_QK_B_STEPS = (2, 2, 2, 1018, 2, 2, 2)  # K low-word walk (second dim half at +16384 B)
+_V_LBO_BIT = 0x4000000  # LBO = 16384 B: dim-half stride of the V tile
+_PV_B_STEP = 128  # 2048 B = 16 tokens x 128 B per K16 step
+_PV_A_STEP = 8  # 16 bf16 P columns = 8 TMEM 32-bit columns per K16 step
+_REG_SOFTMAX = 192
+_REG_CORRECTION = 80
+_REG_OTHER = 48
+_WAIT_TICKS = 0x989680
+
+_TMA_G2S_4D = "cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+_TCGEN05_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+_TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+_TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+_TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+_TMEM_LD_X32 = "tcgen05.ld.sync.aligned.16x32bx2.x32.b32"
+_TMEM_ST_X16 = "tcgen05.st.sync.aligned.16x32bx2.x16.b32"
+_TMEM_ST_X64 = "tcgen05.st.sync.aligned.16x32bx2.x64.b32"
+_LN2_F32 = 0.6931471805599453
+_NEG_INF = float("-inf")
+_FULL_MASK = 0xFFFFFFFF
+
+
+def _u32(value):
+    return K.uint32(value)
+
+
+def _i32(value):
+    return K.int32(value)
+
+
+def _f32(value):
+    return K.float32(value)
+
+
+def _mbar_wait(addr, phase):
+    """``mbarrier.try_wait.parity.acquire.cta`` retry loop with the source's suspend hint."""
+    K.cuda.mbarrier_wait(addr, phase)
+
+
+def _mbar_arrive(addr):
+    K.ptx.mbarrier.arrive.release.cta.shared__cta.b64(addr)
+
+
+def _mbar_expect_tx(addr, tx_bytes):
+    K.ptx.mbarrier.arrive.expect_tx.release.cta.shared__cta.b64(addr, _u32(tx_bytes))
+
+
+def _ld_shared_i32(addr):
+    value = K.local_scalar("int32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _ld_shared_f32(addr):
+    value = K.local_scalar("float32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _ld_shared_counts(addr):
+    """Both instance counts in one ``ld.shared.v2.b32`` (the source's vectorized pair)."""
+    count0 = K.local_scalar("int32")
+    count1 = K.local_scalar("int32")
+    K.ptx.ld.shared.v2.b32(count0, count1, addr)
+    return count0, count1
+
+
+def _flip(phase):
+    K.assign(phase, phase ^ _i32(1))
+
+
+def _advance_ring(stage, phase):
+    """Three-stage ring cursor: stage += 1, wrap to 0 and flip parity at 3."""
+    K.assign(stage, stage + _u32(1))
+    with K.If(stage == _u32(3)), K.Then():
+        K.assign(stage, _u32(0))
+        _flip(phase)
+
+
+def _pack2(lo, hi):
+    packed = K.local_scalar("uint64")
+    K.ptx.mov.b64(packed, lo, hi)
+    return packed
+
+
+def _packed_fma_inplace(values, base, scale_pair, bias_pair):
+    """``fma.rn.ftz.f32x2`` on values[base:base+2] with packed scale and bias."""
+    result = K.local_scalar("uint64")
+    K.ptx.fma.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair, bias_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _packed_mul_inplace(values, base, scale_pair):
+    """``mul.rn.ftz.f32x2`` on values[base:base+2] with a packed scale."""
+    result = K.local_scalar("uint64")
+    K.ptx.mul.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _exp2_inplace(values, index):
+    K.ptx.ex2.approx.ftz.f32(values[index], values[index])
+
+
+def _max_f32(a, b):
+    out = K.local_scalar("float32")
+    K.ptx.max.f32(out, a, b)
+    return out
+
+
+def _shfl_xor_f32(value, lane_xor):
+    out = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret("uint32", value), _u32(lane_xor), _u32(31), _u32(_FULL_MASK)
+    )
+    return K.reinterpret("float32", out)
+
+
+def _tmem_load_x32(dst, base, taddr):
+    K.ptx[_TMEM_LD_X32](*(dst[base + i] for i in range(32)), taddr, 64)
+
+
+def _block_sum(values):
+    """``softmax_block_sum`` over 64 values: 32 packed ``add.f32x2`` into one accumulator."""
+    acc = K.local_scalar("uint64")
+    K.ptx.mov.b64(acc, _f32(0.0), _f32(0.0))
+    for j in range(32):
+        K.ptx.add.f32x2(acc, acc, _pack2(values[2 * j], values[2 * j + 1]))
+    acc_x = K.local_scalar("float32")
+    acc_y = K.local_scalar("float32")
+    K.ptx.mov.b64(acc_x, acc_y, acc)
+    half = K.local_scalar("float32")
+    K.ptx.add.ftz.f32(half, acc_x, acc_y)
+    total = K.local_scalar("float32")
+    K.ptx.add.ftz.f32(total, half, _shfl_xor_f32(half, 16))
+    return total
+
+
+def _row_max(values):
+    """``row_max_x32_accum`` x2 + ``row_max_reduce``: alternating accumulators, 65 ``max.f32``."""
+    acc0 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    acc1 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    for half in range(2):
+        for j in range(16):
+            pair = _max_f32(values[half * 32 + 2 * j], values[half * 32 + 2 * j + 1])
+            if j % 2 == 0:
+                K.assign(acc0, _max_f32(acc0, pair))
+            else:
+                K.assign(acc1, _max_f32(acc1, pair))
+    return _max_f32(acc0, acc1)
+
+
+def _build_kernel():
+    @K.kernel(
+        warps=NUM_WARPS,
+        arch=CUDA_ARCH,
+        min_blocks_per_sm=1,
+        grid=lambda p: [p["mb"], p["num_q_heads"]],
+        host_prelude=_host_prelude,
+    )
+    def cake_vsa_blk128_compact_sm100(
+        q: K.gptr[K.bf16],
+        k: K.gptr[K.bf16],
+        v: K.gptr[K.bf16],
+        out: K.gptr[K.bf16],
+        lse: K.gptr[K.f32],
+        temperature_lse: K.gptr[K.f32],
+        block_mask: K.gptr[K.u8],
+        mb: K.i32,
+        nb: K.i32,
+        num_q_heads: K.i32,
+        num_kv_heads: K.i32,
+        softmax_scale_log2: K.f32,
+        lse_temperature_scale: K.f32,
+        return_softmax_lse: K.i32,
+        return_temperature_lse: K.i32,
+        *,
+        host,
+    ):
+        q_map, k_map, v_map = host
+        del q, k, v, num_kv_heads  # reached only through the tensor maps / host prelude
+        # >>> kernel_flashinfer_blackwell_vsa_blk128_seed_sm100 body starts here
+        q_tile, q_head = K.cta_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        arena = K.alloc_buffer((SMEM_TOTAL,), K.u8, scope="shared.dyn", align=1024)
+        smem = K.local_scalar("uint32", init=K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
+
+        def bar(offset):
+            return smem + _u32(offset)
+
+        # Mbarrier init (10 groups, 19 barriers) by one elected lane of warp 0.
+        with K.If(warp == 0), K.Then():
+            init_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            with K.If(init_leader != _u32(0)), K.Then():
+                for offset, count in _MBARRIER_INIT:
+                    K.ptx.mbarrier.init.shared__cta.b64(bar(offset), _u32(count))
+                K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.warp.sync(_u32(_FULL_MASK))
+
+        # TMEM alloc (512 columns) by warp 0; the address lands in the shared mailbox.
+        with K.If(warp == 0), K.Then():
+            K.ptx[_TMEM_ALLOC](bar(_SMEM_TMEM_MAILBOX), _u32(TMEM_COLS))
+            K.ptx[_TMEM_RELINQUISH]()
+        K.cuda.cta_sync()
+        K.ptx["tcgen05.fence::after_thread_sync"]()
+        taddr = K.local_scalar("uint32")
+        K.ptx.ld.volatile.shared.b32(taddr, bar(_SMEM_TMEM_MAILBOX))
+
+        q_local_base = q_tile * 128
+        kv_len = nb * 128
+
+        # Sibling role guards, as in the source; folding them into an if/else-if chain
+        # measured 1.2-2.3% slower on the two small shapes with no register pressure to relieve.
+        roles = K.specialize(chain_dispatch=False)
+        other_regs = roles.register_scope("other", warps=range(12, 16), regs=_REG_OTHER)
+        r_softmax = roles.role("softmax", warps=range(0, 8), regs=_REG_SOFTMAX)
+        r_correction = roles.role("correction", warps=range(8, 12), regs=_REG_CORRECTION)
+        r_mma = roles.role("mma", warps=[12], register_scope=other_regs)
+        r_idle = roles.role("idle", warps=[13, 14], register_scope=other_regs)
+        r_load = roles.role("load", warps=[15], register_scope=other_regs)
+
+        # Register redistribution: warps 12..15 decrease first so the softmax
+        # increase can be granted.
+        with K.If(K.And(warp >= 12, warp <= 15)), K.Then():
+            other_regs.emit()
+
+        # ---- Role: softmax (warps 0..7, two four-warp instances) ----
+        with r_softmax:
+            q_valid = K.local_scalar("int32", init=_i32(128))
+            with K.If(q_tile >= mb), K.Then():
+                K.assign(q_valid, _i32(0))
+            union_ready_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase)
+            _flip(union_ready_phase)
+            instance = K.uniform(warp // 4)
+            instance_row_offset = K.uniform(instance * 64)
+            instance_token_offset = K.uniform(instance * 64)
+            instance_tmem_offset = K.uniform(instance * 256)
+            union_count = _ld_shared_i32(
+                bar(_SMEM_UNION_COUNT) + K.cast(instance, "uint32") * _u32(4)
+            )
+            warp_in_instance = warp % 4
+            tmem_row_origin = warp_in_instance * 32
+            my_row = warp_in_instance * 16 + lane % 16
+            col_half = lane // 16
+            instance_valid = K.local_scalar("int32", init=q_valid - instance_token_offset)
+            with K.If(instance_valid > _i32(64)), K.Then():
+                K.assign(instance_valid, _i32(64))
+            with K.If(instance_valid < _i32(0)), K.Then():
+                K.assign(instance_valid, _i32(0))
+            row_valid = K.local_scalar("int32", init=K.cast(my_row < instance_valid, "int32"))
+            row_max = K.local_scalar("float32", init=_f32(_NEG_INF))
+            row_sum = K.local_scalar("float32", init=_f32(0.0))
+            temperature_sum = K.local_scalar("float32", init=_f32(0.0))
+            phase_s_full_0 = K.local_scalar("int32", init=_i32(0))
+            phase_s_full_1 = K.local_scalar("int32", init=_i32(0))
+            phase_corr_done_0 = K.local_scalar("int32", init=_i32(0))
+            phase_corr_done_1 = K.local_scalar("int32", init=_i32(0))
+            score_addr = K.local_scalar(
+                "uint32",
+                init=taddr
+                + K.cast(instance_tmem_offset, "uint32")
+                + K.shift_left(K.cast(tmem_row_origin, "uint32"), _u32(16)),
+            )
+            p_addr = K.local_scalar("uint32", init=score_addr + _u32(_TMEM_P_OFFSET))
+            scale_row_addr = bar(_SMEM_SCALE) + K.cast(
+                instance_row_offset + my_row, "uint32"
+            ) * _u32(4)
+            scores = K.alloc_local((64,), "float32")
+            packed_p = K.alloc_local((32,), "uint32")
+            block_sum = K.local_scalar("float32", init=_f32(0.0))
+            block_temperature_sum = K.local_scalar("float32", init=_f32(0.0))
+            acc_scale = K.local_scalar("float32", init=_f32(1.0))
+            temperature_acc_scale = K.local_scalar("float32", init=_f32(1.0))
+            selected_max = K.local_scalar("float32", init=_f32(_NEG_INF))
+            new_max_scaled = K.local_scalar("float32", init=_f32(0.0))
+            safe_max = K.local_scalar("float32", init=_f32(0.0))
+
+            def probabilities_from(frag, bias):
+                """fma, exp2, block sum, bf16 pack and the two P stores of one branch."""
+                scale_pair = _pack2(softmax_scale_log2, softmax_scale_log2)
+                bias_pair = _pack2(bias, bias)
+                for j in range(32):
+                    _packed_fma_inplace(frag, 2 * j, scale_pair, bias_pair)
+                for j in range(64):
+                    _exp2_inplace(frag, j)
+                K.assign(block_sum, _block_sum(frag))
+                for j in range(32):
+                    K.ptx.cvt.rn.bf16x2.f32(packed_p[j], frag[2 * j + 1], frag[2 * j])
+                K.ptx[_TMEM_ST_X16](p_addr, 32, *(packed_p[i] for i in range(16)))
+                K.ptx[_TMEM_ST_X16](p_addr + _u32(16), 32, *(packed_p[16 + i] for i in range(16)))
+
+            union_index = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index < union_count):
+                n_block = _ld_shared_i32(
+                    bar(_SMEM_UNION_BLOCKS)
+                    + K.cast(instance * 64 + union_index, "uint32") * _u32(4)
+                )
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_wait(bar(_MBAR_S_FULL), phase_s_full_0)
+                        _flip(phase_s_full_0)
+                    with K.Else():
+                        _mbar_wait(bar(_MBAR_S_FULL + 8), phase_s_full_1)
+                        _flip(phase_s_full_1)
+                valid_cols = K.local_scalar("int32", init=_i32(0))
+                with K.If(row_valid != _i32(0)), K.Then():
+                    K.assign(valid_cols, kv_len - n_block * 128)
+                    with K.If(valid_cols > _i32(128)), K.Then():
+                        K.assign(valid_cols, _i32(128))
+                    with K.If(valid_cols < _i32(0)), K.Then():
+                        K.assign(valid_cols, _i32(0))
+                _tmem_load_x32(scores, 0, score_addr)
+                _tmem_load_x32(scores, 32, score_addr + _u32(32))
+                half_valid = K.local_scalar("int32", init=valid_cols - col_half * 64)
+                with K.If(half_valid < _i32(0)), K.Then():
+                    K.assign(half_valid, _i32(0))
+                with K.If(half_valid > _i32(64)), K.Then():
+                    K.assign(half_valid, _i32(64))
+                # The source's per-column -inf fill for 0 < half_valid < 64 is unreachable
+                # (valid_cols is a multiple of 128) and nvcc emits no code for it.
+                tile_max = K.local_scalar("float32", init=_row_max(scores))
+                with K.If(half_valid <= _i32(0)), K.Then():
+                    K.assign(tile_max, _f32(_NEG_INF))
+                K.assign(tile_max, _max_f32(tile_max, _shfl_xor_f32(tile_max, 16)))
+                new_max = _max_f32(tile_max, row_max)
+                K.assign(safe_max, K.if_then_else(new_max == _f32(_NEG_INF), _f32(0.0), new_max))
+                K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                neg_new_max_scaled = K.local_scalar("float32")
+                K.ptx.neg.ftz.f32(neg_new_max_scaled, new_max_scaled)
+                acc_scale_log2 = K.local_scalar("float32")
+                K.ptx.fma.rn.ftz.f32(
+                    acc_scale_log2, row_max, softmax_scale_log2, neg_new_max_scaled
+                )
+                with K.If(acc_scale_log2 >= _f32(-8.0)):
+                    with K.Then():
+                        # The running max moves by less than 2^8: keep the old max, skip the rescale.
+                        K.assign(selected_max, row_max)
+                        K.assign(
+                            safe_max, K.if_then_else(row_max == _f32(_NEG_INF), _f32(0.0), row_max)
+                        )
+                        K.assign(acc_scale, _f32(1.0))
+                        K.assign(temperature_acc_scale, _f32(1.0))
+                        K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                    with K.Else():
+                        K.assign(selected_max, new_max)
+                        exp_scale = K.local_scalar("float32")
+                        K.ptx.ex2.approx.ftz.f32(exp_scale, acc_scale_log2)
+                        K.assign(
+                            acc_scale,
+                            K.if_then_else(row_max > _f32(_NEG_INF), exp_scale, _f32(1.0)),
+                        )
+                        tau_log2 = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_log2, acc_scale_log2, lse_temperature_scale)
+                        exp_tau = K.local_scalar("float32")
+                        K.ptx.ex2.approx.ftz.f32(exp_tau, tau_log2)
+                        K.assign(
+                            temperature_acc_scale,
+                            K.if_then_else(row_max > _f32(_NEG_INF), exp_tau, _f32(1.0)),
+                        )
+                K.assign(row_max, selected_max)
+                with K.If(col_half == 0), K.Then():
+                    K.ptx.st.shared.b32(scale_row_addr, acc_scale)
+                K.ptx.fence.proxy.async_.shared__cta()
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG))
+                    with K.Else():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+                # The bias negates the (possibly re-selected) new_max_scaled after the branch.
+                neg_bias = K.local_scalar("float32")
+                K.ptx.neg.ftz.f32(neg_bias, new_max_scaled)
+                score_bias = K.local_scalar("float32")
+                K.assign(score_bias, K.if_then_else(valid_cols > _i32(0), neg_bias, _f32(_NEG_INF)))
+                K.assign(block_temperature_sum, _f32(0.0))
+                K.assign(block_sum, _f32(0.0))
+                with K.If(return_temperature_lse != _i32(0)):
+                    with K.Then():
+                        tau_scale = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_scale, softmax_scale_log2, lse_temperature_scale)
+                        tau_bias = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_bias, score_bias, lse_temperature_scale)
+                        tau_scale_pair = _pack2(tau_scale, tau_scale)
+                        tau_bias_pair = _pack2(tau_bias, tau_bias)
+                        for j in range(32):
+                            _packed_fma_inplace(scores, 2 * j, tau_scale_pair, tau_bias_pair)
+                        for j in range(64):
+                            _exp2_inplace(scores, j)
+                        K.assign(block_temperature_sum, _block_sum(scores))
+                        # S is re-read because the temperature sum consumed the first copy.
+                        _tmem_load_x32(scores, 0, score_addr)
+                        _tmem_load_x32(scores, 32, score_addr + _u32(32))
+                        probabilities_from(scores, score_bias)
+                    with K.Else():
+                        probabilities_from(scores, score_bias)
+                K.ptx.tcgen05.wait__st.sync.aligned()
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_arrive(bar(_MBAR_P_FULL))
+                        _mbar_wait(bar(_MBAR_CORR_DONE), phase_corr_done_0)
+                        _flip(phase_corr_done_0)
+                    with K.Else():
+                        _mbar_arrive(bar(_MBAR_P_FULL + 8))
+                        _mbar_wait(bar(_MBAR_CORR_DONE + 8), phase_corr_done_1)
+                        _flip(phase_corr_done_1)
+                K.ptx.fma.rn.ftz.f32(row_sum, row_sum, acc_scale, block_sum)
+                with K.If(return_temperature_lse != _i32(0)), K.Then():
+                    K.ptx.fma.rn.ftz.f32(
+                        temperature_sum,
+                        temperature_sum,
+                        temperature_acc_scale,
+                        block_temperature_sum,
+                    )
+                K.assign(union_index, union_index + _i32(1))
+            with K.If(col_half == 0), K.Then():
+                K.ptx.st.shared.b32(scale_row_addr + _u32(128 * 4), row_sum)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(256 * 4), row_max)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(384 * 4), temperature_sum)
+            K.ptx.fence.proxy.async_.shared__cta()
+            with K.If(instance == 0):
+                with K.Then():
+                    _mbar_arrive(bar(_MBAR_CORR_SIG))
+                with K.Else():
+                    _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+
+        # ---- Role: correction and epilogue (warps 8..11) ----
+        with r_correction:
+            q_valid_c = K.local_scalar("int32", init=_i32(128))
+            with K.If(q_tile >= mb), K.Then():
+                K.assign(q_valid_c, _i32(0))
+            union_ready_phase_c = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_c)
+            _flip(union_ready_phase_c)
+            count0_c, count1_c = _ld_shared_counts(bar(_SMEM_UNION_COUNT))
+            max_union_count_c = K.local_scalar("int32", init=count0_c)
+            with K.If(max_union_count_c < count1_c), K.Then():
+                K.assign(max_union_count_c, count1_c)
+            warp_in_role = warp - 8
+            tmem_row_origin_c = warp_in_role * 32
+            my_row_c = warp_in_role * 16 + lane % 16
+            col_half_c = lane // 16
+            row_addr = K.local_scalar(
+                "uint32", init=K.shift_left(K.cast(tmem_row_origin_c, "uint32"), _u32(16))
+            )
+            scale_base_c = bar(_SMEM_SCALE) + K.cast(my_row_c, "uint32") * _u32(4)
+            _mbar_arrive(bar(_MBAR_P_FULL))
+            _mbar_arrive(bar(_MBAR_P_FULL + 8))
+            phase_corr_sig_0 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_CORR_SIG), phase_corr_sig_0)
+            _flip(phase_corr_sig_0)
+            _mbar_arrive(bar(_MBAR_CORR_DONE))
+            phase_corr_sig_1 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_CORR_SIG + 8), phase_corr_sig_1)
+            _flip(phase_corr_sig_1)
+            _mbar_arrive(bar(_MBAR_CORR_DONE + 8))
+            o_frag = K.alloc_local((64,), "float32")
+
+            def rescale_instance(instance, phase_corr_sig, union_index_1):
+                count = _ld_shared_i32(bar(_SMEM_UNION_COUNT + 4 * instance))
+                with K.If(count > union_index_1), K.Then():
+                    _mbar_wait(bar(_MBAR_CORR_SIG + 8 * instance), phase_corr_sig)
+                    _flip(phase_corr_sig)
+                    acc_scale_c = _ld_shared_f32(scale_base_c + _u32(64 * 4 * instance))
+                    any_rescale = K.local_scalar("uint32")
+                    K.ptx.vote_sync.any.pred(
+                        any_rescale,
+                        K.ptx.pred(K.cast(acc_scale_c < _f32(1.0), "bool")),
+                        _u32(_FULL_MASK),
+                    )
+                    with K.If(any_rescale != _u32(0)), K.Then():
+                        o_addr = taddr + _u32(_TMEM_OUTPUT[instance]) + row_addr
+                        _tmem_load_x32(o_frag, 0, o_addr)
+                        _tmem_load_x32(o_frag, 32, o_addr + _u32(32))
+                        scale_pair = _pack2(acc_scale_c, acc_scale_c)
+                        for j in range(32):
+                            _packed_mul_inplace(o_frag, 2 * j, scale_pair)
+                        K.ptx[_TMEM_ST_X64](o_addr, 64, *(o_frag[i] for i in range(64)))
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                    _mbar_arrive(bar(_MBAR_P_FULL + 8 * instance))
+                    _mbar_arrive(bar(_MBAR_CORR_DONE + 8 * instance))
+
+            union_index_1 = K.local_scalar("int32", init=_i32(1))
+            with K.While(union_index_1 < max_union_count_c):
+                rescale_instance(0, phase_corr_sig_0, union_index_1)
+                rescale_instance(1, phase_corr_sig_1, union_index_1)
+                K.assign(union_index_1, union_index_1 + _i32(1))
+            phase_o_full_0 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_O_FULL), phase_o_full_0)
+            _flip(phase_o_full_0)
+            phase_o_full_1 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_O_FULL + 8), phase_o_full_1)
+            _flip(phase_o_full_1)
+            _mbar_wait(bar(_MBAR_CORR_SIG), phase_corr_sig_0)
+            _flip(phase_corr_sig_0)
+            _mbar_wait(bar(_MBAR_CORR_SIG + 8), phase_corr_sig_1)
+            _flip(phase_corr_sig_1)
+            K.ptx["tcgen05.fence::after_thread_sync"]()
+            for instance in range(2):
+                stats_addr = scale_base_c + _u32(64 * 4 * instance)
+                final_sum = _ld_shared_f32(stats_addr + _u32(128 * 4))
+                final_max = _ld_shared_f32(stats_addr + _u32(256 * 4))
+                final_temperature_sum = _ld_shared_f32(stats_addr + _u32(384 * 4))
+                rcp_sum = K.local_scalar("float32")
+                K.ptx.rcp.approx.ftz.f32(rcp_sum, final_sum)
+                sum_positive = K.local_scalar("int32", init=K.cast(final_sum > _f32(0.0), "int32"))
+                inv_sum = K.local_scalar(
+                    "float32", init=K.if_then_else(sum_positive != _i32(0), rcp_sum, _f32(0.0))
+                )
+                instance_valid_c = K.local_scalar("int32", init=q_valid_c - _i32(64 * instance))
+                with K.If(instance_valid_c > _i32(64)), K.Then():
+                    K.assign(instance_valid_c, _i32(64))
+                with K.If(instance_valid_c < _i32(0)), K.Then():
+                    K.assign(instance_valid_c, _i32(0))
+                query = q_local_base + 64 * instance + my_row_c
+                output_row = (query * num_q_heads + q_head) * 128
+                o_addr = taddr + _u32(_TMEM_OUTPUT[instance]) + row_addr
+                _tmem_load_x32(o_frag, 0, o_addr)
+                _tmem_load_x32(o_frag, 32, o_addr + _u32(32))
+                col_base = col_half_c * 64
+                with K.If(my_row_c < instance_valid_c), K.Then():
+                    inv_pair = _pack2(inv_sum, inv_sum)
+                    for chunk in range(8):
+                        base = 8 * chunk
+                        for j in range(4):
+                            _packed_mul_inplace(o_frag, base + 2 * j, inv_pair)
+                        words = K.alloc_local((4,), "uint32")
+                        for j in range(4):
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                words[j], o_frag[base + 2 * j + 1], o_frag[base + 2 * j]
+                            )
+                        K.ptx.st.global_.v4.b32(
+                            out.ptr_to([output_row + col_base + base]),
+                            words[0],
+                            words[1],
+                            words[2],
+                            words[3],
+                        )
+                    with K.If(col_half_c == 0), K.Then():
+                        stat_idx = query * num_q_heads + q_head
+                        with K.If(return_softmax_lse != _i32(0)), K.Then():
+                            log2_sum = K.local_scalar("float32")
+                            K.ptx.lg2.approx.ftz.f32(log2_sum, final_sum)
+                            max_scaled = K.local_scalar("float32")
+                            K.ptx.mul.ftz.f32(max_scaled, final_max, softmax_scale_log2)
+                            log_sum = K.local_scalar("float32")
+                            K.ptx.mul.ftz.f32(log_sum, log2_sum, _f32(_LN2_F32))
+                            lse_value = K.local_scalar("float32")
+                            K.ptx.fma.rn.ftz.f32(lse_value, max_scaled, _f32(_LN2_F32), log_sum)
+                            K.ptx.st.global_.b32(
+                                lse.ptr_to([stat_idx]),
+                                K.if_then_else(sum_positive != _i32(0), lse_value, _f32(_NEG_INF)),
+                            )
+                        with K.If(return_temperature_lse != _i32(0)), K.Then():
+                            log2_tsum = K.local_scalar("float32")
+                            K.ptx.lg2.approx.ftz.f32(log2_tsum, final_temperature_sum)
+                            t_value = K.local_scalar("float32", init=_f32(_NEG_INF))
+                            with K.If(final_temperature_sum > _f32(0.0)), K.Then():
+                                max_scaled_t = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(max_scaled_t, final_max, softmax_scale_log2)
+                                max_ln = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(max_ln, max_scaled_t, _f32(_LN2_F32))
+                                log_tsum = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(log_tsum, log2_tsum, _f32(_LN2_F32))
+                                K.ptx.fma.rn.ftz.f32(
+                                    t_value, lse_temperature_scale, max_ln, log_tsum
+                                )
+                            K.ptx.st.global_.b32(temperature_lse.ptr_to([stat_idx]), t_value)
+            K.ptx.tcgen05.wait__ld.sync.aligned()
+            K.ptx["tcgen05.fence::before_thread_sync"]()
+            _mbar_arrive(bar(_MBAR_TMEM_DEALLOC))
+
+        # ---- Role: MMA issuer (warp 12) ----
+        with r_mma:
+            union_ready_phase_m = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_m)
+            _flip(union_ready_phase_m)
+            count0_m, count1_m = _ld_shared_counts(bar(_SMEM_UNION_COUNT))
+            max_union_count_m = K.local_scalar("int32", init=count0_m)
+            with K.If(max_union_count_m < count1_m), K.Then():
+                K.assign(max_union_count_m, count1_m)
+            kv_stage = K.local_scalar("uint32", init=_u32(0))
+            kv_phase = K.local_scalar("int32", init=_i32(0))
+            q_full_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_Q_FULL), q_full_phase)
+            _flip(q_full_phase)
+            first_pv = [K.local_scalar("int32", init=_i32(1)) for _ in range(2)]
+            phase_p_full = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            q_addr = (bar(_SMEM_Q0), bar(_SMEM_Q1))
+            desc_hi = _u32(_DESC_HI)
+
+            def qk_chain(instance, k_stage):
+                a_lo = K.local_scalar(
+                    "uint32", init=K.uniform((q_addr[instance] >> 4) & _u32(0x3FFF))
+                )
+                b_lo = K.local_scalar(
+                    "uint32",
+                    init=K.uniform(((bar(_SMEM_KV) >> 4) & _u32(0x3FFF)) + k_stage * _u32(2048)),
+                )
+                leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                d_tmem = taddr + _u32(_TMEM_SCORES[instance])
+                for k16 in range(8):
+                    K.ptx[_MMA_F16](
+                        d_tmem,
+                        _pack2(a_lo, desc_hi),
+                        _pack2(b_lo, desc_hi),
+                        _u32(_QK_IDESC),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        K.ptx.pred(_u32(0 if k16 == 0 else 1)),
+                        pred=leader,
+                    )
+                    if k16 < 7:
+                        K.assign(a_lo, a_lo + _u32(_QK_A_STEPS[k16]))
+                        K.assign(b_lo, b_lo + _u32(_QK_B_STEPS[k16]))
+                K.ptx[_TCGEN05_COMMIT](bar(_MBAR_S_FULL + 8 * instance), pred=leader)
+                K.ptx[_TCGEN05_COMMIT](bar(_MBAR_KV_EMPTY) + k_stage * _u32(8), pred=leader)
+
+            def pv_chain(instance, v_stage):
+                b_lo = K.local_scalar(
+                    "uint32",
+                    init=K.uniform(
+                        (((bar(_SMEM_KV) >> 4) & _u32(0x3FFF)) | _u32(_V_LBO_BIT))
+                        + v_stage * _u32(2048)
+                    ),
+                )
+                leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                d_tmem = taddr + _u32(_TMEM_OUTPUT[instance])
+                a_tmem = K.local_scalar(
+                    "uint32", init=taddr + _u32(_TMEM_SCORES[instance] + _TMEM_P_OFFSET)
+                )
+                enable_first = K.local_scalar(
+                    "uint32", init=K.if_then_else(first_pv[instance] != _i32(0), _u32(0), _u32(1))
+                )
+                for k16 in range(8):
+                    K.ptx[_MMA_F16](
+                        d_tmem,
+                        a_tmem,
+                        _pack2(b_lo, desc_hi),
+                        _u32(_PV_IDESC),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        K.ptx.pred(enable_first if k16 == 0 else _u32(1)),
+                        pred=leader,
+                    )
+                    if k16 < 7:
+                        K.assign(a_tmem, a_tmem + _u32(_PV_A_STEP))
+                        K.assign(b_lo, b_lo + _u32(_PV_B_STEP))
+                K.assign(first_pv[instance], _i32(0))
+                return leader
+
+            union_index_2 = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_2 < max_union_count_m):
+                counts = []
+                for instance in range(2):
+                    count = _ld_shared_i32(bar(_SMEM_UNION_COUNT + 4 * instance))
+                    counts.append(count)
+                    with K.If(count > union_index_2), K.Then():
+                        k_stage = K.local_scalar("uint32", init=kv_stage)
+                        k_phase = K.local_scalar("int32", init=kv_phase)
+                        _advance_ring(kv_stage, kv_phase)
+                        _mbar_wait(bar(_MBAR_KV_FULL) + k_stage * _u32(8), k_phase)
+                        qk_chain(instance, k_stage)
+                for instance in range(2):
+                    with K.If(counts[instance] > union_index_2), K.Then():
+                        v_stage = K.local_scalar("uint32", init=kv_stage)
+                        v_phase = K.local_scalar("int32", init=kv_phase)
+                        _advance_ring(kv_stage, kv_phase)
+                        _mbar_wait(bar(_MBAR_KV_FULL) + v_stage * _u32(8), v_phase)
+                        _mbar_wait(bar(_MBAR_P_FULL + 8 * instance), phase_p_full[instance])
+                        _flip(phase_p_full[instance])
+                        leader = pv_chain(instance, v_stage)
+                        with K.If(union_index_2 + _i32(1) == counts[instance]), K.Then():
+                            K.ptx[_TCGEN05_COMMIT](bar(_MBAR_O_FULL + 8 * instance), pred=leader)
+                        K.ptx[_TCGEN05_COMMIT](bar(_MBAR_KV_EMPTY) + v_stage * _u32(8), pred=leader)
+                K.assign(union_index_2, union_index_2 + _i32(1))
+            dealloc_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_TMEM_DEALLOC), dealloc_phase)
+            _flip(dealloc_phase)
+            taddr_dealloc = K.local_scalar("uint32")
+            K.ptx.ld.volatile.shared.b32(taddr_dealloc, bar(_SMEM_TMEM_MAILBOX))
+            K.ptx[_TMEM_DEALLOC](taddr_dealloc, _u32(TMEM_COLS))
+
+        # ---- Role: idle (warps 13, 14) ----
+        with r_idle:
+            pass
+
+        # ---- Role: load warp (warp 15) ----
+        with r_load:
+            kv_head = q_head
+            query_base = q_local_base
+            load_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            with K.If(load_leader != _u32(0)), K.Then():
+                _mbar_expect_tx(bar(_MBAR_Q_FULL), 32768)
+                K.ptx[_TMA_G2S_4D](
+                    bar(_SMEM_Q0),
+                    K.address_of(q_map),
+                    _i32(0),
+                    query_base,
+                    q_head,
+                    _i32(0),
+                    bar(_MBAR_Q_FULL),
+                )
+                K.ptx[_TMA_G2S_4D](
+                    bar(_SMEM_Q1),
+                    K.address_of(q_map),
+                    _i32(0),
+                    query_base + _i32(64),
+                    q_head,
+                    _i32(0),
+                    bar(_MBAR_Q_FULL),
+                )
+            q_block = query_base // 128
+            mask_base = (q_head * mb + q_block) * nb
+            selected_count = K.local_scalar("int32", init=_i32(0))
+            block_base = K.local_scalar("int32", init=_i32(0))
+            with K.While(block_base < nb):
+                n_block_1 = block_base + lane
+                selected_1 = K.local_scalar("int32", init=_i32(0))
+                with K.If(n_block_1 < nb), K.Then():
+                    mask_byte = K.local_scalar("uint16")
+                    K.ptx.ld.global_.nc.b8(mask_byte, block_mask.ptr_to([mask_base + n_block_1]))
+                    K.assign(selected_1, K.cast(mask_byte != K.uint16(0), "int32"))
+                vote = K.local_scalar("uint32")
+                K.ptx.vote_sync.ballot.b32(
+                    vote, K.ptx.pred(K.cast(selected_1 != _i32(0), "bool")), _u32(_FULL_MASK)
+                )
+                ballot_count = K.local_scalar("uint32")
+                K.ptx.popc.b32(ballot_count, vote)
+                lower_lanes = K.shift_left(_u32(1), K.cast(lane, "uint32")) - _u32(1)
+                lower_count = K.local_scalar("uint32")
+                K.ptx.popc.b32(lower_count, vote & lower_lanes)
+                selected_slot = selected_count + K.cast(lower_count, "int32")
+                with K.If(selected_1 != _i32(0)), K.Then():
+                    slot_addr = bar(_SMEM_UNION_BLOCKS) + K.cast(selected_slot, "uint32") * _u32(4)
+                    K.ptx.st.shared.b32(slot_addr, n_block_1)
+                    K.ptx.st.shared.b32(slot_addr + _u32(64 * 4), n_block_1)
+                K.assign(selected_count, selected_count + K.cast(ballot_count, "int32"))
+                K.assign(block_base, block_base + _i32(32))
+            with K.If(selected_count == _i32(0)), K.Then():
+                with K.If(lane == 0), K.Then():
+                    K.ptx.st.shared.b32(bar(_SMEM_UNION_BLOCKS), _i32(0))
+                    K.ptx.st.shared.b32(bar(_SMEM_UNION_BLOCKS + 64 * 4), _i32(0))
+                K.assign(selected_count, _i32(1))
+            with K.If(lane < 2), K.Then():
+                K.ptx.st.shared.b32(
+                    bar(_SMEM_UNION_COUNT) + K.cast(lane, "uint32") * _u32(4), selected_count
+                )
+            K.ptx.barrier.sync(_u32(8), _u32(32))
+            K.ptx.fence.proxy.async_.shared__cta()
+            _mbar_arrive(bar(_MBAR_UNION_READY))
+            load_stage = K.local_scalar("uint32", init=_u32(0))
+            count0_l, count1_l = _ld_shared_counts(bar(_SMEM_UNION_COUNT))
+            max_union_count_l = K.local_scalar("int32", init=count0_l)
+            with K.If(max_union_count_l < count1_l), K.Then():
+                K.assign(max_union_count_l, count1_l)
+            phase_kv_empty = K.local_scalar("int32", init=_i32(1))
+
+            def push_tile(tensor_map, instance, union_index_3):
+                count = _ld_shared_i32(bar(_SMEM_UNION_COUNT + 4 * instance))
+                with K.If(count > union_index_3), K.Then():
+                    n_block = _ld_shared_i32(
+                        bar(_SMEM_UNION_BLOCKS + 64 * 4 * instance)
+                        + K.cast(union_index_3, "uint32") * _u32(4)
+                    )
+                    token_base = n_block * 128
+                    _mbar_wait(bar(_MBAR_KV_EMPTY) + load_stage * _u32(8), phase_kv_empty)
+                    push_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    with K.If(push_leader != _u32(0)), K.Then():
+                        full_bar = bar(_MBAR_KV_FULL) + load_stage * _u32(8)
+                        _mbar_expect_tx(full_bar, 32768)
+                        stage_addr = bar(_SMEM_KV) + load_stage * _u32(_SMEM_KV_STAGE_BYTES)
+                        token1 = token_base + _i32(64)
+                        for dim_half in range(2):
+                            for token_half, token in ((0, token_base), (1, token1)):
+                                K.ptx[_TMA_G2S_4D](
+                                    stage_addr + _u32(8192 * token_half + 16384 * dim_half),
+                                    K.address_of(tensor_map),
+                                    _i32(0),
+                                    token,
+                                    _i32(dim_half),
+                                    kv_head,
+                                    full_bar,
+                                )
+                    _advance_ring(load_stage, phase_kv_empty)
+
+            union_index_3 = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_3 < max_union_count_l):
+                for instance in range(2):
+                    push_tile(k_map, instance, union_index_3)
+                for instance in range(2):
+                    push_tile(v_map, instance, union_index_3)
+                K.assign(union_index_3, union_index_3 + _i32(1))
+
+    return cake_vsa_blk128_compact_sm100
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return _build_kernel()
+
+
+def get_kernel(**config: Any):
+    """Return the TIRx PrimFunc; the kernel is shape-generic at runtime."""
+    if config:
+        cfg = _without_label(config)
+        _validate_shape(cfg["M"], cfg["N"], cfg["num_heads"])
+    return _kernel().func
+
+
+@lru_cache(maxsize=1)
+def _compiled_kernel():
+    from tirx_kernels.runner import compile_kernel
+
+    # nvcc mode keeps the TIRx build on the CUDA toolkit on PATH (13.2, PTX ISA
+    # 9.2) -- the same toolchain the upstream ``nvcc -cubin`` build uses -- so
+    # both binaries share one PTX ISA for SASS and profiler comparisons.
+    return compile_kernel(get_kernel(), cuda_compile_mode="nvcc")
+
+
+def _tirx_args(data: dict[str, Any], slot: str = "tirx") -> tuple[Any, ...]:
+    buffers = data[slot]
+    return (
+        data["q"].view(-1),
+        data["k"].view(-1),
+        data["v"].view(-1),
+        buffers["out"].view(-1),
+        buffers["lse"].view(-1),
+        buffers["tlse"].view(-1),
+        data["block_mask_u8"].view(-1),
+        data["mb"],
+        data["nb"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+    )
+
+
+def _tirx_launch(executable, data: dict[str, Any]):
+    arguments = _tirx_args(data)
+
+    def launch():
+        executable(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Upstream source kernel (the reference for correctness and benchmarks)
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=1)
+def _source_module():
+    """Build the upstream cubin + tvm-ffi launcher exactly as FlashInfer does."""
+    from flashinfer import cake_vsa
+
+    return cake_vsa._load_module(PROFILE, CUDA_ARCH)
+
+
+def _source_launch(data: dict[str, Any]):
+    """Replicate ``flashinfer.cake_vsa._run_standard`` for ``blk128_compact``."""
+    import tvm_ffi
+
+    module = _source_module()
+    buffers = data["source"]
+    arguments = (
+        data["q"],
+        data["k"],
+        data["v"],
+        buffers["out"],
+        buffers["lse"],
+        buffers["tlse"],
+        data["block_mask_u8"],
+        data["mb"],
+        data["nb"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+        data["mb"],
+        data["num_heads"],
+        1,
+    )
+
+    def launch():
+        with tvm_ffi.use_torch_stream():
+            module.run(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+def _run_public_api(data: dict[str, Any]):
+    """Run the upstream public API (``plan_cake_vsa`` + ``run_cake_vsa``)."""
+    import torch
+    from flashinfer import cake_vsa
+
+    plan = cake_vsa.plan_cake_vsa(
+        None,
+        None,
+        data["block_mask"],
+        None,
+        None,
+        None,
+        M=data["M"],
+        N=data["N"],
+        R=BLOCK,
+        C=BLOCK,
+        num_qo_heads=data["num_heads"],
+        num_kv_heads=data["num_heads"],
+        head_dim=HEAD_DIM,
+        q_data_type=torch.bfloat16,
+        sm_scale=data["sm_scale"],
+        device=data["q"].device,
+    )
+    return cake_vsa.run_cake_vsa(
+        plan,
+        data["q"],
+        data["k"],
+        data["v"],
+        out=None,
+        lse=None,
+        return_lse=bool(data["return_lse"]),
+        backend="cake",
+    )
+
+
+# ---------------------------------------------------------------------------
+# fp32 oracle and validation
+# ---------------------------------------------------------------------------
+def _oracle(data: dict[str, Any]):
+    """Dense fp32 reference: masked softmax attention, one head at a time."""
+    import torch
+
+    q = data["q"].float()
+    k = data["k"].float()
+    v = data["v"].float()
+    mask = data["block_mask"]
+    M, num_heads = data["M"], data["num_heads"]
+    scale = data["sm_scale"]
+    tau = data["lse_temperature_scale"]
+    out = torch.empty((M, num_heads, HEAD_DIM), dtype=torch.float32, device=q.device)
+    lse = torch.empty((M, num_heads), dtype=torch.float32, device=q.device)
+    tlse = torch.empty((M, num_heads), dtype=torch.float32, device=q.device)
+    for head in range(num_heads):
+        scores = torch.matmul(q[:, head], k[:, head].transpose(0, 1)) * scale
+        token_mask = mask[head].repeat_interleave(BLOCK, 0).repeat_interleave(BLOCK, 1)
+        scores.masked_fill_(~token_mask, float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        out[:, head] = torch.matmul(probs, v[:, head])
+        lse[:, head] = torch.logsumexp(scores, dim=-1)
+        tlse[:, head] = torch.logsumexp(scores * tau, dim=-1)
+    return out, lse, tlse
+
+
+def _empty_rows(data: dict[str, Any]):
+    """Boolean ``(M, num_heads)`` map of query rows whose block row selects nothing."""
+    mask = data["block_mask"]
+    empty = ~mask.any(dim=-1)  # (num_heads, mb)
+    return empty.repeat_interleave(BLOCK, 1).transpose(0, 1)  # (M, num_heads)
+
+
+def _bf16_order_key(values):
+    """Map bf16 bit patterns to integers ordered like the reals (for ULP distances)."""
+    import torch
+
+    bits = values.contiguous().view(torch.int16).to(torch.int32) & 0xFFFF
+    return torch.where(bits < 0x8000, bits + 0x8000, 0x8000 - (bits & 0x7FFF))
+
+
+def _assert_bitwise(name: str, ours, theirs) -> None:
+    import torch
+
+    if ours.dtype == torch.bfloat16:
+        ours_bits, theirs_bits = ours.view(torch.int16), theirs.view(torch.int16)
+    else:
+        ours_bits, theirs_bits = ours.view(torch.int32), theirs.view(torch.int32)
+    mismatch = ours_bits != theirs_bits
+    count = int(mismatch.sum())
+    if count:
+        index = mismatch.reshape(-1).nonzero()[0].item()
+        raise AssertionError(
+            f"{name}: {count} of {mismatch.numel()} elements differ bitwise from the source "
+            f"kernel (first at flat index {index}: tirx={ours.reshape(-1)[index].item()!r} "
+            f"source={theirs.reshape(-1)[index].item()!r})"
+        )
+
+
+def _validate_outputs(data: dict[str, Any], *, with_oracle: bool) -> dict[str, float]:
+    import torch
+
+    tirx, source = data["tirx"], data["source"]
+    return_lse, return_tlse = data["return_lse"], data["return_temperature_lse"]
+
+    for name, buffers in (("tirx", tirx), ("source", source)):
+        if not torch.isfinite(buffers["out"].float()).all():
+            raise AssertionError(f"{name}: non-finite values in out")
+        if return_lse and not torch.isfinite(buffers["lse"]).all():
+            raise AssertionError(f"{name}: non-finite values in lse")
+        if return_tlse and not torch.isfinite(buffers["tlse"]).all():
+            raise AssertionError(f"{name}: non-finite values in temperature lse")
+        if not return_lse and not bool((buffers["lse"] == _LSE_SENTINEL).all()):
+            raise AssertionError(f"{name}: lse sentinel was overwritten with return_lse=0")
+
+    _assert_bitwise("out", tirx["out"], source["out"])
+    _assert_bitwise("lse", tirx["lse"], source["lse"])
+    if return_tlse:
+        _assert_bitwise("temperature_lse", tirx["tlse"], source["tlse"])
+
+    stats: dict[str, float] = {}
+    if not with_oracle:
+        return stats
+    ref_out, ref_lse, ref_tlse = _oracle(data)
+    valid = ~_empty_rows(data)  # rows with an undefined dense reference are skipped
+    cfg = data["config"]
+    for name, buffers in (("tirx", tirx), ("source", source)):
+        out = buffers["out"].float()[valid]
+        expected = ref_out[valid]
+        err = (out - expected).abs()
+        bound = cfg["oracle_atol"] + cfg["oracle_rtol"] * expected.abs()
+        stats[f"{name}_out_max_abs_err"] = float(err.max())
+        stats[f"{name}_out_max_rel_excess"] = float((err / bound).max())
+        if bool((err > bound).any()):
+            raise AssertionError(
+                f"{name}: out mismatch vs fp32 oracle (max abs err {float(err.max()):.3e}, "
+                f"max err/bound {float((err / bound).max()):.3f})"
+            )
+        # bf16 ULP accounting against the oracle rounded to bf16 (sign-magnitude
+        # bit patterns are mapped to a monotonic integer key first), on the
+        # elements large enough for a ULP to be meaningful.
+        sizeable = expected.abs() >= _ORACLE_ULP_MIN_REF
+        if bool(sizeable.any()):
+            ulps = (
+                _bf16_order_key(expected.to(torch.bfloat16))
+                - _bf16_order_key(buffers["out"][valid])
+            ).abs()[sizeable]
+            ulp_max = float(ulps.max())
+            total = ulps.numel()
+            le1 = int((ulps <= 1).sum()) / total
+            le2 = int((ulps <= 2).sum()) / total
+            stats[f"{name}_out_ulp_max"] = ulp_max
+            stats[f"{name}_out_ulp_le1_frac"] = le1
+            stats[f"{name}_out_ulp_le2_frac"] = le2
+            if ulp_max > cfg["ulp_max"] or le1 < cfg["ulp_le1_frac"] or le2 < cfg["ulp_le2_frac"]:
+                raise AssertionError(
+                    f"{name}: bf16 ULP distribution vs oracle too wide (max {ulp_max:.0f}, "
+                    f"<=1 ULP {le1:.5f}, <=2 ULP {le2:.5f})"
+                )
+        small = expected.abs() < 0.125
+        large = expected.abs() >= 0.5
+        stats[f"{name}_out_max_err_small_ref"] = (
+            float(err[small].max()) if bool(small.any()) else 0.0
+        )
+        stats[f"{name}_out_max_rel_err_large_ref"] = (
+            float((err[large] / expected[large].abs()).max()) if bool(large.any()) else 0.0
+        )
+        if return_lse:
+            lse = buffers["lse"][valid]
+            expected_lse = ref_lse[valid]
+            err = (lse - expected_lse).abs()
+            bound = _ORACLE_LSE_ATOL + _ORACLE_LSE_RTOL * expected_lse.abs()
+            stats[f"{name}_lse_max_abs_err"] = float(err.max())
+            if bool((err > bound).any()):
+                raise AssertionError(
+                    f"{name}: lse mismatch vs oracle (max abs err {float(err.max()):.3e})"
+                )
+        if return_tlse:
+            tlse = buffers["tlse"][valid]
+            expected_tlse = ref_tlse[valid]
+            err = (tlse - expected_tlse).abs()
+            bound = _ORACLE_LSE_ATOL + _ORACLE_LSE_RTOL * expected_tlse.abs()
+            stats[f"{name}_tlse_max_abs_err"] = float(err.max())
+            if bool((err > bound).any()):
+                raise AssertionError(
+                    f"{name}: temperature lse mismatch vs oracle (max abs err {float(err.max()):.3e})"
+                )
+    return stats
+
+
+def _skip_unless_supported() -> None:
+    from unittest import SkipTest
+
+    import torch
+
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA device required")
+    if torch.cuda.get_device_capability() != (10, 0):
+        raise SkipTest("cake_vsa blk128_compact sm_100a requires compute capability 10.0")
+
+
+def run_test(**config: Any) -> dict[str, float]:
+    """Compile, launch TIRx and the upstream kernel, and validate one config."""
+    import torch
+
+    _skip_unless_supported()
+    data = prepare_data(**config)
+    executable = _compiled_kernel()
+    tirx_launch = _tirx_launch(executable, data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    first_out = data["tirx"]["out"].clone()
+    first_lse = data["tirx"]["lse"].clone()
+
+    source_launch = _source_launch(data)
+    source_launch()
+    torch.cuda.synchronize()
+    stats = _validate_outputs(data, with_oracle=True)
+
+    # A second TIRx launch into the same buffers must reproduce the first bit for bit.
+    tirx_launch()
+    torch.cuda.synchronize()
+    _assert_bitwise("out (repeat launch)", data["tirx"]["out"], first_out)
+    _assert_bitwise("lse (repeat launch)", data["tirx"]["lse"], first_lse)
+
+    if data["config"]["pattern"] == "upstream":
+        # The public API must dispatch this shape to blk128_compact and agree bitwise.
+        result = _run_public_api(data)
+        api_out, api_lse = result if data["return_lse"] else (result, None)
+        _assert_bitwise("out (public API)", data["tirx"]["out"], api_out)
+        if api_lse is not None:
+            _assert_bitwise("lse (public API)", data["tirx"]["lse"], api_lse)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points
+# ---------------------------------------------------------------------------
+def prepare_bench(**config: Any):
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    _validate_shape(kernel_config["M"], kernel_config["N"], kernel_config["num_heads"])
+    state = {"config": kernel_config, "executable": _compiled_kernel()}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = _without_label({**prepared["config"], **kwargs})
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**config)
+        gpu_state = {
+            "data": data,
+            "tirx_launch": _tirx_launch(prepared["executable"], data),
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    if not gpu_state["validated"]:
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                source_launch = _source_launch(data)
+                gpu_state["source_launch"] = source_launch
+                source_launch()
+                torch.cuda.synchronize()
+            _validate_outputs(data, with_oracle=False)
+        gpu_state["validated"] = True
+
+    source_launch = gpu_state["source_launch"]
+    references = {"flashinfer": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config: Any):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py
+++ b/tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py
@@ -1,0 +1,1775 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ c5365737), Copyright (c) 2026 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Cake VSA ``longseq`` block-sparse attention forward for SM100a.
+
+Upstream sources (FlashInfer @ c5365737570a2a156d7cae0c4070fa3770ecc670):
+
+- ``csrc/cake_vsa/cake_vsa_longseq_sm_100a.cu`` -- the device kernel
+  ``kernel_flashinfer_blackwell_vsa_longseq_warp_specialized_sm100``.
+- ``csrc/cake_vsa/cake_vsa_longseq_host.cpp`` -- the tvm-ffi launcher that
+  encodes three rank-4 SWIZZLE_128B tensor maps and launches grid
+  ``(mb, num_qo_heads, 1)``, 512 threads, and 201344 bytes of dynamic SMEM.
+- ``flashinfer/cake_vsa.py`` -- the planner and public dispatch. This profile
+  covers BF16, D=128, R=C=128, eight-head MHA, ``N >= 16384``, and a uniform
+  selected-block count no larger than 192.
+
+One CTA owns a 128-row query block and one head. Warps 0-7 run two independent
+64-row online-softmax instances, warps 8-11 correct and store their output, warp
+12 issues all QK/PV tensor-core work, warp 13 loads Q/K and compacts the mask,
+warp 14 independently loads V, and warp 15 is idle. K uses a three-stage ring, V
+uses a two-stage ring, and scores/probabilities/output use four TMEM regions.
+Every shared object lives in one rank-one byte arena addressed by explicit scalar
+offsets; no first-class layouts or tile primitives are used.
+"""
+
+import math
+from functools import lru_cache
+from typing import Any
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cake_vsa_longseq_sm100",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "c5365737570a2a156d7cae0c4070fa3770ecc670",
+            },
+            "import": "flashinfer",
+        },
+    ),
+}
+# The upstream kernel is a prebuilt cubin loaded through FlashInfer's own tvm-ffi
+# launcher (``flashinfer.cake_vsa._load_module``); it does not use the CuTe DSL, and
+# tvm-ffi is a dependency of flashinfer-python itself, so only FlashInfer is pinned.
+
+# ---------------------------------------------------------------------------
+# Source contract constants (host.cpp / cake_vsa.py / the device kernel).
+# ---------------------------------------------------------------------------
+HEAD_DIM = 128
+BLOCK = 128  # R == C == 128 query/KV block size of this profile
+MAX_SELECTED_BLOCKS = 192  # ``union_blocks`` capacity per instance
+THREADS = 512
+NUM_WARPS = THREADS // 32
+SMEM_TOTAL = 201344
+TMEM_COLS = 512
+PROFILE = "longseq"
+CUDA_ARCH = "sm_100a"
+_LN2 = math.log(2.0)
+
+# ``lse`` sentinel used when the caller does not request LSE: upstream passes a
+# one-element ``stats`` tensor that the kernel must leave untouched.
+_LSE_SENTINEL = 12345.25
+
+# Oracle tolerances (fp32 torch reference), frozen from the errors measured on
+# GB200 across CONFIGS with a 1.25-1.6x margin (the TIRx-vs-source comparison is
+# bitwise, so both implementations carry the same algorithmic error: bf16 P and
+# output rounding, ``ex2.approx``/``rcp.approx``/``lg2.approx``).  The upstream test
+# uses atol=rtol=1e-2.  ``max_rel_excess`` in the returned stats is the worst
+# error / (atol + rtol*|ref|) ratio.  The bf16 ULP checks apply to |ref| >= 0.125,
+# where one ULP is at least 2^-10.
+_ORACLE_OUT_ATOL = 1.5e-3
+_ORACLE_OUT_RTOL = 6e-3
+_ORACLE_LSE_ATOL = 2e-6
+_ORACLE_LSE_RTOL = 5e-7
+_ORACLE_ULP_MAX = 2
+_ORACLE_ULP_LE1_FRAC = 0.9999
+_ORACLE_ULP_LE2_FRAC = 1.0
+_ORACLE_ULP_MIN_REF = 0.125
+
+
+def _config(
+    label: str,
+    *,
+    M: int,
+    N: int,
+    num_heads: int,
+    pattern: str,
+    selected: int | None = None,
+    sel_lo: int | None = None,
+    sel_hi: int | None = None,
+    return_lse: bool = False,
+    q_amp: float = 1.0,
+    sm_scale: float | None = None,
+    return_temperature_lse: bool = False,
+    lse_temperature_scale: float = 1.0,
+    seed: int = 0,
+    oracle_atol: float = _ORACLE_OUT_ATOL,
+    oracle_rtol: float = _ORACLE_OUT_RTOL,
+    ulp_max: int = _ORACLE_ULP_MAX,
+    ulp_le1_frac: float = _ORACLE_ULP_LE1_FRAC,
+    ulp_le2_frac: float = _ORACLE_ULP_LE2_FRAC,
+) -> dict[str, Any]:
+    return {
+        "label": label,
+        "M": M,
+        "N": N,
+        "num_heads": num_heads,
+        "pattern": pattern,
+        "selected": selected,
+        "sel_lo": sel_lo,
+        "sel_hi": sel_hi,
+        "return_lse": return_lse,
+        "q_amp": q_amp,
+        "sm_scale": sm_scale,
+        "return_temperature_lse": return_temperature_lse,
+        "lse_temperature_scale": lse_temperature_scale,
+        "seed": seed,
+        "oracle_atol": oracle_atol,
+        "oracle_rtol": oracle_rtol,
+        "ulp_max": ulp_max,
+        "ulp_le1_frac": ulp_le1_frac,
+        "ulp_le2_frac": ulp_le2_frac,
+    }
+
+
+# Correctness matrix. Every row is inside the exact longseq dispatch domain.
+CONFIGS = [
+    _config("m128_n16384_h8_sel8", M=128, N=16384, num_heads=8, pattern="upstream", selected=8),
+    _config(
+        "m256_n16512_h8_sel1_tail",
+        M=256,
+        N=16512,
+        num_heads=8,
+        pattern="random",
+        selected=1,
+        seed=1,
+    ),
+    _config(
+        "m512_n16384_h8_sel65", M=512, N=16384, num_heads=8, pattern="random", selected=65, seed=2
+    ),
+    _config(
+        "m512_n16384_h8_sel128", M=512, N=16384, num_heads=8, pattern="random", selected=128, seed=3
+    ),
+    _config(
+        "m512_n24576_h8_sel192_lse",
+        M=512,
+        N=24576,
+        num_heads=8,
+        pattern="random",
+        selected=192,
+        return_lse=True,
+        seed=4,
+    ),
+    _config(
+        "m512_n32768_h8_sel32_tlse",
+        M=512,
+        N=32768,
+        num_heads=8,
+        pattern="random",
+        selected=32,
+        return_temperature_lse=True,
+        lse_temperature_scale=0.7,
+        seed=5,
+    ),
+    _config(
+        "m1024_n32768_h8_sel16_qamp",
+        M=1024,
+        N=32768,
+        num_heads=8,
+        pattern="random",
+        selected=16,
+        q_amp=6.0,
+        sm_scale=0.05,
+        seed=6,
+        oracle_atol=6.5e-3,
+        oracle_rtol=1e-2,
+        ulp_max=8,
+        ulp_le1_frac=0.995,
+        ulp_le2_frac=0.9998,
+    ),
+]
+
+# Benchmark matrix: six long-sequence sparsity and streaming regimes.
+BENCH_CONFIGS = [
+    _config(
+        "m4096_n16384_h8_sel1", M=4096, N=16384, num_heads=8, pattern="random", selected=1, seed=100
+    ),
+    _config(
+        "m4096_n16384_h8_sel8", M=4096, N=16384, num_heads=8, pattern="random", selected=8, seed=101
+    ),
+    _config(
+        "m16384_n32768_h8_sel32",
+        M=16384,
+        N=32768,
+        num_heads=8,
+        pattern="random",
+        selected=32,
+        seed=102,
+    ),
+    _config(
+        "m32768_n65536_h8_sel64",
+        M=32768,
+        N=65536,
+        num_heads=8,
+        pattern="random",
+        selected=64,
+        seed=103,
+    ),
+    _config(
+        "m8192_n24576_h8_sel128",
+        M=8192,
+        N=24576,
+        num_heads=8,
+        pattern="random",
+        selected=128,
+        seed=104,
+    ),
+    _config(
+        "m8192_n32768_h8_sel192",
+        M=8192,
+        N=32768,
+        num_heads=8,
+        pattern="random",
+        selected=192,
+        seed=105,
+    ),
+]
+
+
+def _without_label(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _validate_shape(M: int, N: int, num_heads: int) -> tuple[int, int]:
+    if M <= 0 or M % BLOCK != 0:
+        raise ValueError(f"M={M} must be a positive multiple of {BLOCK}")
+    if N <= 0 or N % BLOCK != 0:
+        raise ValueError(f"N={N} must be a positive multiple of {BLOCK}")
+    if num_heads <= 0:
+        raise ValueError(f"num_heads={num_heads} must be positive")
+    return M // BLOCK, N // BLOCK
+
+
+def _assert_longseq_route(mask, *, N: int, num_heads: int, mb: int) -> int:
+    """Re-evaluate the upstream ``run_cake_vsa`` dispatch chain for this mask.
+
+    BF16, D=128, R=C=128 and MHA are fixed by this module.  Validate the
+    remaining public-dispatch predicates and return its runtime top-k argument.
+    """
+    counts = mask.sum(dim=-1)
+    max_selected = int(counts.max())
+    uniform = bool((counts == counts.flatten()[0]).all())
+    if N < 16384 or num_heads != 8:
+        raise ValueError("longseq requires N >= 16384 and exactly eight heads")
+    if mb >= 625 and max_selected == 6 and uniform:
+        raise ValueError("mask would dispatch to the ultrasparse_bsr profile")
+    if not uniform or not 1 <= max_selected <= MAX_SELECTED_BLOCKS:
+        raise ValueError("longseq requires a fixed selected-block count in [1, 192]")
+    return max_selected
+
+
+def _make_block_mask(
+    *,
+    num_heads: int,
+    mb: int,
+    nb: int,
+    pattern: str,
+    selected: int | None,
+    sel_lo: int | None,
+    sel_hi: int | None,
+    generator,
+):
+    """Build the ``(num_heads, mb, nb)`` boolean block mask for one config."""
+    import torch
+
+    mask = torch.zeros((num_heads, mb, nb), dtype=torch.bool)
+    if pattern == "dense":
+        mask[:] = True
+        return mask
+    if pattern == "upstream":
+        if selected is None:
+            raise ValueError("pattern 'upstream' needs 'selected'")
+        for row in range(mb):
+            columns = (torch.arange(selected) * 7 + row) % nb
+            mask[:, row, columns] = True
+        return mask
+    if pattern in {"random", "emptyrow"}:
+        if selected is None:
+            raise ValueError(f"pattern {pattern!r} needs 'selected'")
+        lo = hi = selected
+    elif pattern == "random_var":
+        if sel_lo is None or sel_hi is None:
+            raise ValueError("pattern 'random_var' needs 'sel_lo' and 'sel_hi'")
+        lo, hi = sel_lo, sel_hi
+    else:
+        raise ValueError(f"unknown mask pattern {pattern!r}")
+    if lo < 1 or hi > min(nb, MAX_SELECTED_BLOCKS) or lo > hi:
+        raise ValueError(f"selected range [{lo}, {hi}] invalid for nb={nb}")
+    for head in range(num_heads):
+        for row in range(mb):
+            count = lo if lo == hi else int(torch.randint(lo, hi + 1, (1,), generator=generator))
+            columns = torch.randperm(nb, generator=generator)[:count]
+            mask[head, row, columns] = True
+    if pattern == "emptyrow":
+        mask[min(1, num_heads - 1), min(2, mb - 1), :] = False
+    return mask
+
+
+def prepare_data(**config: Any) -> dict[str, Any]:
+    """Allocate logical inputs plus independent TIRx and source output buffers."""
+    import torch
+
+    config = _without_label(config)
+    M, N, num_heads = config["M"], config["N"], config["num_heads"]
+    mb, nb = _validate_shape(M, N, num_heads)
+    return_lse = bool(config["return_lse"])
+    return_tlse = bool(config["return_temperature_lse"])
+    sm_scale = config["sm_scale"]
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    generator = torch.Generator().manual_seed(int(config["seed"]))
+    device = torch.device("cuda")
+
+    q = torch.randn((M, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    q = (q * float(config["q_amp"])).to(torch.bfloat16).to(device)
+    k = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    k = k.to(torch.bfloat16).to(device)
+    v = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    v = v.to(torch.bfloat16).to(device)
+    mask = _make_block_mask(
+        num_heads=num_heads,
+        mb=mb,
+        nb=nb,
+        pattern=config["pattern"],
+        selected=config["selected"],
+        sel_lo=config["sel_lo"],
+        sel_hi=config["sel_hi"],
+        generator=generator,
+    )
+    selected_blocks = _assert_longseq_route(mask, N=N, num_heads=num_heads, mb=mb)
+    block_mask = mask.to(device)
+
+    def outputs() -> dict[str, Any]:
+        out = torch.full(
+            (M, num_heads, HEAD_DIM), float("nan"), dtype=torch.bfloat16, device=device
+        )
+        if return_lse:
+            lse = torch.full((M, num_heads), float("nan"), dtype=torch.float32, device=device)
+        else:
+            lse = torch.full((1,), _LSE_SENTINEL, dtype=torch.float32, device=device)
+        if return_tlse:
+            tlse = torch.full((M, num_heads), float("nan"), dtype=torch.float32, device=device)
+        else:
+            tlse = lse  # upstream passes the same ``stats`` tensor for both slots
+        return {"out": out, "lse": lse, "tlse": tlse}
+
+    return {
+        "config": config,
+        "M": M,
+        "N": N,
+        "num_heads": num_heads,
+        "mb": mb,
+        "nb": nb,
+        "selected_blocks": selected_blocks,
+        "q": q,
+        "k": k,
+        "v": v,
+        "block_mask": block_mask,
+        "block_mask_u8": block_mask.view(torch.uint8),
+        "sm_scale": float(sm_scale),
+        "softmax_scale_log2": float(sm_scale) / _LN2,
+        "lse_temperature_scale": float(config["lse_temperature_scale"]),
+        "return_lse": return_lse,
+        "return_temperature_lse": return_tlse,
+        "tirx": outputs(),
+        "source": outputs(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# TIRx kernel
+# ---------------------------------------------------------------------------
+# cuTensorMapEncodeTiled enum values (CUtensorMapInterleave / Swizzle /
+# L2promotion / FloatOOBfill) as used by the upstream host launcher.
+_TMA_INTERLEAVE_NONE = 0
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_PROMOTION_NONE = 0
+_TMA_OOB_FILL_NONE = 0
+
+
+def _host_prelude(params):
+    """Encode the three upstream tensor maps from the runtime shape scalars.
+
+    Mirrors ``EncodeTma_q`` / ``EncodeTma_k`` / ``EncodeTma_v`` in the upstream
+    host launcher: rank-4 bf16 maps, 128-byte swizzle, no L2 promotion, no OOB
+    fill.  Q is ``{64, M, Hq, 2}`` with a ``{64, 64, 1, 2}`` box (one 16 KB
+    transaction covers both head-dim halves of 64 rows); K and V are
+    ``{64, N, 2, Hkv}`` with a ``{64, 64, 1, 1}`` box (8 KB per transaction).
+    """
+    mb = params["mb"]
+    nb = params["nb"]
+    num_q_heads = params["num_q_heads"]
+    num_kv_heads = params["num_kv_heads"]
+    elem_bytes = 2
+
+    def encode(tensor, dims, strides_bytes, box):
+        descriptor = K.stack_alloca("tensormap", 1)
+        K.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            descriptor,
+            "bfloat16",
+            4,
+            tensor.data,
+            *dims,
+            *strides_bytes,
+            *box,
+            1,
+            1,
+            1,
+            1,
+            _TMA_INTERLEAVE_NONE,
+            _TMA_SWIZZLE_128B,
+            _TMA_L2_PROMOTION_NONE,
+            _TMA_OOB_FILL_NONE,
+        )
+        return descriptor
+
+    q_map = encode(
+        params["q"],
+        (64, mb * BLOCK, num_q_heads, HEAD_DIM // 64),
+        (num_q_heads * HEAD_DIM * elem_bytes, HEAD_DIM * elem_bytes, 64 * elem_bytes),
+        (64, 64, 1, HEAD_DIM // 64),
+    )
+    kv_dims = (64, nb * BLOCK, HEAD_DIM // 64, num_kv_heads)
+    kv_strides = (num_kv_heads * HEAD_DIM * elem_bytes, 64 * elem_bytes, HEAD_DIM * elem_bytes)
+    kv_box = (64, 64, 1, 1)
+    k_map = encode(params["k"], kv_dims, kv_strides, kv_box)
+    v_map = encode(params["v"], kv_dims, kv_strides, kv_box)
+    return (q_map, k_map, v_map)
+
+
+# Byte offsets inside the 201344-byte dynamic SMEM arena (source macro table).
+_MBAR_Q_FULL = 0
+_MBAR_UNION_READY = 8
+_MBAR_K_FULL = 16  # 3 stages
+_MBAR_K_EMPTY = 40  # 3 stages
+_MBAR_V_FULL = 64  # 2 stages
+_MBAR_V_EMPTY = 80  # 2 stages
+_MBAR_S_FULL = 96  # 2 instances
+_MBAR_P_FULL = 112  # 2 instances
+_MBAR_CORR_SIG = 128  # 2 instances
+_MBAR_CORR_DONE = 144  # 2 instances
+_MBAR_O_FULL = 160  # 2 instances
+_MBAR_TMEM_DEALLOC = 176
+_SMEM_TMEM_MAILBOX = 184
+_SMEM_Q0 = 1024
+_SMEM_Q1 = 17408
+_SMEM_K = 33792  # 3 x 32768
+_SMEM_V = 132096  # 2 x 32768
+_SMEM_STAGE_BYTES = 32768
+_SMEM_SCALE = 197632  # 512 f32: acc_scale / row_sum / row_max / temperature_sum
+_SMEM_UNION_COUNT = 199680  # 2 i32
+_SMEM_UNION_BLOCKS = 199688  # 2 x 192 i32
+# (offset, arrival count) in source order: q_full, union_ready, k_full x3, k_empty x3,
+# v_full x2, v_empty x2, s_full x2, p_full x2, corr_sig x2, corr_done x2,
+# o_full x2, tmem_dealloc.
+_MBARRIER_INIT = (
+    (_MBAR_Q_FULL, 1),
+    (_MBAR_UNION_READY, 32),
+    (_MBAR_K_FULL, 1),
+    (_MBAR_K_FULL + 8, 1),
+    (_MBAR_K_FULL + 16, 1),
+    (_MBAR_K_EMPTY, 1),
+    (_MBAR_K_EMPTY + 8, 1),
+    (_MBAR_K_EMPTY + 16, 1),
+    (_MBAR_V_FULL, 1),
+    (_MBAR_V_FULL + 8, 1),
+    (_MBAR_V_EMPTY, 1),
+    (_MBAR_V_EMPTY + 8, 1),
+    (_MBAR_S_FULL, 1),
+    (_MBAR_S_FULL + 8, 1),
+    (_MBAR_P_FULL, 256),
+    (_MBAR_P_FULL + 8, 256),
+    (_MBAR_CORR_SIG, 128),
+    (_MBAR_CORR_SIG + 8, 128),
+    (_MBAR_CORR_DONE, 128),
+    (_MBAR_CORR_DONE + 8, 128),
+    (_MBAR_O_FULL, 1),
+    (_MBAR_O_FULL + 8, 1),
+    (_MBAR_TMEM_DEALLOC, 128),
+)
+# TMEM column bases per softmax instance: S (128 columns; P overwrites the upper 64
+# in place) and the O accumulator (128 columns).
+_TMEM_SCORES = (0, 256)
+_TMEM_OUTPUT = (128, 384)
+_TMEM_P_OFFSET = 64
+# UMMA descriptor words and instruction descriptors (source immediates).
+_DESC_HI = 0x40004040  # SBO 1024 B, base-offset bit, 128 B swizzle
+_QK_IDESC = 0x04200490  # bf16 x bf16 -> f32, M=64, N=128, K-major A and B
+_PV_IDESC = 0x04210490  # same with MN-major B (V is token-major)
+_QK_A_STEPS = (2, 2, 2, 506, 2, 2, 2)  # Q low-word walk over K=128 (bytes/16)
+_QK_B_STEPS = (2, 2, 2, 1018, 2, 2, 2)  # K low-word walk (second dim half at +16384 B)
+_V_LBO_BIT = 0x4000000  # LBO = 16384 B: dim-half stride of the V tile
+_PV_B_STEP = 128  # 2048 B = 16 tokens x 128 B per K16 step
+_PV_A_STEP = 8  # 16 bf16 P columns = 8 TMEM 32-bit columns per K16 step
+_REG_SOFTMAX = 192
+_REG_CORRECTION = 80
+_REG_OTHER = 48
+_WAIT_TICKS = 0x989680
+
+_TMA_G2S_4D = "cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+_TCGEN05_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+_TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+_TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+_TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+_TMEM_LD_X32 = "tcgen05.ld.sync.aligned.16x32bx2.x32.b32"
+_TMEM_ST_X16 = "tcgen05.st.sync.aligned.16x32bx2.x16.b32"
+_TMEM_ST_X64 = "tcgen05.st.sync.aligned.16x32bx2.x64.b32"
+_LN2_F32 = 0.6931471805599453
+_NEG_INF = float("-inf")
+_FULL_MASK = 0xFFFFFFFF
+
+
+def _u32(value):
+    return K.uint32(value)
+
+
+def _i32(value):
+    return K.int32(value)
+
+
+def _f32(value):
+    return K.float32(value)
+
+
+def _mbar_wait(addr, phase):
+    """``mbarrier.try_wait.parity.acquire.cta`` retry loop with the source's suspend hint."""
+    K.cuda.mbarrier_wait(addr, phase)
+
+
+def _mbar_arrive(addr):
+    K.ptx.mbarrier.arrive.release.cta.shared__cta.b64(addr)
+
+
+def _mbar_expect_tx(addr, tx_bytes):
+    K.ptx.mbarrier.arrive.expect_tx.release.cta.shared__cta.b64(addr, _u32(tx_bytes))
+
+
+def _ld_shared_i32(addr):
+    value = K.local_scalar("int32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _ld_shared_f32(addr):
+    value = K.local_scalar("float32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _ld_shared_counts(addr):
+    """Both instance counts in one ``ld.shared.v2.b32`` (the source's vectorized pair)."""
+    count0 = K.local_scalar("int32")
+    count1 = K.local_scalar("int32")
+    K.ptx.ld.shared.v2.b32(count0, count1, addr)
+    return count0, count1
+
+
+def _flip(phase):
+    K.assign(phase, phase ^ _i32(1))
+
+
+def _advance_ring(stage, phase):
+    """Three-stage ring cursor: stage += 1, wrap to 0 and flip parity at 3."""
+    K.assign(stage, stage + _u32(1))
+    with K.If(stage == _u32(3)), K.Then():
+        K.assign(stage, _u32(0))
+        _flip(phase)
+
+
+def _advance_v_ring(stage, phase):
+    """Two-stage V ring cursor: stage += 1, wrap to 0 and flip parity at 2."""
+    K.assign(stage, stage + _u32(1))
+    with K.If(stage == _u32(2)), K.Then():
+        K.assign(stage, _u32(0))
+        _flip(phase)
+
+
+def _pack2(lo, hi):
+    packed = K.local_scalar("uint64")
+    K.ptx.mov.b64(packed, lo, hi)
+    return packed
+
+
+def _packed_fma_inplace(values, base, scale_pair, bias_pair):
+    """``fma.rn.ftz.f32x2`` on values[base:base+2] with packed scale and bias."""
+    result = K.local_scalar("uint64")
+    K.ptx.fma.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair, bias_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _packed_mul_inplace(values, base, scale_pair):
+    """``mul.rn.ftz.f32x2`` on values[base:base+2] with a packed scale."""
+    result = K.local_scalar("uint64")
+    K.ptx.mul.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _exp2_inplace(values, index):
+    K.ptx.ex2.approx.ftz.f32(values[index], values[index])
+
+
+def _max_f32(a, b):
+    out = K.local_scalar("float32")
+    K.ptx.max.f32(out, a, b)
+    return out
+
+
+def _shfl_xor_f32(value, lane_xor):
+    out = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret("uint32", value), _u32(lane_xor), _u32(31), _u32(_FULL_MASK)
+    )
+    return K.reinterpret("float32", out)
+
+
+def _tmem_load_x32(dst, base, taddr):
+    K.ptx[_TMEM_LD_X32](*(dst[base + i] for i in range(32)), taddr, 64)
+
+
+def _block_sum(values):
+    """``softmax_block_sum`` over 64 values: 32 packed ``add.f32x2`` into one accumulator."""
+    acc = K.local_scalar("uint64")
+    K.ptx.mov.b64(acc, _f32(0.0), _f32(0.0))
+    for j in range(32):
+        K.ptx.add.f32x2(acc, acc, _pack2(values[2 * j], values[2 * j + 1]))
+    acc_x = K.local_scalar("float32")
+    acc_y = K.local_scalar("float32")
+    K.ptx.mov.b64(acc_x, acc_y, acc)
+    half = K.local_scalar("float32")
+    K.ptx.add.ftz.f32(half, acc_x, acc_y)
+    total = K.local_scalar("float32")
+    K.ptx.add.ftz.f32(total, half, _shfl_xor_f32(half, 16))
+    return total
+
+
+def _row_max(values):
+    """``row_max_x32_accum`` x2 + ``row_max_reduce``: alternating accumulators, 65 ``max.f32``."""
+    acc0 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    acc1 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    for half in range(2):
+        for j in range(16):
+            pair = _max_f32(values[half * 32 + 2 * j], values[half * 32 + 2 * j + 1])
+            if j % 2 == 0:
+                K.assign(acc0, _max_f32(acc0, pair))
+            else:
+                K.assign(acc1, _max_f32(acc1, pair))
+    return _max_f32(acc0, acc1)
+
+
+def _build_kernel():
+    @K.kernel(
+        warps=NUM_WARPS,
+        arch=CUDA_ARCH,
+        min_blocks_per_sm=1,
+        grid=lambda p: [p["mb"], p["num_q_heads"]],
+        host_prelude=_host_prelude,
+    )
+    def cake_vsa_longseq_sm100(
+        q: K.gptr[K.bf16],
+        k: K.gptr[K.bf16],
+        v: K.gptr[K.bf16],
+        out: K.gptr[K.bf16],
+        lse: K.gptr[K.f32],
+        temperature_lse: K.gptr[K.f32],
+        block_mask: K.gptr[K.u8],
+        mb: K.i32,
+        nb: K.i32,
+        selected_blocks: K.i32,
+        num_q_heads: K.i32,
+        num_kv_heads: K.i32,
+        softmax_scale_log2: K.f32,
+        lse_temperature_scale: K.f32,
+        return_softmax_lse: K.i32,
+        return_temperature_lse: K.i32,
+        *,
+        host,
+    ):
+        q_map, k_map, v_map = host
+        del q, k, v, num_kv_heads  # reached only through the tensor maps / host prelude
+        # >>> kernel_flashinfer_blackwell_vsa_longseq_warp_specialized_sm100 body starts here
+        q_tile, q_head = K.cta_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        arena = K.alloc_buffer((SMEM_TOTAL,), K.u8, scope="shared.dyn", align=1024)
+        smem = K.local_scalar("uint32", init=K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
+
+        def bar(offset):
+            return smem + _u32(offset)
+
+        # Mbarrier init (12 groups, 23 barriers) by one elected lane of warp 0.
+        with K.If(warp == 0), K.Then():
+            init_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            with K.If(init_leader != _u32(0)), K.Then():
+                for offset, count in _MBARRIER_INIT:
+                    K.ptx.mbarrier.init.shared__cta.b64(bar(offset), _u32(count))
+                K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.warp.sync(_u32(_FULL_MASK))
+
+        # TMEM alloc (512 columns) by warp 0; the address lands in the shared mailbox.
+        with K.If(warp == 0), K.Then():
+            K.ptx[_TMEM_ALLOC](bar(_SMEM_TMEM_MAILBOX), _u32(TMEM_COLS))
+            K.ptx[_TMEM_RELINQUISH]()
+        K.cuda.cta_sync()
+        K.ptx["tcgen05.fence::after_thread_sync"]()
+        taddr = K.local_scalar("uint32")
+        K.ptx.ld.volatile.shared.b32(taddr, bar(_SMEM_TMEM_MAILBOX))
+
+        q_local_base = q_tile * 128
+        kv_len = nb * 128
+
+        # Sibling role guards, as in the source; folding them into an if/else-if chain
+        # measured 1.2-2.3% slower on the two small shapes with no register pressure to relieve.
+        roles = K.specialize(chain_dispatch=False)
+        other_regs = roles.register_scope("other", warps=range(12, 16), regs=_REG_OTHER)
+        r_softmax = roles.role("softmax", warps=range(0, 8), regs=_REG_SOFTMAX)
+        r_correction = roles.role("correction", warps=range(8, 12), regs=_REG_CORRECTION)
+        r_mma = roles.role("mma", warps=[12], register_scope=other_regs)
+        r_qk_load = roles.role("qk_load", warps=[13], register_scope=other_regs)
+        r_v_load = roles.role("v_load", warps=[14], register_scope=other_regs)
+        r_idle = roles.role("idle", warps=[15], register_scope=other_regs)
+
+        # Register redistribution: warps 12..15 decrease first so the softmax
+        # increase can be granted.
+        with K.If(K.And(warp >= 12, warp <= 15)), K.Then():
+            other_regs.emit()
+
+        # ---- Role: softmax (warps 0..7, two four-warp instances) ----
+        with r_softmax:
+            q_valid = K.local_scalar("int32", init=_i32(128))
+            with K.If(q_tile >= mb), K.Then():
+                K.assign(q_valid, _i32(0))
+            union_ready_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase)
+            _flip(union_ready_phase)
+            instance = K.uniform(warp // 4)
+            instance_row_offset = K.uniform(instance * 64)
+            instance_token_offset = K.uniform(instance * 64)
+            instance_tmem_offset = K.uniform(instance * 256)
+            union_count = selected_blocks
+            warp_in_instance = warp % 4
+            tmem_row_origin = warp_in_instance * 32
+            my_row = warp_in_instance * 16 + lane % 16
+            col_half = lane // 16
+            instance_valid = K.local_scalar("int32", init=q_valid - instance_token_offset)
+            with K.If(instance_valid > _i32(64)), K.Then():
+                K.assign(instance_valid, _i32(64))
+            with K.If(instance_valid < _i32(0)), K.Then():
+                K.assign(instance_valid, _i32(0))
+            row_valid = K.local_scalar("int32", init=K.cast(my_row < instance_valid, "int32"))
+            row_max = K.local_scalar("float32", init=_f32(_NEG_INF))
+            row_sum = K.local_scalar("float32", init=_f32(0.0))
+            temperature_sum = K.local_scalar("float32", init=_f32(0.0))
+            phase_s_full_0 = K.local_scalar("int32", init=_i32(0))
+            phase_s_full_1 = K.local_scalar("int32", init=_i32(0))
+            phase_corr_done_0 = K.local_scalar("int32", init=_i32(0))
+            phase_corr_done_1 = K.local_scalar("int32", init=_i32(0))
+            score_addr = K.local_scalar(
+                "uint32",
+                init=taddr
+                + K.cast(instance_tmem_offset, "uint32")
+                + K.shift_left(K.cast(tmem_row_origin, "uint32"), _u32(16)),
+            )
+            p_addr = K.local_scalar("uint32", init=score_addr + _u32(_TMEM_P_OFFSET))
+            scale_row_addr = bar(_SMEM_SCALE) + K.cast(
+                instance_row_offset + my_row, "uint32"
+            ) * _u32(4)
+            scores = K.alloc_local((64,), "float32")
+            packed_p = K.alloc_local((32,), "uint32")
+            block_sum = K.local_scalar("float32", init=_f32(0.0))
+            block_temperature_sum = K.local_scalar("float32", init=_f32(0.0))
+            acc_scale = K.local_scalar("float32", init=_f32(1.0))
+            temperature_acc_scale = K.local_scalar("float32", init=_f32(1.0))
+            selected_max = K.local_scalar("float32", init=_f32(_NEG_INF))
+            new_max_scaled = K.local_scalar("float32", init=_f32(0.0))
+            safe_max = K.local_scalar("float32", init=_f32(0.0))
+
+            def probabilities_from(frag, bias):
+                """fma, exp2, block sum, bf16 pack and the two P stores of one branch."""
+                scale_pair = _pack2(softmax_scale_log2, softmax_scale_log2)
+                bias_pair = _pack2(bias, bias)
+                for j in range(32):
+                    _packed_fma_inplace(frag, 2 * j, scale_pair, bias_pair)
+                for j in range(64):
+                    _exp2_inplace(frag, j)
+                K.assign(block_sum, _block_sum(frag))
+                for j in range(32):
+                    K.ptx.cvt.rn.bf16x2.f32(packed_p[j], frag[2 * j + 1], frag[2 * j])
+                K.ptx[_TMEM_ST_X16](p_addr, 32, *(packed_p[i] for i in range(16)))
+                K.ptx[_TMEM_ST_X16](p_addr + _u32(16), 32, *(packed_p[16 + i] for i in range(16)))
+
+            union_index = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index < union_count):
+                n_block = _ld_shared_i32(
+                    bar(_SMEM_UNION_BLOCKS)
+                    + K.cast(instance * 192 + union_index, "uint32") * _u32(4)
+                )
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_wait(bar(_MBAR_S_FULL), phase_s_full_0)
+                        _flip(phase_s_full_0)
+                    with K.Else():
+                        _mbar_wait(bar(_MBAR_S_FULL + 8), phase_s_full_1)
+                        _flip(phase_s_full_1)
+                valid_cols = K.local_scalar("int32", init=_i32(0))
+                with K.If(row_valid != _i32(0)), K.Then():
+                    K.assign(valid_cols, kv_len - n_block * 128)
+                    with K.If(valid_cols > _i32(128)), K.Then():
+                        K.assign(valid_cols, _i32(128))
+                    with K.If(valid_cols < _i32(0)), K.Then():
+                        K.assign(valid_cols, _i32(0))
+                _tmem_load_x32(scores, 0, score_addr)
+                _tmem_load_x32(scores, 32, score_addr + _u32(32))
+                half_valid = K.local_scalar("int32", init=valid_cols - col_half * 64)
+                with K.If(half_valid < _i32(0)), K.Then():
+                    K.assign(half_valid, _i32(0))
+                with K.If(half_valid > _i32(64)), K.Then():
+                    K.assign(half_valid, _i32(64))
+                # The source's per-column -inf fill for 0 < half_valid < 64 is unreachable
+                # (valid_cols is a multiple of 128) and nvcc emits no code for it.
+                tile_max = K.local_scalar("float32", init=_row_max(scores))
+                with K.If(half_valid <= _i32(0)), K.Then():
+                    K.assign(tile_max, _f32(_NEG_INF))
+                K.assign(tile_max, _max_f32(tile_max, _shfl_xor_f32(tile_max, 16)))
+                new_max = _max_f32(tile_max, row_max)
+                K.assign(safe_max, K.if_then_else(new_max == _f32(_NEG_INF), _f32(0.0), new_max))
+                K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                neg_new_max_scaled = K.local_scalar("float32")
+                K.ptx.neg.ftz.f32(neg_new_max_scaled, new_max_scaled)
+                acc_scale_log2 = K.local_scalar("float32")
+                K.ptx.fma.rn.ftz.f32(
+                    acc_scale_log2, row_max, softmax_scale_log2, neg_new_max_scaled
+                )
+                with K.If(acc_scale_log2 >= _f32(-8.0)):
+                    with K.Then():
+                        # The running max moves by less than 2^8: keep the old max, skip the rescale.
+                        K.assign(selected_max, row_max)
+                        K.assign(
+                            safe_max, K.if_then_else(row_max == _f32(_NEG_INF), _f32(0.0), row_max)
+                        )
+                        K.assign(acc_scale, _f32(1.0))
+                        K.assign(temperature_acc_scale, _f32(1.0))
+                        K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                    with K.Else():
+                        K.assign(selected_max, new_max)
+                        exp_scale = K.local_scalar("float32")
+                        K.ptx.ex2.approx.ftz.f32(exp_scale, acc_scale_log2)
+                        K.assign(
+                            acc_scale,
+                            K.if_then_else(row_max > _f32(_NEG_INF), exp_scale, _f32(1.0)),
+                        )
+                        tau_log2 = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_log2, acc_scale_log2, lse_temperature_scale)
+                        exp_tau = K.local_scalar("float32")
+                        K.ptx.ex2.approx.ftz.f32(exp_tau, tau_log2)
+                        K.assign(
+                            temperature_acc_scale,
+                            K.if_then_else(row_max > _f32(_NEG_INF), exp_tau, _f32(1.0)),
+                        )
+                K.assign(row_max, selected_max)
+                with K.If(col_half == 0), K.Then():
+                    K.ptx.st.shared.b32(scale_row_addr, acc_scale)
+                K.ptx.fence.proxy.async_.shared__cta()
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG))
+                    with K.Else():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+                # The bias negates the (possibly re-selected) new_max_scaled after the branch.
+                neg_bias = K.local_scalar("float32")
+                K.ptx.neg.ftz.f32(neg_bias, new_max_scaled)
+                score_bias = K.local_scalar("float32")
+                K.assign(score_bias, K.if_then_else(valid_cols > _i32(0), neg_bias, _f32(_NEG_INF)))
+                K.assign(block_temperature_sum, _f32(0.0))
+                K.assign(block_sum, _f32(0.0))
+                with K.If(return_temperature_lse != _i32(0)):
+                    with K.Then():
+                        tau_scale = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_scale, softmax_scale_log2, lse_temperature_scale)
+                        tau_bias = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_bias, score_bias, lse_temperature_scale)
+                        tau_scale_pair = _pack2(tau_scale, tau_scale)
+                        tau_bias_pair = _pack2(tau_bias, tau_bias)
+                        for j in range(32):
+                            _packed_fma_inplace(scores, 2 * j, tau_scale_pair, tau_bias_pair)
+                        for j in range(64):
+                            _exp2_inplace(scores, j)
+                        K.assign(block_temperature_sum, _block_sum(scores))
+                        # S is re-read because the temperature sum consumed the first copy.
+                        _tmem_load_x32(scores, 0, score_addr)
+                        _tmem_load_x32(scores, 32, score_addr + _u32(32))
+                        probabilities_from(scores, score_bias)
+                    with K.Else():
+                        probabilities_from(scores, score_bias)
+                K.ptx.tcgen05.wait__st.sync.aligned()
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_arrive(bar(_MBAR_P_FULL))
+                        _mbar_wait(bar(_MBAR_CORR_DONE), phase_corr_done_0)
+                        _flip(phase_corr_done_0)
+                    with K.Else():
+                        _mbar_arrive(bar(_MBAR_P_FULL + 8))
+                        _mbar_wait(bar(_MBAR_CORR_DONE + 8), phase_corr_done_1)
+                        _flip(phase_corr_done_1)
+                K.ptx.fma.rn.ftz.f32(row_sum, row_sum, acc_scale, block_sum)
+                with K.If(return_temperature_lse != _i32(0)), K.Then():
+                    K.ptx.fma.rn.ftz.f32(
+                        temperature_sum,
+                        temperature_sum,
+                        temperature_acc_scale,
+                        block_temperature_sum,
+                    )
+                K.assign(union_index, union_index + _i32(1))
+            with K.If(col_half == 0), K.Then():
+                K.ptx.st.shared.b32(scale_row_addr + _u32(128 * 4), row_sum)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(256 * 4), row_max)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(384 * 4), temperature_sum)
+            K.ptx.fence.proxy.async_.shared__cta()
+            with K.If(instance == 0):
+                with K.Then():
+                    _mbar_arrive(bar(_MBAR_CORR_SIG))
+                with K.Else():
+                    _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+
+        # ---- Role: correction and epilogue (warps 8..11) ----
+        with r_correction:
+            q_valid_c = K.local_scalar("int32", init=_i32(128))
+            with K.If(q_tile >= mb), K.Then():
+                K.assign(q_valid_c, _i32(0))
+            union_ready_phase_c = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_c)
+            _flip(union_ready_phase_c)
+            max_union_count_c = selected_blocks
+            warp_in_role = warp - 8
+            tmem_row_origin_c = warp_in_role * 32
+            my_row_c = warp_in_role * 16 + lane % 16
+            col_half_c = lane // 16
+            row_addr = K.local_scalar(
+                "uint32", init=K.shift_left(K.cast(tmem_row_origin_c, "uint32"), _u32(16))
+            )
+            scale_base_c = bar(_SMEM_SCALE) + K.cast(my_row_c, "uint32") * _u32(4)
+            _mbar_arrive(bar(_MBAR_P_FULL))
+            _mbar_arrive(bar(_MBAR_P_FULL + 8))
+            phase_corr_sig_0 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_CORR_SIG), phase_corr_sig_0)
+            _flip(phase_corr_sig_0)
+            _mbar_arrive(bar(_MBAR_CORR_DONE))
+            phase_corr_sig_1 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_CORR_SIG + 8), phase_corr_sig_1)
+            _flip(phase_corr_sig_1)
+            _mbar_arrive(bar(_MBAR_CORR_DONE + 8))
+            o_frag = K.alloc_local((64,), "float32")
+
+            def rescale_instance(instance, phase_corr_sig, union_index_1):
+                count = selected_blocks
+                with K.If(count > union_index_1), K.Then():
+                    _mbar_wait(bar(_MBAR_CORR_SIG + 8 * instance), phase_corr_sig)
+                    _flip(phase_corr_sig)
+                    acc_scale_c = _ld_shared_f32(scale_base_c + _u32(64 * 4 * instance))
+                    any_rescale = K.local_scalar("uint32")
+                    K.ptx.vote_sync.any.pred(
+                        any_rescale,
+                        K.ptx.pred(K.cast(acc_scale_c < _f32(1.0), "bool")),
+                        _u32(_FULL_MASK),
+                    )
+                    with K.If(any_rescale != _u32(0)), K.Then():
+                        o_addr = taddr + _u32(_TMEM_OUTPUT[instance]) + row_addr
+                        _tmem_load_x32(o_frag, 0, o_addr)
+                        _tmem_load_x32(o_frag, 32, o_addr + _u32(32))
+                        scale_pair = _pack2(acc_scale_c, acc_scale_c)
+                        for j in range(32):
+                            _packed_mul_inplace(o_frag, 2 * j, scale_pair)
+                        K.ptx[_TMEM_ST_X64](o_addr, 64, *(o_frag[i] for i in range(64)))
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                    _mbar_arrive(bar(_MBAR_P_FULL + 8 * instance))
+                    _mbar_arrive(bar(_MBAR_CORR_DONE + 8 * instance))
+
+            union_index_1 = K.local_scalar("int32", init=_i32(1))
+            with K.While(union_index_1 < max_union_count_c):
+                rescale_instance(0, phase_corr_sig_0, union_index_1)
+                rescale_instance(1, phase_corr_sig_1, union_index_1)
+                K.assign(union_index_1, union_index_1 + _i32(1))
+            phase_o_full_0 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_O_FULL), phase_o_full_0)
+            _flip(phase_o_full_0)
+            phase_o_full_1 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_O_FULL + 8), phase_o_full_1)
+            _flip(phase_o_full_1)
+            _mbar_wait(bar(_MBAR_CORR_SIG), phase_corr_sig_0)
+            _flip(phase_corr_sig_0)
+            _mbar_wait(bar(_MBAR_CORR_SIG + 8), phase_corr_sig_1)
+            _flip(phase_corr_sig_1)
+            K.ptx["tcgen05.fence::after_thread_sync"]()
+            for instance in range(2):
+                stats_addr = scale_base_c + _u32(64 * 4 * instance)
+                final_sum = _ld_shared_f32(stats_addr + _u32(128 * 4))
+                final_max = _ld_shared_f32(stats_addr + _u32(256 * 4))
+                final_temperature_sum = _ld_shared_f32(stats_addr + _u32(384 * 4))
+                rcp_sum = K.local_scalar("float32")
+                K.ptx.rcp.approx.ftz.f32(rcp_sum, final_sum)
+                sum_positive = K.local_scalar("int32", init=K.cast(final_sum > _f32(0.0), "int32"))
+                inv_sum = K.local_scalar(
+                    "float32", init=K.if_then_else(sum_positive != _i32(0), rcp_sum, _f32(0.0))
+                )
+                instance_valid_c = K.local_scalar("int32", init=q_valid_c - _i32(64 * instance))
+                with K.If(instance_valid_c > _i32(64)), K.Then():
+                    K.assign(instance_valid_c, _i32(64))
+                with K.If(instance_valid_c < _i32(0)), K.Then():
+                    K.assign(instance_valid_c, _i32(0))
+                query = q_local_base + 64 * instance + my_row_c
+                output_row = (query * num_q_heads + q_head) * 128
+                o_addr = taddr + _u32(_TMEM_OUTPUT[instance]) + row_addr
+                _tmem_load_x32(o_frag, 0, o_addr)
+                _tmem_load_x32(o_frag, 32, o_addr + _u32(32))
+                col_base = col_half_c * 64
+                with K.If(my_row_c < instance_valid_c), K.Then():
+                    inv_pair = _pack2(inv_sum, inv_sum)
+                    for chunk in range(8):
+                        base = 8 * chunk
+                        for j in range(4):
+                            _packed_mul_inplace(o_frag, base + 2 * j, inv_pair)
+                        words = K.alloc_local((4,), "uint32")
+                        for j in range(4):
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                words[j], o_frag[base + 2 * j + 1], o_frag[base + 2 * j]
+                            )
+                        K.ptx.st.global_.v4.b32(
+                            out.ptr_to([output_row + col_base + base]),
+                            words[0],
+                            words[1],
+                            words[2],
+                            words[3],
+                        )
+                    with K.If(col_half_c == 0), K.Then():
+                        stat_idx = query * num_q_heads + q_head
+                        with K.If(return_softmax_lse != _i32(0)), K.Then():
+                            log2_sum = K.local_scalar("float32")
+                            K.ptx.lg2.approx.ftz.f32(log2_sum, final_sum)
+                            max_scaled = K.local_scalar("float32")
+                            K.ptx.mul.ftz.f32(max_scaled, final_max, softmax_scale_log2)
+                            log_sum = K.local_scalar("float32")
+                            K.ptx.mul.ftz.f32(log_sum, log2_sum, _f32(_LN2_F32))
+                            lse_value = K.local_scalar("float32")
+                            K.ptx.fma.rn.ftz.f32(lse_value, max_scaled, _f32(_LN2_F32), log_sum)
+                            K.ptx.st.global_.b32(
+                                lse.ptr_to([stat_idx]),
+                                K.if_then_else(sum_positive != _i32(0), lse_value, _f32(_NEG_INF)),
+                            )
+                        with K.If(return_temperature_lse != _i32(0)), K.Then():
+                            log2_tsum = K.local_scalar("float32")
+                            K.ptx.lg2.approx.ftz.f32(log2_tsum, final_temperature_sum)
+                            t_value = K.local_scalar("float32", init=_f32(_NEG_INF))
+                            with K.If(final_temperature_sum > _f32(0.0)), K.Then():
+                                max_scaled_t = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(max_scaled_t, final_max, softmax_scale_log2)
+                                max_ln = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(max_ln, max_scaled_t, _f32(_LN2_F32))
+                                log_tsum = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(log_tsum, log2_tsum, _f32(_LN2_F32))
+                                K.ptx.fma.rn.ftz.f32(
+                                    t_value, lse_temperature_scale, max_ln, log_tsum
+                                )
+                            K.ptx.st.global_.b32(temperature_lse.ptr_to([stat_idx]), t_value)
+            K.ptx.tcgen05.wait__ld.sync.aligned()
+            K.ptx["tcgen05.fence::before_thread_sync"]()
+            _mbar_arrive(bar(_MBAR_TMEM_DEALLOC))
+
+        # ---- Role: MMA issuer (warp 12) ----
+        with r_mma:
+            union_ready_phase_m = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_m)
+            _flip(union_ready_phase_m)
+            max_union_count_m = selected_blocks
+            k_stage_cursor = K.local_scalar("uint32", init=_u32(0))
+            k_phase_cursor = K.local_scalar("int32", init=_i32(0))
+            v_stage_cursor = K.local_scalar("uint32", init=_u32(0))
+            v_phase_cursor = K.local_scalar("int32", init=_i32(0))
+            q_full_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_Q_FULL), q_full_phase)
+            _flip(q_full_phase)
+            first_pv = [K.local_scalar("int32", init=_i32(1)) for _ in range(2)]
+            phase_p_full = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            q_addr = (bar(_SMEM_Q0), bar(_SMEM_Q1))
+            desc_hi = _u32(_DESC_HI)
+
+            def qk_chain(instance, k_stage):
+                a_lo = K.local_scalar(
+                    "uint32", init=K.uniform((q_addr[instance] >> 4) & _u32(0x3FFF))
+                )
+                b_lo = K.local_scalar(
+                    "uint32",
+                    init=K.uniform(((bar(_SMEM_K) >> 4) & _u32(0x3FFF)) + k_stage * _u32(2048)),
+                )
+                leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                d_tmem = taddr + _u32(_TMEM_SCORES[instance])
+                for k16 in range(8):
+                    K.ptx[_MMA_F16](
+                        d_tmem,
+                        _pack2(a_lo, desc_hi),
+                        _pack2(b_lo, desc_hi),
+                        _u32(_QK_IDESC),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        K.ptx.pred(_u32(0 if k16 == 0 else 1)),
+                        pred=leader,
+                    )
+                    if k16 < 7:
+                        K.assign(a_lo, a_lo + _u32(_QK_A_STEPS[k16]))
+                        K.assign(b_lo, b_lo + _u32(_QK_B_STEPS[k16]))
+                K.ptx[_TCGEN05_COMMIT](bar(_MBAR_S_FULL + 8 * instance), pred=leader)
+                K.ptx[_TCGEN05_COMMIT](bar(_MBAR_K_EMPTY) + k_stage * _u32(8), pred=leader)
+
+            def pv_chain(instance, v_stage):
+                b_lo = K.local_scalar(
+                    "uint32",
+                    init=K.uniform(
+                        (((bar(_SMEM_V) >> 4) & _u32(0x3FFF)) | _u32(_V_LBO_BIT))
+                        + v_stage * _u32(2048)
+                    ),
+                )
+                leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                d_tmem = taddr + _u32(_TMEM_OUTPUT[instance])
+                a_tmem = K.local_scalar(
+                    "uint32", init=taddr + _u32(_TMEM_SCORES[instance] + _TMEM_P_OFFSET)
+                )
+                enable_first = K.local_scalar(
+                    "uint32", init=K.if_then_else(first_pv[instance] != _i32(0), _u32(0), _u32(1))
+                )
+                for k16 in range(8):
+                    K.ptx[_MMA_F16](
+                        d_tmem,
+                        a_tmem,
+                        _pack2(b_lo, desc_hi),
+                        _u32(_PV_IDESC),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        K.ptx.pred(enable_first if k16 == 0 else _u32(1)),
+                        pred=leader,
+                    )
+                    if k16 < 7:
+                        K.assign(a_tmem, a_tmem + _u32(_PV_A_STEP))
+                        K.assign(b_lo, b_lo + _u32(_PV_B_STEP))
+                K.assign(first_pv[instance], _i32(0))
+                return leader
+
+            # Prime S for both instances before the first PV, exactly as the source.
+            for instance in range(2):
+                with K.If(selected_blocks > _i32(0)), K.Then():
+                    k_stage = K.local_scalar("uint32", init=k_stage_cursor)
+                    k_phase = K.local_scalar("int32", init=k_phase_cursor)
+                    _advance_ring(k_stage_cursor, k_phase_cursor)
+                    _mbar_wait(bar(_MBAR_K_FULL) + k_stage * _u32(8), k_phase)
+                    qk_chain(instance, k_stage)
+
+            union_index_2 = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_2 < max_union_count_m):
+                for instance in range(2):
+                    with K.If(selected_blocks > union_index_2), K.Then():
+                        v_stage = K.local_scalar("uint32", init=v_stage_cursor)
+                        v_phase = K.local_scalar("int32", init=v_phase_cursor)
+                        _advance_v_ring(v_stage_cursor, v_phase_cursor)
+                        _mbar_wait(bar(_MBAR_V_FULL) + v_stage * _u32(8), v_phase)
+                        _mbar_wait(bar(_MBAR_P_FULL + 8 * instance), phase_p_full[instance])
+                        _flip(phase_p_full[instance])
+                        leader = pv_chain(instance, v_stage)
+                        with K.If(union_index_2 + _i32(1) == selected_blocks), K.Then():
+                            K.ptx[_TCGEN05_COMMIT](bar(_MBAR_O_FULL + 8 * instance), pred=leader)
+                        K.ptx[_TCGEN05_COMMIT](bar(_MBAR_V_EMPTY) + v_stage * _u32(8), pred=leader)
+                    next_union_index = union_index_2 + _i32(1)
+                    with K.If(next_union_index < selected_blocks), K.Then():
+                        next_k_stage = K.local_scalar("uint32", init=k_stage_cursor)
+                        next_k_phase = K.local_scalar("int32", init=k_phase_cursor)
+                        _advance_ring(k_stage_cursor, k_phase_cursor)
+                        _mbar_wait(bar(_MBAR_K_FULL) + next_k_stage * _u32(8), next_k_phase)
+                        qk_chain(instance, next_k_stage)
+                K.assign(union_index_2, union_index_2 + _i32(1))
+            dealloc_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_TMEM_DEALLOC), dealloc_phase)
+            _flip(dealloc_phase)
+            taddr_dealloc = K.local_scalar("uint32")
+            K.ptx.ld.volatile.shared.b32(taddr_dealloc, bar(_SMEM_TMEM_MAILBOX))
+            K.ptx[_TMEM_DEALLOC](taddr_dealloc, _u32(TMEM_COLS))
+
+        # ---- Role: Q/mask/K load warp (warp 13) ----
+        with r_qk_load:
+            kv_head = q_head
+            query_base = q_local_base
+            load_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            with K.If(load_leader != _u32(0)), K.Then():
+                _mbar_expect_tx(bar(_MBAR_Q_FULL), 32768)
+                K.ptx[_TMA_G2S_4D](
+                    bar(_SMEM_Q0),
+                    K.address_of(q_map),
+                    _i32(0),
+                    query_base,
+                    q_head,
+                    _i32(0),
+                    bar(_MBAR_Q_FULL),
+                )
+                K.ptx[_TMA_G2S_4D](
+                    bar(_SMEM_Q1),
+                    K.address_of(q_map),
+                    _i32(0),
+                    query_base + _i32(64),
+                    q_head,
+                    _i32(0),
+                    bar(_MBAR_Q_FULL),
+                )
+            q_block = query_base // 128
+            mask_base = (q_head * mb + q_block) * nb
+            selected_count = K.local_scalar("int32", init=_i32(0))
+            block_base = K.local_scalar("int32", init=_i32(0))
+            with K.While(block_base < nb):
+                n_block_1 = block_base + lane
+                selected_1 = K.local_scalar("int32", init=_i32(0))
+                with K.If(n_block_1 < nb), K.Then():
+                    mask_byte = K.local_scalar("uint16")
+                    K.ptx.ld.global_.nc.b8(mask_byte, block_mask.ptr_to([mask_base + n_block_1]))
+                    K.assign(selected_1, K.cast(mask_byte != K.uint16(0), "int32"))
+                vote = K.local_scalar("uint32")
+                K.ptx.vote_sync.ballot.b32(
+                    vote, K.ptx.pred(K.cast(selected_1 != _i32(0), "bool")), _u32(_FULL_MASK)
+                )
+                ballot_count = K.local_scalar("uint32")
+                K.ptx.popc.b32(ballot_count, vote)
+                lower_lanes = K.shift_left(_u32(1), K.cast(lane, "uint32")) - _u32(1)
+                lower_count = K.local_scalar("uint32")
+                K.ptx.popc.b32(lower_count, vote & lower_lanes)
+                selected_slot = selected_count + K.cast(lower_count, "int32")
+                with K.If(selected_1 != _i32(0)), K.Then():
+                    slot_addr = bar(_SMEM_UNION_BLOCKS) + K.cast(selected_slot, "uint32") * _u32(4)
+                    K.ptx.st.shared.b32(slot_addr, n_block_1)
+                    K.ptx.st.shared.b32(slot_addr + _u32(192 * 4), n_block_1)
+                K.assign(selected_count, selected_count + K.cast(ballot_count, "int32"))
+                K.assign(block_base, block_base + _i32(32))
+            with K.If(selected_count == _i32(0)), K.Then():
+                with K.If(lane == 0), K.Then():
+                    K.ptx.st.shared.b32(bar(_SMEM_UNION_BLOCKS), _i32(0))
+                    K.ptx.st.shared.b32(bar(_SMEM_UNION_BLOCKS + 192 * 4), _i32(0))
+                K.assign(selected_count, _i32(1))
+            with K.If(lane < 2), K.Then():
+                K.ptx.st.shared.b32(
+                    bar(_SMEM_UNION_COUNT) + K.cast(lane, "uint32") * _u32(4), selected_count
+                )
+            K.ptx.barrier.sync(_u32(8), _u32(32))
+            K.ptx.fence.proxy.async_.shared__cta()
+            _mbar_arrive(bar(_MBAR_UNION_READY))
+            k_stage_load = K.local_scalar("uint32", init=_u32(0))
+            phase_k_empty = K.local_scalar("int32", init=_i32(1))
+            union_index_3 = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_3 < selected_blocks):
+                for instance in range(2):
+                    n_block = _ld_shared_i32(
+                        bar(_SMEM_UNION_BLOCKS + 192 * 4 * instance)
+                        + K.cast(union_index_3, "uint32") * _u32(4)
+                    )
+                    token_base = n_block * 128
+                    _mbar_wait(bar(_MBAR_K_EMPTY) + k_stage_load * _u32(8), phase_k_empty)
+                    push_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    with K.If(push_leader != _u32(0)), K.Then():
+                        full_bar = bar(_MBAR_K_FULL) + k_stage_load * _u32(8)
+                        _mbar_expect_tx(full_bar, 32768)
+                        stage_addr = bar(_SMEM_K) + k_stage_load * _u32(_SMEM_STAGE_BYTES)
+                        token1 = token_base + _i32(64)
+                        for dim_half in range(2):
+                            for token_half, token in ((0, token_base), (1, token1)):
+                                K.ptx[_TMA_G2S_4D](
+                                    stage_addr + _u32(8192 * token_half + 16384 * dim_half),
+                                    K.address_of(k_map),
+                                    _i32(0),
+                                    token,
+                                    _i32(dim_half),
+                                    kv_head,
+                                    full_bar,
+                                )
+                    _advance_ring(k_stage_load, phase_k_empty)
+                K.assign(union_index_3, union_index_3 + _i32(1))
+
+        # ---- Role: V load warp (warp 14) ----
+        with r_v_load:
+            union_ready_phase_v = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_v)
+            _flip(union_ready_phase_v)
+            kv_head = q_head
+            v_stage_load = K.local_scalar("uint32", init=_u32(0))
+            phase_v_empty = K.local_scalar("int32", init=_i32(1))
+            union_index_4 = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_4 < selected_blocks):
+                for instance in range(2):
+                    n_block = _ld_shared_i32(
+                        bar(_SMEM_UNION_BLOCKS + 192 * 4 * instance)
+                        + K.cast(union_index_4, "uint32") * _u32(4)
+                    )
+                    token_base = n_block * 128
+                    _mbar_wait(bar(_MBAR_V_EMPTY) + v_stage_load * _u32(8), phase_v_empty)
+                    push_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    with K.If(push_leader != _u32(0)), K.Then():
+                        full_bar = bar(_MBAR_V_FULL) + v_stage_load * _u32(8)
+                        _mbar_expect_tx(full_bar, 32768)
+                        stage_addr = bar(_SMEM_V) + v_stage_load * _u32(_SMEM_STAGE_BYTES)
+                        token1 = token_base + _i32(64)
+                        for dim_half in range(2):
+                            for token_half, token in ((0, token_base), (1, token1)):
+                                K.ptx[_TMA_G2S_4D](
+                                    stage_addr + _u32(8192 * token_half + 16384 * dim_half),
+                                    K.address_of(v_map),
+                                    _i32(0),
+                                    token,
+                                    _i32(dim_half),
+                                    kv_head,
+                                    full_bar,
+                                )
+                    _advance_v_ring(v_stage_load, phase_v_empty)
+                K.assign(union_index_4, union_index_4 + _i32(1))
+
+        # ---- Role: idle (warp 15) ----
+        with r_idle:
+            pass
+
+    return cake_vsa_longseq_sm100
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return _build_kernel()
+
+
+def get_kernel(**config: Any):
+    """Return the TIRx PrimFunc; the kernel is shape-generic at runtime."""
+    if config:
+        cfg = _without_label(config)
+        _validate_shape(cfg["M"], cfg["N"], cfg["num_heads"])
+    return _kernel().func
+
+
+# Match the upstream cubin's native ptxas ``--register-usage-level=5``.  The
+# TIRx nvcc path otherwise defaults to level 10, which leaves this kernel at the
+# same 128-register allocation but introduces a 56-byte issuer-role stack and
+# dynamic local spill traffic.  A fixed level 4/5/6 bench-suite sweep selected
+# level 5 across the short, streaming, and capacity regimes.
+_PTXAS_REG_LEVEL = "5"
+
+
+@lru_cache(maxsize=1)
+def _compiled_kernel():
+    import os
+
+    from tirx_kernels.runner import compile_kernel
+
+    # nvcc mode keeps the TIRx build on the CUDA toolkit on PATH (13.2, PTX ISA
+    # 9.2) -- the same toolchain the upstream ``nvcc -cubin`` build uses -- so
+    # both binaries share one PTX ISA for SASS and profiler comparisons.
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = _PTXAS_REG_LEVEL
+    try:
+        return compile_kernel(get_kernel(), cuda_compile_mode="nvcc")
+    finally:
+        if previous is None:
+            del os.environ["TVM_CUDA_PTXAS_REG_LEVEL"]
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
+def _tirx_args(data: dict[str, Any], slot: str = "tirx") -> tuple[Any, ...]:
+    buffers = data[slot]
+    return (
+        data["q"].view(-1),
+        data["k"].view(-1),
+        data["v"].view(-1),
+        buffers["out"].view(-1),
+        buffers["lse"].view(-1),
+        buffers["tlse"].view(-1),
+        data["block_mask_u8"].view(-1),
+        data["mb"],
+        data["nb"],
+        data["selected_blocks"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+    )
+
+
+def _tirx_launch(executable, data: dict[str, Any]):
+    arguments = _tirx_args(data)
+
+    def launch():
+        executable(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Upstream source kernel (the reference for correctness and benchmarks)
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=1)
+def _source_module():
+    """Build the upstream cubin + tvm-ffi launcher exactly as FlashInfer does."""
+    from flashinfer import cake_vsa
+
+    return cake_vsa._load_module(PROFILE, CUDA_ARCH)
+
+
+def _source_launch(data: dict[str, Any]):
+    """Replicate ``flashinfer.cake_vsa._run_standard`` for ``longseq``."""
+    import tvm_ffi
+
+    module = _source_module()
+    buffers = data["source"]
+    arguments = (
+        data["q"],
+        data["k"],
+        data["v"],
+        buffers["out"],
+        buffers["lse"],
+        buffers["tlse"],
+        data["block_mask_u8"],
+        data["mb"],
+        data["nb"],
+        data["selected_blocks"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+        data["mb"],
+        data["num_heads"],
+        1,
+    )
+
+    def launch():
+        with tvm_ffi.use_torch_stream():
+            module.run(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+def _run_public_api(data: dict[str, Any]):
+    """Run the upstream public API (``plan_cake_vsa`` + ``run_cake_vsa``)."""
+    import torch
+    from flashinfer import cake_vsa
+
+    plan = cake_vsa.plan_cake_vsa(
+        None,
+        None,
+        data["block_mask"],
+        None,
+        None,
+        None,
+        M=data["M"],
+        N=data["N"],
+        R=BLOCK,
+        C=BLOCK,
+        num_qo_heads=data["num_heads"],
+        num_kv_heads=data["num_heads"],
+        head_dim=HEAD_DIM,
+        q_data_type=torch.bfloat16,
+        sm_scale=data["sm_scale"],
+        device=data["q"].device,
+    )
+    return cake_vsa.run_cake_vsa(
+        plan,
+        data["q"],
+        data["k"],
+        data["v"],
+        out=None,
+        lse=None,
+        return_lse=bool(data["return_lse"]),
+        backend="cake",
+    )
+
+
+# ---------------------------------------------------------------------------
+# fp32 oracle and validation
+# ---------------------------------------------------------------------------
+def _oracle(data: dict[str, Any]):
+    """Dense fp32 reference: masked softmax attention, one head at a time."""
+    import torch
+
+    q = data["q"].float()
+    k = data["k"].float()
+    v = data["v"].float()
+    mask = data["block_mask"]
+    M, num_heads = data["M"], data["num_heads"]
+    scale = data["sm_scale"]
+    tau = data["lse_temperature_scale"]
+    out = torch.empty((M, num_heads, HEAD_DIM), dtype=torch.float32, device=q.device)
+    lse = torch.empty((M, num_heads), dtype=torch.float32, device=q.device)
+    tlse = torch.empty((M, num_heads), dtype=torch.float32, device=q.device)
+    for head in range(num_heads):
+        scores = torch.matmul(q[:, head], k[:, head].transpose(0, 1)) * scale
+        token_mask = mask[head].repeat_interleave(BLOCK, 0).repeat_interleave(BLOCK, 1)
+        scores.masked_fill_(~token_mask, float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        out[:, head] = torch.matmul(probs, v[:, head])
+        lse[:, head] = torch.logsumexp(scores, dim=-1)
+        tlse[:, head] = torch.logsumexp(scores * tau, dim=-1)
+    return out, lse, tlse
+
+
+def _empty_rows(data: dict[str, Any]):
+    """Boolean ``(M, num_heads)`` map of query rows whose block row selects nothing."""
+    mask = data["block_mask"]
+    empty = ~mask.any(dim=-1)  # (num_heads, mb)
+    return empty.repeat_interleave(BLOCK, 1).transpose(0, 1)  # (M, num_heads)
+
+
+def _bf16_order_key(values):
+    """Map bf16 bit patterns to integers ordered like the reals (for ULP distances)."""
+    import torch
+
+    bits = values.contiguous().view(torch.int16).to(torch.int32) & 0xFFFF
+    return torch.where(bits < 0x8000, bits + 0x8000, 0x8000 - (bits & 0x7FFF))
+
+
+def _assert_bitwise(name: str, ours, theirs) -> None:
+    import torch
+
+    if ours.dtype == torch.bfloat16:
+        ours_bits, theirs_bits = ours.view(torch.int16), theirs.view(torch.int16)
+    else:
+        ours_bits, theirs_bits = ours.view(torch.int32), theirs.view(torch.int32)
+    mismatch = ours_bits != theirs_bits
+    count = int(mismatch.sum())
+    if count:
+        index = mismatch.reshape(-1).nonzero()[0].item()
+        raise AssertionError(
+            f"{name}: {count} of {mismatch.numel()} elements differ bitwise from the source "
+            f"kernel (first at flat index {index}: tirx={ours.reshape(-1)[index].item()!r} "
+            f"source={theirs.reshape(-1)[index].item()!r})"
+        )
+
+
+def _validate_outputs(data: dict[str, Any], *, with_oracle: bool) -> dict[str, float]:
+    import torch
+
+    tirx, source = data["tirx"], data["source"]
+    return_lse, return_tlse = data["return_lse"], data["return_temperature_lse"]
+
+    for name, buffers in (("tirx", tirx), ("source", source)):
+        if not torch.isfinite(buffers["out"].float()).all():
+            raise AssertionError(f"{name}: non-finite values in out")
+        if return_lse and not torch.isfinite(buffers["lse"]).all():
+            raise AssertionError(f"{name}: non-finite values in lse")
+        if return_tlse and not torch.isfinite(buffers["tlse"]).all():
+            raise AssertionError(f"{name}: non-finite values in temperature lse")
+        if not return_lse and not bool((buffers["lse"] == _LSE_SENTINEL).all()):
+            raise AssertionError(f"{name}: lse sentinel was overwritten with return_lse=0")
+
+    _assert_bitwise("out", tirx["out"], source["out"])
+    _assert_bitwise("lse", tirx["lse"], source["lse"])
+    if return_tlse:
+        _assert_bitwise("temperature_lse", tirx["tlse"], source["tlse"])
+
+    stats: dict[str, float] = {}
+    if not with_oracle:
+        return stats
+    ref_out, ref_lse, ref_tlse = _oracle(data)
+    valid = ~_empty_rows(data)  # rows with an undefined dense reference are skipped
+    cfg = data["config"]
+    for name, buffers in (("tirx", tirx), ("source", source)):
+        out = buffers["out"].float()[valid]
+        expected = ref_out[valid]
+        err = (out - expected).abs()
+        bound = cfg["oracle_atol"] + cfg["oracle_rtol"] * expected.abs()
+        stats[f"{name}_out_max_abs_err"] = float(err.max())
+        stats[f"{name}_out_max_rel_excess"] = float((err / bound).max())
+        if bool((err > bound).any()):
+            raise AssertionError(
+                f"{name}: out mismatch vs fp32 oracle (max abs err {float(err.max()):.3e}, "
+                f"max err/bound {float((err / bound).max()):.3f})"
+            )
+        # bf16 ULP accounting against the oracle rounded to bf16 (sign-magnitude
+        # bit patterns are mapped to a monotonic integer key first), on the
+        # elements large enough for a ULP to be meaningful.
+        sizeable = expected.abs() >= _ORACLE_ULP_MIN_REF
+        if bool(sizeable.any()):
+            ulps = (
+                _bf16_order_key(expected.to(torch.bfloat16))
+                - _bf16_order_key(buffers["out"][valid])
+            ).abs()[sizeable]
+            ulp_max = float(ulps.max())
+            total = ulps.numel()
+            le1 = int((ulps <= 1).sum()) / total
+            le2 = int((ulps <= 2).sum()) / total
+            stats[f"{name}_out_ulp_max"] = ulp_max
+            stats[f"{name}_out_ulp_le1_frac"] = le1
+            stats[f"{name}_out_ulp_le2_frac"] = le2
+            if ulp_max > cfg["ulp_max"] or le1 < cfg["ulp_le1_frac"] or le2 < cfg["ulp_le2_frac"]:
+                raise AssertionError(
+                    f"{name}: bf16 ULP distribution vs oracle too wide (max {ulp_max:.0f}, "
+                    f"<=1 ULP {le1:.5f}, <=2 ULP {le2:.5f})"
+                )
+        small = expected.abs() < 0.125
+        large = expected.abs() >= 0.5
+        stats[f"{name}_out_max_err_small_ref"] = (
+            float(err[small].max()) if bool(small.any()) else 0.0
+        )
+        stats[f"{name}_out_max_rel_err_large_ref"] = (
+            float((err[large] / expected[large].abs()).max()) if bool(large.any()) else 0.0
+        )
+        if return_lse:
+            lse = buffers["lse"][valid]
+            expected_lse = ref_lse[valid]
+            err = (lse - expected_lse).abs()
+            bound = _ORACLE_LSE_ATOL + _ORACLE_LSE_RTOL * expected_lse.abs()
+            stats[f"{name}_lse_max_abs_err"] = float(err.max())
+            if bool((err > bound).any()):
+                raise AssertionError(
+                    f"{name}: lse mismatch vs oracle (max abs err {float(err.max()):.3e})"
+                )
+        if return_tlse:
+            tlse = buffers["tlse"][valid]
+            expected_tlse = ref_tlse[valid]
+            err = (tlse - expected_tlse).abs()
+            bound = _ORACLE_LSE_ATOL + _ORACLE_LSE_RTOL * expected_tlse.abs()
+            stats[f"{name}_tlse_max_abs_err"] = float(err.max())
+            if bool((err > bound).any()):
+                raise AssertionError(
+                    f"{name}: temperature lse mismatch vs oracle (max abs err {float(err.max()):.3e})"
+                )
+    return stats
+
+
+def _skip_unless_supported() -> None:
+    from unittest import SkipTest
+
+    import torch
+
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA device required")
+    if torch.cuda.get_device_capability() != (10, 0):
+        raise SkipTest("cake_vsa longseq sm_100a requires compute capability 10.0")
+
+
+def run_test(**config: Any) -> dict[str, float]:
+    """Compile, launch TIRx and the upstream kernel, and validate one config."""
+    import torch
+
+    _skip_unless_supported()
+    data = prepare_data(**config)
+    executable = _compiled_kernel()
+    tirx_launch = _tirx_launch(executable, data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    first_out = data["tirx"]["out"].clone()
+    first_lse = data["tirx"]["lse"].clone()
+
+    source_launch = _source_launch(data)
+    source_launch()
+    torch.cuda.synchronize()
+    stats = _validate_outputs(data, with_oracle=True)
+
+    # A second TIRx launch into the same buffers must reproduce the first bit for bit.
+    tirx_launch()
+    torch.cuda.synchronize()
+    _assert_bitwise("out (repeat launch)", data["tirx"]["out"], first_out)
+    _assert_bitwise("lse (repeat launch)", data["tirx"]["lse"], first_lse)
+
+    if data["config"]["pattern"] == "upstream":
+        # The public API must dispatch this shape to longseq and agree bitwise.
+        result = _run_public_api(data)
+        api_out, api_lse = result if data["return_lse"] else (result, None)
+        _assert_bitwise("out (public API)", data["tirx"]["out"], api_out)
+        if api_lse is not None:
+            _assert_bitwise("lse (public API)", data["tirx"]["lse"], api_lse)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points
+# ---------------------------------------------------------------------------
+def prepare_bench(**config: Any):
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    _validate_shape(kernel_config["M"], kernel_config["N"], kernel_config["num_heads"])
+    state = {"config": kernel_config, "executable": _compiled_kernel()}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = _without_label({**prepared["config"], **kwargs})
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**config)
+        gpu_state = {
+            "data": data,
+            "tirx_launch": _tirx_launch(prepared["executable"], data),
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    if not gpu_state["validated"]:
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                source_launch = _source_launch(data)
+                gpu_state["source_launch"] = source_launch
+                source_launch()
+                torch.cuda.synchronize()
+            _validate_outputs(data, with_oracle=False)
+        gpu_state["validated"] = True
+
+    source_launch = gpu_state["source_launch"]
+    references = {"flashinfer": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config: Any):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py
+++ b/tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py
@@ -1,0 +1,1810 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ cc6e8794), Copyright (c) 2026 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Cake VSA longseq block-sparse attention forward for SM103a.
+
+Upstream sources (FlashInfer @ cc6e8794c49bf66172627bdb9742fcb17d18b839):
+
+- csrc/cake_vsa/cake_vsa_longseq_sm_103a.cu supplies
+  kernel_flashinfer_blackwell_vsa_longseq_warp_specialized_sm100;
+- csrc/cake_vsa/cake_vsa_longseq_host.cpp encodes three rank-4,
+  SWIZZLE_128B tensor maps and launches 512 threads with 201344 dynamic
+  shared-memory bytes;
+- flashinfer/cake_vsa.py selects this profile for BF16, D=128, MHA with
+  eight heads, N >= 16384, and a uniform top-k no larger than 192 blocks.
+
+Each CTA handles one 128-row query block and one head. Warps 0-7 perform two
+online-softmax instances, warps 8-11 correct and store the output, warp 12
+issues QK/PV tensor-core operations, warp 13 produces Q and the three-stage K
+ring, warp 14 produces the two-stage V ring, and warp 15 is idle. Every shared
+object occupies one rank-one byte arena and is addressed by explicit offsets;
+no first-class layouts or tile primitives are used.
+"""
+
+import math
+import os
+from functools import lru_cache
+from typing import Any
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cake_vsa_longseq_sm103",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_103a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "cc6e8794c49bf66172627bdb9742fcb17d18b839",
+            },
+            "import": "flashinfer",
+        },
+    ),
+}
+# The upstream kernel is a prebuilt cubin loaded through FlashInfer's own tvm-ffi
+# launcher (``flashinfer.cake_vsa._load_module``); it does not use the CuTe DSL, and
+# tvm-ffi is a dependency of flashinfer-python itself, so only FlashInfer is pinned.
+
+# ---------------------------------------------------------------------------
+# Source contract constants (host.cpp / cake_vsa.py / the device kernel).
+# ---------------------------------------------------------------------------
+HEAD_DIM = 128
+BLOCK = 128  # R == C == 128 query/KV block size of this profile
+MAX_SELECTED_BLOCKS = 192  # ``union_blocks`` capacity per instance
+THREADS = 512
+NUM_WARPS = THREADS // 32
+SMEM_TOTAL = 201344
+TMEM_COLS = 512
+PROFILE = "longseq"
+CUDA_ARCH = "sm_103a"
+_PTXAS_REGISTER_USAGE_LEVEL = "5"
+
+
+def _config(
+    label: str,
+    *,
+    M: int,
+    N: int,
+    selected: int,
+    pattern: str,
+    return_lse: bool = False,
+    return_temperature_lse: bool = False,
+    lse_temperature_scale: float = 1.0,
+    q_amp: float = 1.0,
+    sm_scale: float | None = None,
+    seed: int = 0,
+    oracle_atol: float = 1.5e-3,
+    oracle_rtol: float = 6.0e-3,
+    oracle_lse_atol: float = 2.0e-6,
+    oracle_lse_rtol: float = 5.0e-7,
+    ulp_max: int = 2,
+    ulp_le1_frac: float = 0.9999,
+    ulp_le2_frac: float = 1.0,
+) -> dict[str, Any]:
+    return {
+        "label": label,
+        "M": M,
+        "N": N,
+        "num_heads": 8,
+        "selected": selected,
+        "pattern": pattern,
+        "return_lse": return_lse,
+        "return_temperature_lse": return_temperature_lse,
+        "lse_temperature_scale": lse_temperature_scale,
+        "q_amp": q_amp,
+        "sm_scale": sm_scale,
+        "seed": seed,
+        "oracle_atol": oracle_atol,
+        "oracle_rtol": oracle_rtol,
+        "oracle_lse_atol": oracle_lse_atol,
+        "oracle_lse_rtol": oracle_lse_rtol,
+        "ulp_max": ulp_max,
+        "ulp_le1_frac": ulp_le1_frac,
+        "ulp_le2_frac": ulp_le2_frac,
+    }
+
+
+# Correctness matrix: uniform selected counts are a hard ABI invariant of this profile.
+CONFIGS = [
+    _config("m128_n16384_h8_sel8_upstream", M=128, N=16384, selected=8, pattern="upstream"),
+    _config("m256_n16512_h8_sel1_tail", M=256, N=16512, selected=1, pattern="tail", seed=1),
+    _config("m512_n32768_h8_sel7_ring", M=512, N=32768, selected=7, pattern="ring", seed=2),
+    _config(
+        "m128_n24576_h8_sel192_capacity", M=128, N=24576, selected=192, pattern="dense", seed=3
+    ),
+    _config("m1024_n65536_h8_sel64_window", M=1024, N=65536, selected=64, pattern="window", seed=4),
+    _config(
+        "m256_n32768_h8_sel8_kramp",
+        M=256,
+        N=32768,
+        selected=8,
+        pattern="kramp",
+        q_amp=6.0,
+        sm_scale=0.05,
+        seed=5,
+        oracle_atol=6.5e-3,
+        oracle_rtol=1.0e-2,
+        ulp_max=8,
+        ulp_le1_frac=0.995,
+        ulp_le2_frac=0.9998,
+    ),
+    _config(
+        "m128_n16384_h8_sel3_bothlse",
+        M=128,
+        N=16384,
+        selected=3,
+        pattern="ring",
+        return_lse=True,
+        return_temperature_lse=True,
+        lse_temperature_scale=0.7,
+        seed=6,
+    ),
+]
+
+
+BENCH_CONFIGS = [
+    _config("m2048_n16384_h8_sel8", M=2048, N=16384, selected=8, pattern="random", seed=100),
+    _config("m8192_n32768_h8_sel64", M=8192, N=32768, selected=64, pattern="random", seed=101),
+    _config(
+        "m32768_n131072_h8_sel192", M=32768, N=131072, selected=192, pattern="random", seed=102
+    ),
+    _config("m2048_n131072_h8_sel8", M=2048, N=131072, selected=8, pattern="random", seed=103),
+    _config(
+        "m16384_n32768_h8_sel32_window", M=16384, N=32768, selected=32, pattern="window", seed=104
+    ),
+    _config(
+        "m8192_n65536_h8_sel64_kramp",
+        M=8192,
+        N=65536,
+        selected=64,
+        pattern="kramp",
+        q_amp=6.0,
+        sm_scale=0.05,
+        seed=105,
+        oracle_atol=6.5e-3,
+        oracle_rtol=1.0e-2,
+        ulp_max=8,
+        ulp_le1_frac=0.995,
+        ulp_le2_frac=0.9998,
+    ),
+]
+
+
+_LN2 = math.log(2.0)
+_LSE_SENTINEL = 12345.25
+_GUARD_ELEMS = 64
+_OUT_GUARD = 42.5
+_STATS_GUARD = -54321.25
+_ORACLE_ULP_MIN_REF = 0.125
+_ORACLE_TILES_PER_CHUNK = 1
+
+
+def _without_label(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _validate_shape(M: int, N: int, num_heads: int, selected: int) -> tuple[int, int]:
+    if M <= 0 or M % BLOCK != 0:
+        raise ValueError(f"M={M} must be a positive multiple of {BLOCK}")
+    if N < 16384 or N % BLOCK != 0:
+        raise ValueError(f"N={N} must be at least 16384 and a multiple of {BLOCK}")
+    if num_heads != 8:
+        raise ValueError(f"longseq requires exactly 8 heads, got {num_heads}")
+    nb = N // BLOCK
+    if selected <= 0 or selected > min(nb, MAX_SELECTED_BLOCKS):
+        raise ValueError(f"selected={selected} must be in [1, min(nb={nb}, {MAX_SELECTED_BLOCKS})]")
+    return M // BLOCK, nb
+
+
+def _make_block_mask(*, num_heads: int, mb: int, nb: int, selected: int, pattern: str, generator):
+    """Build a deterministic (H, mb, nb) mask with exactly selected bits per row."""
+    import torch
+
+    mask = torch.zeros((num_heads, mb, nb), dtype=torch.bool)
+    slots = torch.arange(selected, dtype=torch.int64)
+    if pattern == "dense":
+        if selected != nb:
+            raise ValueError("dense pattern requires selected == nb")
+        mask[:] = True
+        return mask
+    for head in range(num_heads):
+        for row in range(mb):
+            if pattern == "upstream":
+                columns = (slots * 7 + row) % nb
+            elif pattern == "tail":
+                columns = torch.arange(nb - selected, nb)
+            elif pattern == "ring":
+                columns = (slots * 19 + row * 13 + head * 17) % nb
+            elif pattern == "window":
+                columns = (slots + row * 23 + head * 11) % nb
+            elif pattern in {"random", "kramp"}:
+                columns = torch.randperm(nb, generator=generator)[:selected]
+            else:
+                raise ValueError(f"unknown mask pattern {pattern!r}")
+            if int(torch.unique(columns).numel()) != selected:
+                raise ValueError(f"pattern {pattern!r} generated duplicate columns")
+            mask[head, row, columns] = True
+    counts = mask.sum(dim=-1)
+    if not bool((counts == selected).all()):
+        raise AssertionError("longseq mask must have a uniform selected-block count")
+    return mask
+
+
+def _assert_longseq_route(mask, *, N: int, num_heads: int, selected: int) -> None:
+    counts = mask.sum(dim=-1)
+    if N < 16384 or num_heads != 8:
+        raise AssertionError("shape does not satisfy the public longseq predicate")
+    if selected > MAX_SELECTED_BLOCKS:
+        raise AssertionError("selected count exceeds longseq capacity")
+    if not bool((counts == selected).all()):
+        raise AssertionError("longseq requires a fixed top-k count in every row and head")
+
+
+def _guarded_tensor(shape, dtype, *, fill: float, guard: float, device):
+    """Return a contiguous interior view plus its guarded backing storage."""
+    import math as _math
+
+    import torch
+
+    elements = _math.prod(shape)
+    storage = torch.full((elements + 2 * _GUARD_ELEMS,), guard, dtype=dtype, device=device)
+    view = storage[_GUARD_ELEMS : _GUARD_ELEMS + elements].view(shape)
+    view.fill_(fill)
+    return view, storage
+
+
+def prepare_data(**config: Any) -> dict[str, Any]:
+    """Allocate deterministic inputs and independently guarded output buffers."""
+    import torch
+
+    config = _without_label(config)
+    M, N = int(config["M"]), int(config["N"])
+    num_heads, selected = int(config["num_heads"]), int(config["selected"])
+    mb, nb = _validate_shape(M, N, num_heads, selected)
+    return_lse = bool(config["return_lse"])
+    return_tlse = bool(config["return_temperature_lse"])
+    sm_scale = config["sm_scale"]
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    generator = torch.Generator().manual_seed(int(config["seed"]))
+    device = torch.device("cuda")
+
+    q = torch.randn((M, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    q = (q * float(config["q_amp"])).to(torch.bfloat16).to(device)
+    k = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    k = k.to(torch.bfloat16).to(device)
+    v = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    v = v.to(torch.bfloat16).to(device)
+    mask = _make_block_mask(
+        num_heads=num_heads,
+        mb=mb,
+        nb=nb,
+        selected=selected,
+        pattern=config["pattern"],
+        generator=generator,
+    )
+    _assert_longseq_route(mask, N=N, num_heads=num_heads, selected=selected)
+    block_mask = mask.to(device)
+
+    def outputs() -> dict[str, Any]:
+        out, out_storage = _guarded_tensor(
+            (M, num_heads, HEAD_DIM),
+            torch.bfloat16,
+            fill=float("nan"),
+            guard=_OUT_GUARD,
+            device=device,
+        )
+        lse_shape = (M, num_heads) if return_lse else (1,)
+        lse_fill = float("nan") if return_lse else _LSE_SENTINEL
+        lse, lse_storage = _guarded_tensor(
+            lse_shape, torch.float32, fill=lse_fill, guard=_STATS_GUARD, device=device
+        )
+        if return_tlse:
+            tlse, tlse_storage = _guarded_tensor(
+                (M, num_heads), torch.float32, fill=float("nan"), guard=_STATS_GUARD, device=device
+            )
+        else:
+            tlse, tlse_storage = lse, lse_storage
+        return {
+            "out": out,
+            "lse": lse,
+            "tlse": tlse,
+            "guards": {"out": out_storage, "lse": lse_storage, "tlse": tlse_storage},
+        }
+
+    return {
+        "config": config,
+        "M": M,
+        "N": N,
+        "num_heads": num_heads,
+        "mb": mb,
+        "nb": nb,
+        "selected_blocks": selected,
+        "q": q,
+        "k": k,
+        "v": v,
+        "block_mask": block_mask,
+        "block_mask_u8": block_mask.view(torch.uint8),
+        "selected_indices": mask.nonzero(as_tuple=False)[:, 2]
+        .view(num_heads, mb, selected)
+        .permute(1, 0, 2)
+        .contiguous(),
+        "sm_scale": float(sm_scale),
+        "softmax_scale_log2": float(sm_scale) / _LN2,
+        "lse_temperature_scale": float(config["lse_temperature_scale"]),
+        "return_lse": return_lse,
+        "return_temperature_lse": return_tlse,
+        "tirx": outputs(),
+        "source": outputs(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# TIRx kernel
+# ---------------------------------------------------------------------------
+# cuTensorMapEncodeTiled enum values (CUtensorMapInterleave / Swizzle /
+# L2promotion / FloatOOBfill) as used by the upstream host launcher.
+_TMA_INTERLEAVE_NONE = 0
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_PROMOTION_NONE = 0
+_TMA_OOB_FILL_NONE = 0
+
+
+def _host_prelude(params):
+    """Encode the three upstream tensor maps from the runtime shape scalars.
+
+    Mirrors ``EncodeTma_q`` / ``EncodeTma_k`` / ``EncodeTma_v`` in the upstream
+    host launcher: rank-4 bf16 maps, 128-byte swizzle, no L2 promotion, no OOB
+    fill.  Q is ``{64, M, Hq, 2}`` with a ``{64, 64, 1, 2}`` box (one 16 KB
+    transaction covers both head-dim halves of 64 rows); K and V are
+    ``{64, N, 2, Hkv}`` with a ``{64, 64, 1, 1}`` box (8 KB per transaction).
+    """
+    mb = params["mb"]
+    nb = params["nb"]
+    num_q_heads = params["num_q_heads"]
+    num_kv_heads = params["num_kv_heads"]
+    elem_bytes = 2
+
+    def encode(tensor, dims, strides_bytes, box):
+        descriptor = K.stack_alloca("tensormap", 1)
+        K.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            descriptor,
+            "bfloat16",
+            4,
+            tensor.data,
+            *dims,
+            *strides_bytes,
+            *box,
+            1,
+            1,
+            1,
+            1,
+            _TMA_INTERLEAVE_NONE,
+            _TMA_SWIZZLE_128B,
+            _TMA_L2_PROMOTION_NONE,
+            _TMA_OOB_FILL_NONE,
+        )
+        return descriptor
+
+    q_map = encode(
+        params["q"],
+        (64, mb * BLOCK, num_q_heads, HEAD_DIM // 64),
+        (num_q_heads * HEAD_DIM * elem_bytes, HEAD_DIM * elem_bytes, 64 * elem_bytes),
+        (64, 64, 1, HEAD_DIM // 64),
+    )
+    kv_dims = (64, nb * BLOCK, HEAD_DIM // 64, num_kv_heads)
+    kv_strides = (num_kv_heads * HEAD_DIM * elem_bytes, 64 * elem_bytes, HEAD_DIM * elem_bytes)
+    kv_box = (64, 64, 1, 1)
+    k_map = encode(params["k"], kv_dims, kv_strides, kv_box)
+    v_map = encode(params["v"], kv_dims, kv_strides, kv_box)
+    return (q_map, k_map, v_map)
+
+
+# Byte offsets inside the 201344-byte dynamic SMEM arena (source macro table).
+_MBAR_Q_FULL = 0
+_MBAR_UNION_READY = 8
+_MBAR_K_FULL = 16  # 3 stages
+_MBAR_K_EMPTY = 40  # 3 stages
+_MBAR_V_FULL = 64  # 2 stages
+_MBAR_V_EMPTY = 80  # 2 stages
+_MBAR_S_FULL = 96  # 2 instances
+_MBAR_P_FULL = 112  # 2 instances
+_MBAR_CORR_SIG = 128  # 2 instances
+_MBAR_CORR_DONE = 144  # 2 instances
+_MBAR_O_FULL = 160  # 2 instances
+_MBAR_TMEM_DEALLOC = 176
+_SMEM_TMEM_MAILBOX = 184
+_SMEM_Q0 = 1024
+_SMEM_Q1 = 17408
+_SMEM_K = 33792  # 3 x 32768
+_SMEM_V = 132096  # 2 x 32768
+_SMEM_STAGE_BYTES = 32768
+_SMEM_SCALE = 197632  # 512 f32: acc_scale / row_sum / row_max / temperature_sum
+_SMEM_UNION_COUNT = 199680  # 2 i32
+_SMEM_UNION_BLOCKS = 199688  # 2 x 192 i32
+# (offset, arrival count) in exact source order.
+_MBARRIER_INIT = (
+    (_MBAR_Q_FULL, 1),
+    (_MBAR_UNION_READY, 32),
+    (_MBAR_K_FULL, 1),
+    (_MBAR_K_FULL + 8, 1),
+    (_MBAR_K_FULL + 16, 1),
+    (_MBAR_K_EMPTY, 1),
+    (_MBAR_K_EMPTY + 8, 1),
+    (_MBAR_K_EMPTY + 16, 1),
+    (_MBAR_V_FULL, 1),
+    (_MBAR_V_FULL + 8, 1),
+    (_MBAR_V_EMPTY, 1),
+    (_MBAR_V_EMPTY + 8, 1),
+    (_MBAR_S_FULL, 1),
+    (_MBAR_S_FULL + 8, 1),
+    (_MBAR_P_FULL, 256),
+    (_MBAR_P_FULL + 8, 256),
+    (_MBAR_CORR_SIG, 128),
+    (_MBAR_CORR_SIG + 8, 128),
+    (_MBAR_CORR_DONE, 128),
+    (_MBAR_CORR_DONE + 8, 128),
+    (_MBAR_O_FULL, 1),
+    (_MBAR_O_FULL + 8, 1),
+    (_MBAR_TMEM_DEALLOC, 128),
+)
+# TMEM column bases per softmax instance: S (128 columns; P overwrites the upper 64
+# in place) and the O accumulator (128 columns).
+_TMEM_SCORES = (0, 256)
+_TMEM_OUTPUT = (128, 384)
+_TMEM_P_OFFSET = 64
+# UMMA descriptor words and instruction descriptors (source immediates).
+_DESC_HI = 0x40004040  # SBO 1024 B, base-offset bit, 128 B swizzle
+_QK_IDESC = 0x04200490  # bf16 x bf16 -> f32, M=64, N=128, K-major A and B
+_PV_IDESC = 0x04210490  # same with MN-major B (V is token-major)
+_QK_A_STEPS = (2, 2, 2, 506, 2, 2, 2)  # Q low-word walk over K=128 (bytes/16)
+_QK_B_STEPS = (2, 2, 2, 1018, 2, 2, 2)  # K low-word walk (second dim half at +16384 B)
+_V_LBO_BIT = 0x4000000  # LBO = 16384 B: dim-half stride of the V tile
+_PV_B_STEP = 128  # 2048 B = 16 tokens x 128 B per K16 step
+_PV_A_STEP = 8  # 16 bf16 P columns = 8 TMEM 32-bit columns per K16 step
+_REG_SOFTMAX = 192
+_REG_CORRECTION = 80
+_REG_OTHER = 48
+_WAIT_TICKS = 0x989680
+
+_TMA_G2S_4D = "cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+_TCGEN05_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+_TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+_TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+_TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+_TMEM_LD_X32 = "tcgen05.ld.sync.aligned.16x32bx2.x32.b32"
+_TMEM_ST_X16 = "tcgen05.st.sync.aligned.16x32bx2.x16.b32"
+_TMEM_ST_X64 = "tcgen05.st.sync.aligned.16x32bx2.x64.b32"
+_LN2_F32 = 0.6931471805599453
+_NEG_INF = float("-inf")
+_FULL_MASK = 0xFFFFFFFF
+
+
+def _u32(value):
+    return K.uint32(value)
+
+
+def _i32(value):
+    return K.int32(value)
+
+
+def _f32(value):
+    return K.float32(value)
+
+
+def _mbar_wait(addr, phase):
+    """``mbarrier.try_wait.parity.acquire.cta`` retry loop with the source's suspend hint."""
+    K.cuda.mbarrier_wait(addr, phase)
+
+
+def _mbar_arrive(addr):
+    K.ptx.mbarrier.arrive.release.cta.shared__cta.b64(addr)
+
+
+def _mbar_expect_tx(addr, tx_bytes):
+    K.ptx.mbarrier.arrive.expect_tx.release.cta.shared__cta.b64(addr, _u32(tx_bytes))
+
+
+def _ld_shared_i32(addr):
+    value = K.local_scalar("int32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _ld_shared_f32(addr):
+    value = K.local_scalar("float32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _ld_shared_counts(addr):
+    """Both instance counts in one ``ld.shared.v2.b32`` (the source's vectorized pair)."""
+    count0 = K.local_scalar("int32")
+    count1 = K.local_scalar("int32")
+    K.ptx.ld.shared.v2.b32(count0, count1, addr)
+    return count0, count1
+
+
+def _flip(phase):
+    K.assign(phase, phase ^ _i32(1))
+
+
+def _advance_ring(stage, phase, stages):
+    """Advance a K/V ring cursor and flip parity exactly at its stage count."""
+    K.assign(stage, stage + _u32(1))
+    with K.If(stage == _u32(stages)), K.Then():
+        K.assign(stage, _u32(0))
+        _flip(phase)
+
+
+def _pack2(lo, hi):
+    packed = K.local_scalar("uint64")
+    K.ptx.mov.b64(packed, lo, hi)
+    return packed
+
+
+def _packed_fma_inplace(values, base, scale_pair, bias_pair):
+    """``fma.rn.ftz.f32x2`` on values[base:base+2] with packed scale and bias."""
+    result = K.local_scalar("uint64")
+    K.ptx.fma.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair, bias_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _packed_mul_inplace(values, base, scale_pair):
+    """``mul.rn.ftz.f32x2`` on values[base:base+2] with a packed scale."""
+    result = K.local_scalar("uint64")
+    K.ptx.mul.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _exp2_inplace(values, index):
+    K.ptx.ex2.approx.ftz.f32(values[index], values[index])
+
+
+def _max_f32(a, b):
+    out = K.local_scalar("float32")
+    K.ptx.max.f32(out, a, b)
+    return out
+
+
+def _shfl_xor_f32(value, lane_xor):
+    out = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(
+        out, K.reinterpret("uint32", value), _u32(lane_xor), _u32(31), _u32(_FULL_MASK)
+    )
+    return K.reinterpret("float32", out)
+
+
+def _tmem_load_x32(dst, base, taddr):
+    K.ptx[_TMEM_LD_X32](*(dst[base + i] for i in range(32)), taddr, 64)
+
+
+def _block_sum(values):
+    """``softmax_block_sum`` over 64 values: 32 packed ``add.f32x2`` into one accumulator."""
+    acc = K.local_scalar("uint64")
+    K.ptx.mov.b64(acc, _f32(0.0), _f32(0.0))
+    for j in range(32):
+        K.ptx.add.f32x2(acc, acc, _pack2(values[2 * j], values[2 * j + 1]))
+    acc_x = K.local_scalar("float32")
+    acc_y = K.local_scalar("float32")
+    K.ptx.mov.b64(acc_x, acc_y, acc)
+    half = K.local_scalar("float32")
+    K.ptx.add.ftz.f32(half, acc_x, acc_y)
+    total = K.local_scalar("float32")
+    K.ptx.add.ftz.f32(total, half, _shfl_xor_f32(half, 16))
+    return total
+
+
+def _row_max(values):
+    """``row_max_x32_accum`` x2 + ``row_max_reduce``: alternating accumulators, 65 ``max.f32``."""
+    acc0 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    acc1 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    for half in range(2):
+        for j in range(16):
+            pair = _max_f32(values[half * 32 + 2 * j], values[half * 32 + 2 * j + 1])
+            if j % 2 == 0:
+                K.assign(acc0, _max_f32(acc0, pair))
+            else:
+                K.assign(acc1, _max_f32(acc1, pair))
+    return _max_f32(acc0, acc1)
+
+
+def _build_kernel():
+    @K.kernel(
+        warps=NUM_WARPS,
+        arch=CUDA_ARCH,
+        min_blocks_per_sm=1,
+        grid=lambda p: [p["mb"], p["num_q_heads"]],
+        host_prelude=_host_prelude,
+    )
+    def cake_vsa_longseq_sm103(
+        q: K.gptr[K.bf16],
+        k: K.gptr[K.bf16],
+        v: K.gptr[K.bf16],
+        out: K.gptr[K.bf16],
+        lse: K.gptr[K.f32],
+        temperature_lse: K.gptr[K.f32],
+        block_mask: K.gptr[K.u8],
+        mb: K.i32,
+        nb: K.i32,
+        selected_blocks: K.i32,
+        num_q_heads: K.i32,
+        num_kv_heads: K.i32,
+        softmax_scale_log2: K.f32,
+        lse_temperature_scale: K.f32,
+        return_softmax_lse: K.i32,
+        return_temperature_lse: K.i32,
+        *,
+        host,
+    ):
+        q_map, k_map, v_map = host
+        del q, k, v, num_kv_heads  # reached only through the tensor maps / host prelude
+        # >>> kernel_flashinfer_blackwell_vsa_longseq_warp_specialized_sm100 body starts here
+        q_tile, q_head = K.cta_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        arena = K.alloc_buffer((SMEM_TOTAL,), K.u8, scope="shared.dyn", align=1024)
+        smem = K.local_scalar("uint32", init=K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
+
+        def bar(offset):
+            return smem + _u32(offset)
+
+        # Mbarrier init (12 groups, 23 barriers) by one elected lane of warp 0.
+        with K.If(warp == 0), K.Then():
+            init_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            with K.If(init_leader != _u32(0)), K.Then():
+                for offset, count in _MBARRIER_INIT:
+                    K.ptx.mbarrier.init.shared__cta.b64(bar(offset), _u32(count))
+                K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.warp.sync(_u32(_FULL_MASK))
+
+        # TMEM alloc (512 columns) by warp 0; the address lands in the shared mailbox.
+        with K.If(warp == 0), K.Then():
+            K.ptx[_TMEM_ALLOC](bar(_SMEM_TMEM_MAILBOX), _u32(TMEM_COLS))
+            K.ptx[_TMEM_RELINQUISH]()
+        K.cuda.cta_sync()
+        K.ptx["tcgen05.fence::after_thread_sync"]()
+        taddr = K.local_scalar("uint32")
+        K.ptx.ld.volatile.shared.b32(taddr, bar(_SMEM_TMEM_MAILBOX))
+
+        q_local_base = q_tile * 128
+        kv_len = nb * 128
+
+        # Sibling role guards, as in the source; folding them into an if/else-if chain
+        # measured 1.2-2.3% slower on the two small shapes with no register pressure to relieve.
+        roles = K.specialize(chain_dispatch=False)
+        other_regs = roles.register_scope("other", warps=range(12, 16), regs=_REG_OTHER)
+        r_softmax = roles.role("softmax", warps=range(0, 8), regs=_REG_SOFTMAX)
+        r_correction = roles.role("correction", warps=range(8, 12), regs=_REG_CORRECTION)
+        r_mma = roles.role("mma", warps=[12], register_scope=other_regs)
+        r_qk_load = roles.role("qk_load", warps=[13], register_scope=other_regs)
+        r_v_load = roles.role("v_load", warps=[14], register_scope=other_regs)
+        r_idle = roles.role("idle", warps=[15], register_scope=other_regs)
+
+        # Register redistribution: warps 12..15 decrease first so the softmax
+        # increase can be granted.
+        with K.If(K.And(warp >= 12, warp <= 15)), K.Then():
+            other_regs.emit()
+
+        # ---- Role: softmax (warps 0..7, two four-warp instances) ----
+        with r_softmax:
+            q_valid = K.local_scalar("int32", init=_i32(128))
+            with K.If(q_tile >= mb), K.Then():
+                K.assign(q_valid, _i32(0))
+            union_ready_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase)
+            _flip(union_ready_phase)
+            instance = K.uniform(warp // 4)
+            instance_row_offset = K.uniform(instance * 64)
+            instance_token_offset = K.uniform(instance * 64)
+            instance_tmem_offset = K.uniform(instance * 256)
+            union_count = selected_blocks
+            warp_in_instance = warp % 4
+            tmem_row_origin = warp_in_instance * 32
+            my_row = warp_in_instance * 16 + lane % 16
+            col_half = lane // 16
+            instance_valid = K.local_scalar("int32", init=q_valid - instance_token_offset)
+            with K.If(instance_valid > _i32(64)), K.Then():
+                K.assign(instance_valid, _i32(64))
+            with K.If(instance_valid < _i32(0)), K.Then():
+                K.assign(instance_valid, _i32(0))
+            row_valid = K.local_scalar("int32", init=K.cast(my_row < instance_valid, "int32"))
+            row_max = K.local_scalar("float32", init=_f32(_NEG_INF))
+            row_sum = K.local_scalar("float32", init=_f32(0.0))
+            temperature_sum = K.local_scalar("float32", init=_f32(0.0))
+            phase_s_full_0 = K.local_scalar("int32", init=_i32(0))
+            phase_s_full_1 = K.local_scalar("int32", init=_i32(0))
+            phase_corr_done_0 = K.local_scalar("int32", init=_i32(0))
+            phase_corr_done_1 = K.local_scalar("int32", init=_i32(0))
+            score_addr = K.local_scalar(
+                "uint32",
+                init=taddr
+                + K.cast(instance_tmem_offset, "uint32")
+                + K.shift_left(K.cast(tmem_row_origin, "uint32"), _u32(16)),
+            )
+            p_addr = K.local_scalar("uint32", init=score_addr + _u32(_TMEM_P_OFFSET))
+            scale_row_addr = bar(_SMEM_SCALE) + K.cast(
+                instance_row_offset + my_row, "uint32"
+            ) * _u32(4)
+            scores = K.alloc_local((64,), "float32")
+            packed_p = K.alloc_local((32,), "uint32")
+            block_sum = K.local_scalar("float32", init=_f32(0.0))
+            block_temperature_sum = K.local_scalar("float32", init=_f32(0.0))
+            acc_scale = K.local_scalar("float32", init=_f32(1.0))
+            temperature_acc_scale = K.local_scalar("float32", init=_f32(1.0))
+            selected_max = K.local_scalar("float32", init=_f32(_NEG_INF))
+            new_max_scaled = K.local_scalar("float32", init=_f32(0.0))
+            safe_max = K.local_scalar("float32", init=_f32(0.0))
+
+            def probabilities_from(frag, bias):
+                """fma, exp2, block sum, bf16 pack and the two P stores of one branch."""
+                scale_pair = _pack2(softmax_scale_log2, softmax_scale_log2)
+                bias_pair = _pack2(bias, bias)
+                for j in range(32):
+                    _packed_fma_inplace(frag, 2 * j, scale_pair, bias_pair)
+                for j in range(64):
+                    _exp2_inplace(frag, j)
+                K.assign(block_sum, _block_sum(frag))
+                for j in range(32):
+                    K.ptx.cvt.rn.bf16x2.f32(packed_p[j], frag[2 * j + 1], frag[2 * j])
+                K.ptx[_TMEM_ST_X16](p_addr, 32, *(packed_p[i] for i in range(16)))
+                K.ptx[_TMEM_ST_X16](p_addr + _u32(16), 32, *(packed_p[16 + i] for i in range(16)))
+
+            union_index = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index < union_count):
+                n_block = _ld_shared_i32(
+                    bar(_SMEM_UNION_BLOCKS)
+                    + K.cast(instance * 192 + union_index, "uint32") * _u32(4)
+                )
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_wait(bar(_MBAR_S_FULL), phase_s_full_0)
+                        _flip(phase_s_full_0)
+                    with K.Else():
+                        _mbar_wait(bar(_MBAR_S_FULL + 8), phase_s_full_1)
+                        _flip(phase_s_full_1)
+                valid_cols = K.local_scalar("int32", init=_i32(0))
+                with K.If(row_valid != _i32(0)), K.Then():
+                    K.assign(valid_cols, kv_len - n_block * 128)
+                    with K.If(valid_cols > _i32(128)), K.Then():
+                        K.assign(valid_cols, _i32(128))
+                    with K.If(valid_cols < _i32(0)), K.Then():
+                        K.assign(valid_cols, _i32(0))
+                _tmem_load_x32(scores, 0, score_addr)
+                _tmem_load_x32(scores, 32, score_addr + _u32(32))
+                half_valid = K.local_scalar("int32", init=valid_cols - col_half * 64)
+                with K.If(half_valid < _i32(0)), K.Then():
+                    K.assign(half_valid, _i32(0))
+                with K.If(half_valid > _i32(64)), K.Then():
+                    K.assign(half_valid, _i32(64))
+                # The source's per-column -inf fill for 0 < half_valid < 64 is unreachable
+                # (valid_cols is a multiple of 128) and nvcc emits no code for it.
+                tile_max = K.local_scalar("float32", init=_row_max(scores))
+                with K.If(half_valid <= _i32(0)), K.Then():
+                    K.assign(tile_max, _f32(_NEG_INF))
+                K.assign(tile_max, _max_f32(tile_max, _shfl_xor_f32(tile_max, 16)))
+                new_max = _max_f32(tile_max, row_max)
+                K.assign(safe_max, K.if_then_else(new_max == _f32(_NEG_INF), _f32(0.0), new_max))
+                K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                neg_new_max_scaled = K.local_scalar("float32")
+                K.ptx.neg.ftz.f32(neg_new_max_scaled, new_max_scaled)
+                acc_scale_log2 = K.local_scalar("float32")
+                K.ptx.fma.rn.ftz.f32(
+                    acc_scale_log2, row_max, softmax_scale_log2, neg_new_max_scaled
+                )
+                with K.If(acc_scale_log2 >= _f32(-8.0)):
+                    with K.Then():
+                        # The running max moves by less than 2^8: keep the old max, skip the rescale.
+                        K.assign(selected_max, row_max)
+                        K.assign(
+                            safe_max, K.if_then_else(row_max == _f32(_NEG_INF), _f32(0.0), row_max)
+                        )
+                        K.assign(acc_scale, _f32(1.0))
+                        K.assign(temperature_acc_scale, _f32(1.0))
+                        K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                    with K.Else():
+                        K.assign(selected_max, new_max)
+                        exp_scale = K.local_scalar("float32")
+                        K.ptx.ex2.approx.ftz.f32(exp_scale, acc_scale_log2)
+                        K.assign(
+                            acc_scale,
+                            K.if_then_else(row_max > _f32(_NEG_INF), exp_scale, _f32(1.0)),
+                        )
+                        tau_log2 = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_log2, acc_scale_log2, lse_temperature_scale)
+                        exp_tau = K.local_scalar("float32")
+                        K.ptx.ex2.approx.ftz.f32(exp_tau, tau_log2)
+                        K.assign(
+                            temperature_acc_scale,
+                            K.if_then_else(row_max > _f32(_NEG_INF), exp_tau, _f32(1.0)),
+                        )
+                K.assign(row_max, selected_max)
+                with K.If(col_half == 0), K.Then():
+                    K.ptx.st.shared.b32(scale_row_addr, acc_scale)
+                K.ptx.fence.proxy.async_.shared__cta()
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG))
+                    with K.Else():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+                # The bias negates the (possibly re-selected) new_max_scaled after the branch.
+                neg_bias = K.local_scalar("float32")
+                K.ptx.neg.ftz.f32(neg_bias, new_max_scaled)
+                score_bias = K.local_scalar("float32")
+                K.assign(score_bias, K.if_then_else(valid_cols > _i32(0), neg_bias, _f32(_NEG_INF)))
+                K.assign(block_temperature_sum, _f32(0.0))
+                K.assign(block_sum, _f32(0.0))
+                with K.If(return_temperature_lse != _i32(0)):
+                    with K.Then():
+                        tau_scale = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_scale, softmax_scale_log2, lse_temperature_scale)
+                        tau_bias = K.local_scalar("float32")
+                        K.ptx.mul.ftz.f32(tau_bias, score_bias, lse_temperature_scale)
+                        tau_scale_pair = _pack2(tau_scale, tau_scale)
+                        tau_bias_pair = _pack2(tau_bias, tau_bias)
+                        for j in range(32):
+                            _packed_fma_inplace(scores, 2 * j, tau_scale_pair, tau_bias_pair)
+                        for j in range(64):
+                            _exp2_inplace(scores, j)
+                        K.assign(block_temperature_sum, _block_sum(scores))
+                        # S is re-read because the temperature sum consumed the first copy.
+                        _tmem_load_x32(scores, 0, score_addr)
+                        _tmem_load_x32(scores, 32, score_addr + _u32(32))
+                        probabilities_from(scores, score_bias)
+                    with K.Else():
+                        probabilities_from(scores, score_bias)
+                K.ptx.tcgen05.wait__st.sync.aligned()
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_arrive(bar(_MBAR_P_FULL))
+                        _mbar_wait(bar(_MBAR_CORR_DONE), phase_corr_done_0)
+                        _flip(phase_corr_done_0)
+                    with K.Else():
+                        _mbar_arrive(bar(_MBAR_P_FULL + 8))
+                        _mbar_wait(bar(_MBAR_CORR_DONE + 8), phase_corr_done_1)
+                        _flip(phase_corr_done_1)
+                K.ptx.fma.rn.ftz.f32(row_sum, row_sum, acc_scale, block_sum)
+                with K.If(return_temperature_lse != _i32(0)), K.Then():
+                    K.ptx.fma.rn.ftz.f32(
+                        temperature_sum,
+                        temperature_sum,
+                        temperature_acc_scale,
+                        block_temperature_sum,
+                    )
+                K.assign(union_index, union_index + _i32(1))
+            with K.If(col_half == 0), K.Then():
+                K.ptx.st.shared.b32(scale_row_addr + _u32(128 * 4), row_sum)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(256 * 4), row_max)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(384 * 4), temperature_sum)
+            K.ptx.fence.proxy.async_.shared__cta()
+            with K.If(instance == 0):
+                with K.Then():
+                    _mbar_arrive(bar(_MBAR_CORR_SIG))
+                with K.Else():
+                    _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+
+        # ---- Role: correction and epilogue (warps 8..11) ----
+        with r_correction:
+            q_valid_c = K.local_scalar("int32", init=_i32(128))
+            with K.If(q_tile >= mb), K.Then():
+                K.assign(q_valid_c, _i32(0))
+            union_ready_phase_c = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_c)
+            _flip(union_ready_phase_c)
+            max_union_count_c = selected_blocks
+            warp_in_role = warp - 8
+            tmem_row_origin_c = warp_in_role * 32
+            my_row_c = warp_in_role * 16 + lane % 16
+            col_half_c = lane // 16
+            row_addr = K.local_scalar(
+                "uint32", init=K.shift_left(K.cast(tmem_row_origin_c, "uint32"), _u32(16))
+            )
+            scale_base_c = bar(_SMEM_SCALE) + K.cast(my_row_c, "uint32") * _u32(4)
+            _mbar_arrive(bar(_MBAR_P_FULL))
+            _mbar_arrive(bar(_MBAR_P_FULL + 8))
+            phase_corr_sig_0 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_CORR_SIG), phase_corr_sig_0)
+            _flip(phase_corr_sig_0)
+            _mbar_arrive(bar(_MBAR_CORR_DONE))
+            phase_corr_sig_1 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_CORR_SIG + 8), phase_corr_sig_1)
+            _flip(phase_corr_sig_1)
+            _mbar_arrive(bar(_MBAR_CORR_DONE + 8))
+            o_frag = K.alloc_local((64,), "float32")
+
+            def rescale_instance(instance, phase_corr_sig, union_index_1):
+                count = selected_blocks
+                with K.If(count > union_index_1), K.Then():
+                    _mbar_wait(bar(_MBAR_CORR_SIG + 8 * instance), phase_corr_sig)
+                    _flip(phase_corr_sig)
+                    acc_scale_c = _ld_shared_f32(scale_base_c + _u32(64 * 4 * instance))
+                    any_rescale = K.local_scalar("uint32")
+                    K.ptx.vote_sync.any.pred(
+                        any_rescale,
+                        K.ptx.pred(K.cast(acc_scale_c < _f32(1.0), "bool")),
+                        _u32(_FULL_MASK),
+                    )
+                    with K.If(any_rescale != _u32(0)), K.Then():
+                        o_addr = taddr + _u32(_TMEM_OUTPUT[instance]) + row_addr
+                        _tmem_load_x32(o_frag, 0, o_addr)
+                        _tmem_load_x32(o_frag, 32, o_addr + _u32(32))
+                        scale_pair = _pack2(acc_scale_c, acc_scale_c)
+                        for j in range(32):
+                            _packed_mul_inplace(o_frag, 2 * j, scale_pair)
+                        K.ptx[_TMEM_ST_X64](o_addr, 64, *(o_frag[i] for i in range(64)))
+                        K.ptx.tcgen05.wait__st.sync.aligned()
+                    _mbar_arrive(bar(_MBAR_P_FULL + 8 * instance))
+                    _mbar_arrive(bar(_MBAR_CORR_DONE + 8 * instance))
+
+            union_index_1 = K.local_scalar("int32", init=_i32(1))
+            with K.While(union_index_1 < max_union_count_c):
+                rescale_instance(0, phase_corr_sig_0, union_index_1)
+                rescale_instance(1, phase_corr_sig_1, union_index_1)
+                K.assign(union_index_1, union_index_1 + _i32(1))
+            phase_o_full_0 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_O_FULL), phase_o_full_0)
+            _flip(phase_o_full_0)
+            phase_o_full_1 = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_O_FULL + 8), phase_o_full_1)
+            _flip(phase_o_full_1)
+            _mbar_wait(bar(_MBAR_CORR_SIG), phase_corr_sig_0)
+            _flip(phase_corr_sig_0)
+            _mbar_wait(bar(_MBAR_CORR_SIG + 8), phase_corr_sig_1)
+            _flip(phase_corr_sig_1)
+            K.ptx["tcgen05.fence::after_thread_sync"]()
+            for instance in range(2):
+                stats_addr = scale_base_c + _u32(64 * 4 * instance)
+                final_sum = _ld_shared_f32(stats_addr + _u32(128 * 4))
+                final_max = _ld_shared_f32(stats_addr + _u32(256 * 4))
+                final_temperature_sum = _ld_shared_f32(stats_addr + _u32(384 * 4))
+                rcp_sum = K.local_scalar("float32")
+                K.ptx.rcp.approx.ftz.f32(rcp_sum, final_sum)
+                sum_positive = K.local_scalar("int32", init=K.cast(final_sum > _f32(0.0), "int32"))
+                inv_sum = K.local_scalar(
+                    "float32", init=K.if_then_else(sum_positive != _i32(0), rcp_sum, _f32(0.0))
+                )
+                instance_valid_c = K.local_scalar("int32", init=q_valid_c - _i32(64 * instance))
+                with K.If(instance_valid_c > _i32(64)), K.Then():
+                    K.assign(instance_valid_c, _i32(64))
+                with K.If(instance_valid_c < _i32(0)), K.Then():
+                    K.assign(instance_valid_c, _i32(0))
+                query = q_local_base + 64 * instance + my_row_c
+                output_row = (query * num_q_heads + q_head) * 128
+                o_addr = taddr + _u32(_TMEM_OUTPUT[instance]) + row_addr
+                _tmem_load_x32(o_frag, 0, o_addr)
+                _tmem_load_x32(o_frag, 32, o_addr + _u32(32))
+                col_base = col_half_c * 64
+                with K.If(my_row_c < instance_valid_c), K.Then():
+                    inv_pair = _pack2(inv_sum, inv_sum)
+                    for chunk in range(8):
+                        base = 8 * chunk
+                        for j in range(4):
+                            _packed_mul_inplace(o_frag, base + 2 * j, inv_pair)
+                        words = K.alloc_local((4,), "uint32")
+                        for j in range(4):
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                words[j], o_frag[base + 2 * j + 1], o_frag[base + 2 * j]
+                            )
+                        K.ptx.st.global_.v4.b32(
+                            out.ptr_to([output_row + col_base + base]),
+                            words[0],
+                            words[1],
+                            words[2],
+                            words[3],
+                        )
+                    with K.If(col_half_c == 0), K.Then():
+                        stat_idx = query * num_q_heads + q_head
+                        with K.If(return_softmax_lse != _i32(0)), K.Then():
+                            log2_sum = K.local_scalar("float32")
+                            K.ptx.lg2.approx.ftz.f32(log2_sum, final_sum)
+                            max_scaled = K.local_scalar("float32")
+                            K.ptx.mul.ftz.f32(max_scaled, final_max, softmax_scale_log2)
+                            log_sum = K.local_scalar("float32")
+                            K.ptx.mul.ftz.f32(log_sum, log2_sum, _f32(_LN2_F32))
+                            lse_value = K.local_scalar("float32")
+                            K.ptx.fma.rn.ftz.f32(lse_value, max_scaled, _f32(_LN2_F32), log_sum)
+                            K.ptx.st.global_.b32(
+                                lse.ptr_to([stat_idx]),
+                                K.if_then_else(sum_positive != _i32(0), lse_value, _f32(_NEG_INF)),
+                            )
+                        with K.If(return_temperature_lse != _i32(0)), K.Then():
+                            log2_tsum = K.local_scalar("float32")
+                            K.ptx.lg2.approx.ftz.f32(log2_tsum, final_temperature_sum)
+                            t_value = K.local_scalar("float32", init=_f32(_NEG_INF))
+                            with K.If(final_temperature_sum > _f32(0.0)), K.Then():
+                                max_scaled_t = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(max_scaled_t, final_max, softmax_scale_log2)
+                                max_ln = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(max_ln, max_scaled_t, _f32(_LN2_F32))
+                                log_tsum = K.local_scalar("float32")
+                                K.ptx.mul.ftz.f32(log_tsum, log2_tsum, _f32(_LN2_F32))
+                                K.ptx.fma.rn.ftz.f32(
+                                    t_value, lse_temperature_scale, max_ln, log_tsum
+                                )
+                            K.ptx.st.global_.b32(temperature_lse.ptr_to([stat_idx]), t_value)
+            K.ptx.tcgen05.wait__ld.sync.aligned()
+            K.ptx["tcgen05.fence::before_thread_sync"]()
+            _mbar_arrive(bar(_MBAR_TMEM_DEALLOC))
+
+        # ---- Role: MMA issuer (warp 12) ----
+        with r_mma:
+            union_ready_phase_m = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_m)
+            _flip(union_ready_phase_m)
+            max_union_count_m = selected_blocks
+            k_stage = K.local_scalar("uint32", init=_u32(0))
+            k_phase = K.local_scalar("int32", init=_i32(0))
+            v_stage = K.local_scalar("uint32", init=_u32(0))
+            v_phase = K.local_scalar("int32", init=_i32(0))
+            q_full_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_Q_FULL), q_full_phase)
+            _flip(q_full_phase)
+            first_pv = [K.local_scalar("int32", init=_i32(1)) for _ in range(2)]
+            phase_p_full = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            q_addr = (bar(_SMEM_Q0), bar(_SMEM_Q1))
+            desc_hi = _u32(_DESC_HI)
+
+            def qk_chain(instance, k_stage_now):
+                a_lo = K.local_scalar(
+                    "uint32", init=K.uniform((q_addr[instance] >> 4) & _u32(0x3FFF))
+                )
+                b_lo = K.local_scalar(
+                    "uint32",
+                    init=K.uniform(((bar(_SMEM_K) >> 4) & _u32(0x3FFF)) + k_stage_now * _u32(2048)),
+                )
+                leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                d_tmem = taddr + _u32(_TMEM_SCORES[instance])
+                for k16 in range(8):
+                    K.ptx[_MMA_F16](
+                        d_tmem,
+                        _pack2(a_lo, desc_hi),
+                        _pack2(b_lo, desc_hi),
+                        _u32(_QK_IDESC),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        K.ptx.pred(_u32(0 if k16 == 0 else 1)),
+                        pred=leader,
+                    )
+                    if k16 < 7:
+                        K.assign(a_lo, a_lo + _u32(_QK_A_STEPS[k16]))
+                        K.assign(b_lo, b_lo + _u32(_QK_B_STEPS[k16]))
+                commit_s_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                K.ptx[_TCGEN05_COMMIT](bar(_MBAR_S_FULL + 8 * instance), pred=commit_s_leader)
+                commit_k_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                K.ptx[_TCGEN05_COMMIT](
+                    bar(_MBAR_K_EMPTY) + k_stage_now * _u32(8), pred=commit_k_leader
+                )
+
+            def pv_chain(instance, v_stage_now):
+                b_lo = K.local_scalar(
+                    "uint32",
+                    init=K.uniform(
+                        (((bar(_SMEM_V) >> 4) & _u32(0x3FFF)) | _u32(_V_LBO_BIT))
+                        + v_stage_now * _u32(2048)
+                    ),
+                )
+                leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                d_tmem = taddr + _u32(_TMEM_OUTPUT[instance])
+                a_tmem = K.local_scalar(
+                    "uint32", init=taddr + _u32(_TMEM_SCORES[instance] + _TMEM_P_OFFSET)
+                )
+                enable_first = K.local_scalar(
+                    "uint32", init=K.if_then_else(first_pv[instance] != _i32(0), _u32(0), _u32(1))
+                )
+                for k16 in range(8):
+                    K.ptx[_MMA_F16](
+                        d_tmem,
+                        a_tmem,
+                        _pack2(b_lo, desc_hi),
+                        _u32(_PV_IDESC),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        _u32(0),
+                        K.ptx.pred(enable_first if k16 == 0 else _u32(1)),
+                        pred=leader,
+                    )
+                    if k16 < 7:
+                        K.assign(a_tmem, a_tmem + _u32(_PV_A_STEP))
+                        K.assign(b_lo, b_lo + _u32(_PV_B_STEP))
+                K.assign(first_pv[instance], _i32(0))
+
+            # Prime QK for both 64-row instances before the PV pipeline loop.
+            for instance in range(2):
+                with K.If(selected_blocks > _i32(0)), K.Then():
+                    k_stage_now = K.local_scalar("uint32", init=k_stage)
+                    k_phase_now = K.local_scalar("int32", init=k_phase)
+                    _advance_ring(k_stage, k_phase, 3)
+                    _mbar_wait(bar(_MBAR_K_FULL) + k_stage_now * _u32(8), k_phase_now)
+                    qk_chain(instance, k_stage_now)
+
+            union_index_m = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_m < max_union_count_m):
+                for instance in range(2):
+                    with K.If(selected_blocks > union_index_m), K.Then():
+                        v_stage_now = K.local_scalar("uint32", init=v_stage)
+                        v_phase_now = K.local_scalar("int32", init=v_phase)
+                        _advance_ring(v_stage, v_phase, 2)
+                        _mbar_wait(bar(_MBAR_V_FULL) + v_stage_now * _u32(8), v_phase_now)
+                        _mbar_wait(bar(_MBAR_P_FULL + 8 * instance), phase_p_full[instance])
+                        _flip(phase_p_full[instance])
+                        pv_chain(instance, v_stage_now)
+                        with K.If(union_index_m + _i32(1) == selected_blocks), K.Then():
+                            commit_o_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                            K.ptx[_TCGEN05_COMMIT](
+                                bar(_MBAR_O_FULL + 8 * instance), pred=commit_o_leader
+                            )
+                        commit_v_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                        K.ptx[_TCGEN05_COMMIT](
+                            bar(_MBAR_V_EMPTY) + v_stage_now * _u32(8), pred=commit_v_leader
+                        )
+                    next_union_index = union_index_m + _i32(1)
+                    with K.If(next_union_index < selected_blocks), K.Then():
+                        k_stage_now = K.local_scalar("uint32", init=k_stage)
+                        k_phase_now = K.local_scalar("int32", init=k_phase)
+                        _advance_ring(k_stage, k_phase, 3)
+                        _mbar_wait(bar(_MBAR_K_FULL) + k_stage_now * _u32(8), k_phase_now)
+                        qk_chain(instance, k_stage_now)
+                K.assign(union_index_m, union_index_m + _i32(1))
+            dealloc_phase = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_TMEM_DEALLOC), dealloc_phase)
+            _flip(dealloc_phase)
+            taddr_dealloc = K.local_scalar("uint32")
+            K.ptx.ld.volatile.shared.b32(taddr_dealloc, bar(_SMEM_TMEM_MAILBOX))
+            K.ptx[_TMEM_DEALLOC](taddr_dealloc, _u32(TMEM_COLS))
+
+        # ---- Role: Q/mask/K producer (warp 13) ----
+        with r_qk_load:
+            kv_head = q_head
+            query_base = q_local_base
+            load_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            with K.If(load_leader != _u32(0)), K.Then():
+                _mbar_expect_tx(bar(_MBAR_Q_FULL), 32768)
+                K.ptx[_TMA_G2S_4D](
+                    bar(_SMEM_Q0),
+                    K.address_of(q_map),
+                    _i32(0),
+                    query_base,
+                    q_head,
+                    _i32(0),
+                    bar(_MBAR_Q_FULL),
+                )
+                K.ptx[_TMA_G2S_4D](
+                    bar(_SMEM_Q1),
+                    K.address_of(q_map),
+                    _i32(0),
+                    query_base + _i32(64),
+                    q_head,
+                    _i32(0),
+                    bar(_MBAR_Q_FULL),
+                )
+            q_block = query_base // 128
+            mask_base = (q_head * mb + q_block) * nb
+            selected_count = K.local_scalar("int32", init=_i32(0))
+            block_base = K.local_scalar("int32", init=_i32(0))
+            with K.While(block_base < nb):
+                n_block = block_base + lane
+                selected = K.local_scalar("int32", init=_i32(0))
+                with K.If(n_block < nb), K.Then():
+                    mask_byte = K.local_scalar("uint16")
+                    K.ptx.ld.global_.nc.b8(mask_byte, block_mask.ptr_to([mask_base + n_block]))
+                    K.assign(selected, K.cast(mask_byte != K.uint16(0), "int32"))
+                vote = K.local_scalar("uint32")
+                K.ptx.vote_sync.ballot.b32(
+                    vote, K.ptx.pred(K.cast(selected != _i32(0), "bool")), _u32(_FULL_MASK)
+                )
+                ballot_count = K.local_scalar("uint32")
+                K.ptx.popc.b32(ballot_count, vote)
+                lower_lanes = K.shift_left(_u32(1), K.cast(lane, "uint32")) - _u32(1)
+                lower_count = K.local_scalar("uint32")
+                K.ptx.popc.b32(lower_count, vote & lower_lanes)
+                selected_slot = selected_count + K.cast(lower_count, "int32")
+                with K.If(selected != _i32(0)), K.Then():
+                    slot_addr = bar(_SMEM_UNION_BLOCKS) + K.cast(selected_slot, "uint32") * _u32(4)
+                    K.ptx.st.shared.b32(slot_addr, n_block)
+                    K.ptx.st.shared.b32(slot_addr + _u32(MAX_SELECTED_BLOCKS * 4), n_block)
+                K.assign(selected_count, selected_count + K.cast(ballot_count, "int32"))
+                K.assign(block_base, block_base + _i32(32))
+            with K.If(selected_count == _i32(0)), K.Then():
+                with K.If(lane == 0), K.Then():
+                    K.ptx.st.shared.b32(bar(_SMEM_UNION_BLOCKS), _i32(0))
+                    K.ptx.st.shared.b32(bar(_SMEM_UNION_BLOCKS + MAX_SELECTED_BLOCKS * 4), _i32(0))
+                K.assign(selected_count, _i32(1))
+            with K.If(lane < 2), K.Then():
+                K.ptx.st.shared.b32(
+                    bar(_SMEM_UNION_COUNT) + K.cast(lane, "uint32") * _u32(4), selected_count
+                )
+            K.ptx.barrier.sync(8, 32)
+            K.ptx.fence.proxy.async_.shared__cta()
+            _mbar_arrive(bar(_MBAR_UNION_READY))
+
+            k_load_stage = K.local_scalar("uint32", init=_u32(0))
+            phase_k_empty = K.local_scalar("int32", init=_i32(1))
+            union_index_k = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_k < selected_blocks):
+                for instance in range(2):
+                    n_block_k = _ld_shared_i32(
+                        bar(_SMEM_UNION_BLOCKS + MAX_SELECTED_BLOCKS * 4 * instance)
+                        + K.cast(union_index_k, "uint32") * _u32(4)
+                    )
+                    token_base = n_block_k * 128
+                    _mbar_wait(bar(_MBAR_K_EMPTY) + k_load_stage * _u32(8), phase_k_empty)
+                    push_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    with K.If(push_leader != _u32(0)), K.Then():
+                        full_bar = bar(_MBAR_K_FULL) + k_load_stage * _u32(8)
+                        _mbar_expect_tx(full_bar, 32768)
+                        stage_addr = bar(_SMEM_K) + k_load_stage * _u32(_SMEM_STAGE_BYTES)
+                        token1 = token_base + _i32(64)
+                        for dim_half in range(2):
+                            for token_half, token in ((0, token_base), (1, token1)):
+                                K.ptx[_TMA_G2S_4D](
+                                    stage_addr + _u32(8192 * token_half + 16384 * dim_half),
+                                    K.address_of(k_map),
+                                    _i32(0),
+                                    token,
+                                    _i32(dim_half),
+                                    kv_head,
+                                    full_bar,
+                                )
+                    _advance_ring(k_load_stage, phase_k_empty, 3)
+                K.assign(union_index_k, union_index_k + _i32(1))
+
+        # ---- Role: V producer (warp 14) ----
+        with r_v_load:
+            union_ready_phase_v = K.local_scalar("int32", init=_i32(0))
+            _mbar_wait(bar(_MBAR_UNION_READY), union_ready_phase_v)
+            _flip(union_ready_phase_v)
+            kv_head_v = q_head
+            v_load_stage = K.local_scalar("uint32", init=_u32(0))
+            phase_v_empty = K.local_scalar("int32", init=_i32(1))
+            union_index_v = K.local_scalar("int32", init=_i32(0))
+            with K.While(union_index_v < selected_blocks):
+                for instance in range(2):
+                    n_block_v = _ld_shared_i32(
+                        bar(_SMEM_UNION_BLOCKS + MAX_SELECTED_BLOCKS * 4 * instance)
+                        + K.cast(union_index_v, "uint32") * _u32(4)
+                    )
+                    token_base_v = n_block_v * 128
+                    _mbar_wait(bar(_MBAR_V_EMPTY) + v_load_stage * _u32(8), phase_v_empty)
+                    push_leader_v = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    with K.If(push_leader_v != _u32(0)), K.Then():
+                        full_bar_v = bar(_MBAR_V_FULL) + v_load_stage * _u32(8)
+                        _mbar_expect_tx(full_bar_v, 32768)
+                        stage_addr_v = bar(_SMEM_V) + v_load_stage * _u32(_SMEM_STAGE_BYTES)
+                        token1_v = token_base_v + _i32(64)
+                        for dim_half in range(2):
+                            for token_half, token in ((0, token_base_v), (1, token1_v)):
+                                K.ptx[_TMA_G2S_4D](
+                                    stage_addr_v + _u32(8192 * token_half + 16384 * dim_half),
+                                    K.address_of(v_map),
+                                    _i32(0),
+                                    token,
+                                    _i32(dim_half),
+                                    kv_head_v,
+                                    full_bar_v,
+                                )
+                    _advance_ring(v_load_stage, phase_v_empty, 2)
+                K.assign(union_index_v, union_index_v + _i32(1))
+
+        # ---- Role: idle (warp 15) ----
+        with r_idle:
+            pass
+
+    return cake_vsa_longseq_sm103
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return _build_kernel()
+
+
+def get_kernel(**config: Any):
+    """Return the TIRx PrimFunc; the kernel is shape-generic at runtime."""
+    if config:
+        cfg = _without_label(config)
+        _validate_shape(cfg["M"], cfg["N"], cfg["num_heads"], cfg["selected"])
+    return _kernel().func
+
+
+@lru_cache(maxsize=1)
+def _compiled_kernel():
+    from tirx_kernels.runner import compile_kernel
+
+    # nvcc mode keeps the TIRx build on the CUDA toolkit on PATH (13.3, PTX ISA
+    # 9.3) -- the same toolchain the upstream ``nvcc -cubin`` build uses -- so
+    # both binaries share one PTX ISA for SASS and profiler comparisons.
+    # Match the native ptxas register-usage level. The narrow 48-register
+    # producer roles spill descriptor and uniform values at TVM level 10,
+    # default even though the source build has no local-memory traffic.
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = _PTXAS_REGISTER_USAGE_LEVEL
+    try:
+        return compile_kernel(get_kernel(), cuda_compile_mode="nvcc")
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
+def _tirx_args(data: dict[str, Any], slot: str = "tirx") -> tuple[Any, ...]:
+    buffers = data[slot]
+    return (
+        data["q"].view(-1),
+        data["k"].view(-1),
+        data["v"].view(-1),
+        buffers["out"].view(-1),
+        buffers["lse"].view(-1),
+        buffers["tlse"].view(-1),
+        data["block_mask_u8"].view(-1),
+        data["mb"],
+        data["nb"],
+        data["selected_blocks"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+    )
+
+
+def _tirx_launch(executable, data: dict[str, Any]):
+    arguments = _tirx_args(data)
+
+    def launch():
+        executable(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Upstream source kernel (the reference for correctness and benchmarks)
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=1)
+def _source_module():
+    """Build the upstream cubin + tvm-ffi launcher exactly as FlashInfer does."""
+    from flashinfer import cake_vsa
+
+    return cake_vsa._load_module(PROFILE, CUDA_ARCH)
+
+
+def _source_launch(data: dict[str, Any]):
+    """Replicate ``flashinfer.cake_vsa._run_standard`` for ``longseq``."""
+    import tvm_ffi
+
+    module = _source_module()
+    buffers = data["source"]
+    arguments = (
+        data["q"],
+        data["k"],
+        data["v"],
+        buffers["out"],
+        buffers["lse"],
+        buffers["tlse"],
+        data["block_mask_u8"],
+        data["mb"],
+        data["nb"],
+        data["selected_blocks"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+        data["mb"],
+        data["num_heads"],
+        1,
+    )
+
+    def launch():
+        with tvm_ffi.use_torch_stream():
+            module.run(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+def _run_public_api(data: dict[str, Any]):
+    """Run the upstream public API (``plan_cake_vsa`` + ``run_cake_vsa``)."""
+    import torch
+    from flashinfer import cake_vsa
+
+    plan = cake_vsa.plan_cake_vsa(
+        None,
+        None,
+        data["block_mask"],
+        None,
+        None,
+        None,
+        M=data["M"],
+        N=data["N"],
+        R=BLOCK,
+        C=BLOCK,
+        num_qo_heads=data["num_heads"],
+        num_kv_heads=data["num_heads"],
+        head_dim=HEAD_DIM,
+        q_data_type=torch.bfloat16,
+        sm_scale=data["sm_scale"],
+        device=data["q"].device,
+    )
+    if data["return_lse"]:
+        raise AssertionError("the public longseq route rejects return_lse")
+    if (
+        plan["N"] < 16384
+        or plan["num_qo_heads"] != 8
+        or not plan["uniform_selected_blocks"]
+        or plan["max_selected_blocks"] != data["selected_blocks"]
+        or plan["max_selected_blocks"] > MAX_SELECTED_BLOCKS
+    ):
+        raise AssertionError("public API plan does not satisfy the longseq route")
+    return cake_vsa.run_cake_vsa(
+        plan, data["q"], data["k"], data["v"], out=None, lse=None, return_lse=False, backend="cake"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fp64 sparse oracle and validation
+# ---------------------------------------------------------------------------
+def _bf16_order_key(values):
+    """Map bf16 bit patterns to monotonically ordered integers."""
+    import torch
+
+    bits = values.contiguous().view(torch.int16).to(torch.int32) & 0xFFFF
+    return torch.where(bits < 0x8000, bits + 0x8000, 0x8000 - (bits & 0x7FFF))
+
+
+def _assert_bitwise(name: str, ours, theirs) -> None:
+    if ours.dtype == theirs.dtype and ours.dtype.is_floating_point:
+        view_dtype = (
+            __import__("torch").int16 if ours.dtype.itemsize == 2 else __import__("torch").int32
+        )
+        ours_bits, theirs_bits = (
+            ours.contiguous().view(view_dtype),
+            theirs.contiguous().view(view_dtype),
+        )
+    else:
+        ours_bits, theirs_bits = ours, theirs
+    mismatch = ours_bits != theirs_bits
+    count = int(mismatch.sum())
+    if count:
+        index = int(mismatch.reshape(-1).nonzero()[0])
+        raise AssertionError(
+            f"{name}: {count} of {mismatch.numel()} elements differ bitwise "
+            f"(first flat index {index}: tirx={ours.reshape(-1)[index].item()!r}, "
+            f"source={theirs.reshape(-1)[index].item()!r})"
+        )
+
+
+def _assert_guards(name: str, buffers: dict[str, Any]) -> None:
+    expected = {"out": _OUT_GUARD, "lse": _STATS_GUARD, "tlse": _STATS_GUARD}
+    for key, storage in buffers["guards"].items():
+        guard = expected[key]
+        if not bool((storage[:_GUARD_ELEMS] == guard).all()):
+            raise AssertionError(f"{name}: {key} prefix guard was overwritten")
+        if not bool((storage[-_GUARD_ELEMS:] == guard).all()):
+            raise AssertionError(f"{name}: {key} suffix guard was overwritten")
+
+
+class _OracleStats:
+    def __init__(self, cfg: dict[str, Any], *, return_lse: bool, return_tlse: bool):
+        self.cfg = cfg
+        self.return_lse = return_lse
+        self.return_tlse = return_tlse
+        self.out_max_abs_err = 0.0
+        self.out_max_rel_excess = 0.0
+        self.out_max_err_small_ref = 0.0
+        self.out_max_rel_err_large_ref = 0.0
+        self.ulp_max = 0
+        self.ulp_total = 0
+        self.ulp_le1 = 0
+        self.ulp_le2 = 0
+        self.lse_max_abs_err = 0.0
+        self.lse_max_rel_excess = 0.0
+        self.tlse_max_abs_err = 0.0
+        self.tlse_max_rel_excess = 0.0
+
+    def update(self, out_bf16, lse, tlse, ref_out, ref_lse, ref_tlse) -> None:
+        cfg = self.cfg
+        out = out_bf16.double()
+        err = (out - ref_out).abs()
+        bound = cfg["oracle_atol"] + cfg["oracle_rtol"] * ref_out.abs()
+        self.out_max_abs_err = max(self.out_max_abs_err, float(err.max()))
+        self.out_max_rel_excess = max(self.out_max_rel_excess, float((err / bound).max()))
+        small = ref_out.abs() < _ORACLE_ULP_MIN_REF
+        large = ref_out.abs() >= 0.5
+        if bool(small.any()):
+            self.out_max_err_small_ref = max(self.out_max_err_small_ref, float(err[small].max()))
+        if bool(large.any()):
+            self.out_max_rel_err_large_ref = max(
+                self.out_max_rel_err_large_ref, float((err[large] / ref_out[large].abs()).max())
+            )
+        sizeable = ~small
+        if bool(sizeable.any()):
+            ulps = (_bf16_order_key(ref_out.to(out_bf16.dtype)) - _bf16_order_key(out_bf16)).abs()[
+                sizeable
+            ]
+            self.ulp_max = max(self.ulp_max, int(ulps.max()))
+            self.ulp_total += ulps.numel()
+            self.ulp_le1 += int((ulps <= 1).sum())
+            self.ulp_le2 += int((ulps <= 2).sum())
+        for flag, values, ref, attr in (
+            (self.return_lse, lse, ref_lse, "lse"),
+            (self.return_tlse, tlse, ref_tlse, "tlse"),
+        ):
+            if not flag:
+                continue
+            stat_err = (values.double() - ref).abs()
+            stat_bound = cfg["oracle_lse_atol"] + cfg["oracle_lse_rtol"] * ref.abs()
+            setattr(
+                self,
+                f"{attr}_max_abs_err",
+                max(getattr(self, f"{attr}_max_abs_err"), float(stat_err.max())),
+            )
+            setattr(
+                self,
+                f"{attr}_max_rel_excess",
+                max(getattr(self, f"{attr}_max_rel_excess"), float((stat_err / stat_bound).max())),
+            )
+
+    def check(self, name: str, stats: dict[str, float]) -> None:
+        cfg = self.cfg
+        stats[f"{name}_out_max_abs_err"] = self.out_max_abs_err
+        stats[f"{name}_out_max_rel_excess"] = self.out_max_rel_excess
+        stats[f"{name}_out_max_err_small_ref"] = self.out_max_err_small_ref
+        stats[f"{name}_out_max_rel_err_large_ref"] = self.out_max_rel_err_large_ref
+        if self.out_max_rel_excess > 1.0:
+            raise AssertionError(
+                f"{name}: out mismatch vs fp64 oracle (max abs "
+                f"{self.out_max_abs_err:.3e}, max err/bound "
+                f"{self.out_max_rel_excess:.3f})"
+            )
+        if self.ulp_total:
+            le1 = self.ulp_le1 / self.ulp_total
+            le2 = self.ulp_le2 / self.ulp_total
+            stats[f"{name}_out_ulp_max"] = float(self.ulp_max)
+            stats[f"{name}_out_ulp_le1_frac"] = le1
+            stats[f"{name}_out_ulp_le2_frac"] = le2
+            if (
+                self.ulp_max > cfg["ulp_max"]
+                or le1 < cfg["ulp_le1_frac"]
+                or le2 < cfg["ulp_le2_frac"]
+            ):
+                raise AssertionError(
+                    f"{name}: bf16 ULP distribution vs fp64 oracle too wide "
+                    f"(max {self.ulp_max}, <=1 {le1:.6f}, <=2 {le2:.6f})"
+                )
+        for flag, attr in ((self.return_lse, "lse"), (self.return_tlse, "tlse")):
+            if not flag:
+                continue
+            max_abs = getattr(self, f"{attr}_max_abs_err")
+            excess = getattr(self, f"{attr}_max_rel_excess")
+            stats[f"{name}_{attr}_max_abs_err"] = max_abs
+            stats[f"{name}_{attr}_max_rel_excess"] = excess
+            if excess > 1.0:
+                raise AssertionError(
+                    f"{name}: {attr} mismatch vs fp64 oracle "
+                    f"(max abs {max_abs:.3e}, max err/bound {excess:.3f})"
+                )
+
+
+def _oracle_chunk(data: dict[str, Any], t0: int, t1: int):
+    """Block-gather fp64 reference for query tiles [t0, t1)."""
+    import torch
+
+    T = t1 - t0
+    H, S = data["num_heads"], data["selected_blocks"]
+    nb = data["nb"]
+    idx = data["selected_indices"][t0:t1].to(device=data["q"].device, dtype=torch.int64)
+    heads = torch.arange(H, device=data["q"].device)[None, :, None]
+    q = data["q"][t0 * BLOCK : t1 * BLOCK].double().view(T, BLOCK, H, HEAD_DIM)
+    q = q.permute(0, 2, 1, 3)
+    k_by_head = data["k"].view(nb, BLOCK, H, HEAD_DIM).permute(2, 0, 1, 3)
+    v_by_head = data["v"].view(nb, BLOCK, H, HEAD_DIM).permute(2, 0, 1, 3)
+    k_g = k_by_head[heads, idx].reshape(T, H, S * BLOCK, HEAD_DIM).double()
+    v_g = v_by_head[heads, idx].reshape(T, H, S * BLOCK, HEAD_DIM).double()
+    scores = torch.matmul(q, k_g.transpose(-1, -2)) * data["sm_scale"]
+    ref_lse = torch.logsumexp(scores, dim=-1)
+    ref_tlse = torch.logsumexp(scores * data["lse_temperature_scale"], dim=-1)
+    probs = torch.softmax(scores, dim=-1)
+    ref_out = torch.matmul(probs, v_g)
+    return ref_out, ref_lse, ref_tlse
+
+
+def _validate_outputs(data: dict[str, Any], *, with_oracle: bool) -> dict[str, float]:
+    import torch
+
+    tirx, source = data["tirx"], data["source"]
+    return_lse = data["return_lse"]
+    return_tlse = data["return_temperature_lse"]
+    for name, buffers in (("tirx", tirx), ("source", source)):
+        _assert_guards(name, buffers)
+        if not torch.isfinite(buffers["out"].float()).all():
+            raise AssertionError(f"{name}: non-finite values in out")
+        if return_lse and not torch.isfinite(buffers["lse"]).all():
+            raise AssertionError(f"{name}: non-finite values in lse")
+        if return_tlse and not torch.isfinite(buffers["tlse"]).all():
+            raise AssertionError(f"{name}: non-finite values in temperature lse")
+        if not return_lse and not bool((buffers["lse"] == _LSE_SENTINEL).all()):
+            raise AssertionError(f"{name}: lse sentinel overwritten with return_lse=0")
+
+    _assert_bitwise("out", tirx["out"], source["out"])
+    _assert_bitwise("lse", tirx["lse"], source["lse"])
+    if return_tlse:
+        _assert_bitwise("temperature_lse", tirx["tlse"], source["tlse"])
+
+    stats: dict[str, float] = {}
+    if not with_oracle:
+        return stats
+    trackers = {
+        name: _OracleStats(data["config"], return_lse=return_lse, return_tlse=return_tlse)
+        for name in ("tirx", "source")
+    }
+    mb, H = data["mb"], data["num_heads"]
+    for t0 in range(0, mb, _ORACLE_TILES_PER_CHUNK):
+        t1 = min(mb, t0 + _ORACLE_TILES_PER_CHUNK)
+        ref_out, ref_lse, ref_tlse = _oracle_chunk(data, t0, t1)
+        T = t1 - t0
+        for name, buffers in (("tirx", tirx), ("source", source)):
+            out = buffers["out"][t0 * BLOCK : t1 * BLOCK].view(T, BLOCK, H, HEAD_DIM)
+            out = out.permute(0, 2, 1, 3)
+            lse = (
+                buffers["lse"][t0 * BLOCK : t1 * BLOCK].view(T, BLOCK, H).permute(0, 2, 1)
+                if return_lse
+                else None
+            )
+            tlse = (
+                buffers["tlse"][t0 * BLOCK : t1 * BLOCK].view(T, BLOCK, H).permute(0, 2, 1)
+                if return_tlse
+                else None
+            )
+            trackers[name].update(out, lse, tlse, ref_out, ref_lse, ref_tlse)
+    for name, tracker in trackers.items():
+        tracker.check(name, stats)
+    return stats
+
+
+def _skip_unless_supported() -> None:
+    from unittest import SkipTest
+
+    import torch
+
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA device required")
+    if torch.cuda.get_device_capability() != (10, 3):
+        raise SkipTest("cake_vsa longseq sm_103a requires compute capability 10.3")
+
+
+def _assert_inputs_unchanged(data: dict[str, Any], snapshots: dict[str, Any]) -> None:
+    import torch
+
+    for name, before in snapshots.items():
+        if not torch.equal(data[name], before):
+            raise AssertionError(f"input {name} was modified by a kernel launch")
+
+
+def run_test(**config: Any) -> dict[str, float]:
+    """Run one config against source, fp64 oracle, guards, and determinism checks."""
+    import torch
+
+    _skip_unless_supported()
+    data = prepare_data(**config)
+    snapshots = {name: data[name].clone() for name in ("q", "k", "v", "block_mask")}
+    tirx_launch = _tirx_launch(_compiled_kernel(), data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    first = {key: data["tirx"][key].clone() for key in ("out", "lse", "tlse")}
+
+    source_launch = _source_launch(data)
+    source_launch()
+    torch.cuda.synchronize()
+    stats = _validate_outputs(data, with_oracle=True)
+    _assert_inputs_unchanged(data, snapshots)
+
+    tirx_launch()
+    torch.cuda.synchronize()
+    for key in ("out", "lse", "tlse"):
+        _assert_bitwise(f"{key} (repeat launch)", data["tirx"][key], first[key])
+    _assert_guards("tirx repeat", data["tirx"])
+    _assert_inputs_unchanged(data, snapshots)
+
+    if data["config"]["pattern"] == "upstream":
+        api_out = _run_public_api(data)
+        _assert_bitwise("out (public API)", data["tirx"]["out"], api_out)
+        _assert_inputs_unchanged(data, snapshots)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points
+# ---------------------------------------------------------------------------
+def prepare_bench(**config: Any):
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    _validate_shape(
+        kernel_config["M"],
+        kernel_config["N"],
+        kernel_config["num_heads"],
+        kernel_config["selected"],
+    )
+    state = {"config": kernel_config, "executable": _compiled_kernel()}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = _without_label({**prepared["config"], **kwargs})
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**config)
+        gpu_state = {
+            "data": data,
+            "tirx_launch": _tirx_launch(prepared["executable"], data),
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    if not gpu_state["validated"]:
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                source_launch = _source_launch(data)
+                gpu_state["source_launch"] = source_launch
+                source_launch()
+                torch.cuda.synchronize()
+            _validate_outputs(data, with_oracle=False)
+        gpu_state["validated"] = True
+
+    source_launch = gpu_state["source_launch"]
+    references = {"flashinfer": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config: Any):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py
+++ b/tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py
@@ -1,0 +1,1782 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ c5365737), Copyright (c) 2026 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Cake VSA ``ultrasparse_bsr`` block-sparse attention forward for SM100a.
+
+Upstream sources (FlashInfer @ c5365737570a2a156d7cae0c4070fa3770ecc670):
+
+- ``csrc/cake_vsa/cake_vsa_ultrasparse_bsr_sm_100a.cu`` -- the device kernel
+  ``kernel_flashinfer_blackwell_vsa_ultrasparse_bsr_sm100`` (Cake source export,
+  last changed by upstream commit adc49a85, "perf(cake_vsa): refresh Blackwell
+  block-sparse WS kernel (#4804)").
+- ``csrc/cake_vsa/cake_vsa_ultrasparse_bsr_host.cpp`` -- the tvm-ffi launcher
+  that encodes the three 4-D SWIZZLE_128B tensor maps, requires exactly six
+  selected blocks per query block and ``total_tiles == mb * num_q_heads``, and
+  launches 512 threads with 135424 bytes of dynamic SMEM.
+- ``flashinfer/cake_vsa.py`` -- ``plan_cake_vsa``/``run_cake_vsa`` dispatch.
+  The ``ultrasparse_bsr`` profile is the route for bf16, head_dim 128, R = C =
+  128, ``num_qo_heads == num_kv_heads == 8``, at least 625 query blocks, one BSR
+  pattern shared by all heads with exactly six blocks in every row, and
+  ``return_lse=False``; it launches ``grid = (min(mb * 8, SM count), 1, 1)``.
+
+Kernel structure (persistent: every CTA walks ``tile_idx = blockIdx.x; tile_idx <
+total_tiles; tile_idx += gridDim.x`` with ``q_tile = tile_idx % mb`` and
+``q_head = tile_idx / mb``):
+
+- warp 15 waits for the previous tile's epilogue, loads the 128-row Q tile with
+  one 32 KB TMA transaction, copies the six BSR column indices of the query block
+  into shared memory, then streams K and V tiles through a three-stage 32 KB
+  SMEM ring in the order K5 K4 V5 K3 V4 K2 V3 K1 V2 K0 V1 V0;
+- warp 12 issues every ``tcgen05.mma.cta_group::1.kind::f16``: eight K=16
+  steps for ``S_i = Q K^T`` (M=128, N=128) per instance into TMEM, then eight
+  steps for ``O_i += P_i V`` with P read from TMEM;
+- warps 0-7 form two four-warp softmax instances that both own all 128 query
+  rows and alternate over the six KV blocks (instance i handles blocks
+  5-i, 3-i, 1-i): each thread reads its full 128-column fp32 score row from
+  TMEM, applies the ``2^-8`` rescale-skip decision, writes bf16 P back in place
+  and keeps per-row running max and sum;
+- warps 8-11 rescale the TMEM O accumulator of an instance when a warp vote says
+  any row needs it, then merge the two instances' accumulators and statistics
+  (combine scales and one reciprocal), store bf16 output rows and, when
+  requested, the natural-log LSE (also duplicated into ``temperature_lse``).
+
+Every SMEM object lives in one rank-one byte arena addressed by explicit scalar
+offsets; no first-class layouts or tile primitives are used.
+"""
+
+import math
+from functools import lru_cache
+from typing import Any
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "cake_vsa_ultrasparse_bsr_sm100",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "c5365737570a2a156d7cae0c4070fa3770ecc670",
+            },
+            "import": "flashinfer",
+        },
+    ),
+}
+# The upstream kernel is a prebuilt cubin loaded through FlashInfer's own tvm-ffi
+# launcher (``flashinfer.cake_vsa._load_module``); tvm-ffi is a dependency of
+# flashinfer-python itself, so only FlashInfer is pinned.
+
+# ---------------------------------------------------------------------------
+# Source contract constants (host.cpp / cake_vsa.py / the device kernel).
+# ---------------------------------------------------------------------------
+HEAD_DIM = 128
+BLOCK = 128  # R == C == 128 query/KV block size of this profile
+SELECTED_BLOCKS = 6  # host.cpp: selected_blocks must equal 6
+NUM_HEADS = 8  # cake_vsa.py: num_qo_heads == num_kv_heads == 8 on this route
+MIN_QUERY_BLOCKS = 625  # cake_vsa.py: mb >= 625 on this route
+THREADS = 512
+NUM_WARPS = THREADS // 32
+SMEM_TOTAL = 135424
+TMEM_COLS = 512
+PROFILE = "ultrasparse_bsr"
+CUDA_ARCH = "sm_100a"
+_LN2 = math.log(2.0)
+
+# ``lse`` sentinel used when the caller does not request LSE: upstream passes a
+# one-element ``stats`` tensor that the kernel must leave untouched.
+_LSE_SENTINEL = 12345.25
+
+# Oracle tolerances (fp64 block-gather reference), frozen from the errors measured
+# on GB200 across CONFIGS with a 1.25-1.6x margin (the TIRx-vs-source comparison is
+# bitwise, so both implementations carry the same algorithmic error: bf16 P and
+# output rounding, ``ex2.approx``/``rcp.approx``/``lg2.approx``).  Measured worst
+# cases: out error/bound 0.79 (m81920_n131072 unsorted), bf16 ULP max 2 with
+# >= 0.9999996 of the sizeable elements within 1 ULP, LSE abs error 1.1e-6.
+# ``max_rel_excess`` in the returned stats is the worst error / (atol + rtol*|ref|)
+# ratio.  The bf16 ULP checks apply to |ref| >= 0.125, where one ULP is at least 2^-10.
+_ORACLE_OUT_ATOL = 1.5e-3
+_ORACLE_OUT_RTOL = 6e-3
+_ORACLE_LSE_ATOL = 6e-7
+_ORACLE_LSE_RTOL = 1.5e-7
+_ORACLE_ULP_MAX = 2
+_ORACLE_ULP_LE1_FRAC = 0.9999
+_ORACLE_ULP_LE2_FRAC = 1.0
+_ORACLE_ULP_MIN_REF = 0.125
+_ORACLE_TILES_PER_CHUNK = 16
+
+# Per-band K amplification of the ``kramp`` pattern, indexed by band (= slot).
+# Slots 5,4 are consumed first (pair 0), then 3,2, then 1,0, so the running max
+# grows by more than 2^8 (in the exp2 domain) at every pair boundary.
+_KRAMP_BAND_AMPS = (4.0, 4.0, 2.0, 2.0, 1.0, 1.0)
+
+
+def _config(
+    label: str,
+    *,
+    M: int,
+    N: int,
+    pattern: str,
+    return_lse: bool = False,
+    return_temperature_lse: bool = False,
+    q_amp: float = 1.0,
+    sm_scale: float | None = None,
+    lse_temperature_scale: float = 1.0,
+    api_check: str | None = "block_mask",
+    seed: int = 0,
+    oracle_atol: float = _ORACLE_OUT_ATOL,
+    oracle_rtol: float = _ORACLE_OUT_RTOL,
+    oracle_lse_atol: float = _ORACLE_LSE_ATOL,
+    oracle_lse_rtol: float = _ORACLE_LSE_RTOL,
+    ulp_max: int = _ORACLE_ULP_MAX,
+    ulp_le1_frac: float = _ORACLE_ULP_LE1_FRAC,
+    ulp_le2_frac: float = _ORACLE_ULP_LE2_FRAC,
+) -> dict[str, Any]:
+    return {
+        "label": label,
+        "M": M,
+        "N": N,
+        "pattern": pattern,
+        "return_lse": return_lse,
+        "return_temperature_lse": return_temperature_lse,
+        "q_amp": q_amp,
+        "sm_scale": sm_scale,
+        "lse_temperature_scale": lse_temperature_scale,
+        "api_check": api_check,
+        "seed": seed,
+        "oracle_atol": oracle_atol,
+        "oracle_rtol": oracle_rtol,
+        "oracle_lse_atol": oracle_lse_atol,
+        "oracle_lse_rtol": oracle_lse_rtol,
+        "ulp_max": ulp_max,
+        "ulp_le1_frac": ulp_le1_frac,
+        "ulp_le2_frac": ulp_le2_frac,
+    }
+
+
+# Correctness matrix.  Every row stays inside the ``ultrasparse_bsr`` dispatch
+# domain (asserted by ``_assert_ultrasparse_route``): 8 heads, at least 625 query
+# blocks, exactly six distinct KV blocks per query block shared by all heads.  The
+# public API refuses ``return_lse`` on this route; the device kernel implements the
+# LSE and temperature-LSE stores, which the direct launch exercises.
+CONFIGS = [
+    # 5000 tiles over 152 CTAs: 136 CTAs run 33 tiles, 16 run 32 (uneven persistent
+    # tail; barrier phases live across 33 tiles).  No LSE: the sentinel must survive.
+    _config("m80000_n8192_h8_sel6_tail", M=80000, N=8192, pattern="random_sorted", seed=0),
+    # nb == 6: every KV block is selected (K5..K0 covers the whole sequence); 627 query
+    # blocks give exactly 33 tiles per CTA.  Kernel-ABI LSE store.
+    _config(
+        "m80256_n768_h8_sel6_dense_lse", M=80256, N=768, pattern="dense6", return_lse=True, seed=1
+    ),
+    # 1024 KV blocks (token coordinates up to 131071) in caller order (unsorted per
+    # row), handed to the public API through its trusted indptr/indices path.
+    _config(
+        "m81920_n131072_h8_sel6_unsorted",
+        M=81920,
+        N=131072,
+        pattern="random_unsorted",
+        api_check="indices",
+        seed=2,
+    ),
+    # Banded pattern with K rows amplified per band (x4, x4, x2, x2, x1, x1) and Q
+    # amplified x4: the running max grows by far more than 2^8 in pairs 1 and 2 on
+    # every row, so the O-rescale branch, the warp vote and unequal combine scales
+    # all execute.  Skipped rescales leave bf16 P values up to 2^8, so this regime
+    # carries a larger inherent error than the default tolerance (measured: error/bound
+    # 0.76, ULP max 7, 0.99962 within 1 ULP, 0.999982 within 2 ULP).
+    _config(
+        "m80000_n4096_h8_sel6_kramp",
+        M=80000,
+        N=4096,
+        pattern="kramp",
+        q_amp=4.0,
+        seed=3,
+        oracle_atol=6.5e-3,
+        oracle_rtol=1e-2,
+        ulp_max=8,
+        ulp_le1_frac=0.9995,
+        ulp_le2_frac=0.9998,
+    ),
+    # 8192 tiles (54 waves) with six consecutive blocks around the diagonal:
+    # adjacent persistent tiles reuse K/V.
+    _config("m131072_n32768_h8_sel6_window", M=131072, N=32768, pattern="window", seed=4),
+    # Blocks 0 and nb-1 always selected (first/last TMA coordinates); both LSE flags
+    # with two distinct full-size buffers (the kernel writes the same value to both).
+    _config(
+        "m80000_n1024_h8_sel6_edges_bothlse",
+        M=80000,
+        N=1024,
+        pattern="edges",
+        return_lse=True,
+        return_temperature_lse=True,
+        seed=5,
+    ),
+]
+
+# Benchmark matrix (no LSE; the upstream Python path never requests it here).
+BENCH_CONFIGS = [
+    _config("m80000_n8192_h8_sel6", M=80000, N=8192, pattern="random_sorted", seed=100),
+    _config("m131072_n32768_h8_sel6", M=131072, N=32768, pattern="random_sorted", seed=101),
+    _config("m262144_n131072_h8_sel6", M=262144, N=131072, pattern="random_sorted", seed=102),
+    _config("m80256_n768_h8_sel6_dense", M=80256, N=768, pattern="dense6", seed=103),
+    _config("m131072_n16384_h8_sel6_window", M=131072, N=16384, pattern="window", seed=104),
+    _config("m80000_n4096_h8_sel6_kramp", M=80000, N=4096, pattern="kramp", q_amp=4.0, seed=105),
+]
+
+
+def _without_label(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in config.items() if key != "label"}
+
+
+def _validate_shape(M: int, N: int) -> tuple[int, int]:
+    if M <= 0 or M % BLOCK != 0:
+        raise ValueError(f"M={M} must be a positive multiple of {BLOCK}")
+    if N <= 0 or N % BLOCK != 0:
+        raise ValueError(f"N={N} must be a positive multiple of {BLOCK}")
+    mb, nb = M // BLOCK, N // BLOCK
+    if nb < SELECTED_BLOCKS:
+        raise ValueError(f"N={N} has {nb} KV blocks; the route selects {SELECTED_BLOCKS} per row")
+    return mb, nb
+
+
+def _assert_ultrasparse_route(indices, *, mb: int, nb: int) -> None:
+    """Re-evaluate the upstream ``run_cake_vsa`` dispatch predicates for this pattern.
+
+    bf16, D=128, R=C=128 and eight MHA heads are fixed by this module.  The route
+    is taken when ``mb >= 625``, the BSR pattern is shared by all heads (true by
+    construction: one ``(mb, 6)`` index table) and every row selects exactly six
+    distinct blocks.
+    """
+    if mb < MIN_QUERY_BLOCKS:
+        raise ValueError(f"mb={mb} < {MIN_QUERY_BLOCKS}: shape would dispatch to blk128_compact")
+    if tuple(indices.shape) != (mb, SELECTED_BLOCKS):
+        raise ValueError(f"indices must be ({mb}, {SELECTED_BLOCKS}), got {tuple(indices.shape)}")
+    if int(indices.min()) < 0 or int(indices.max()) >= nb:
+        raise ValueError("BSR column index out of range")
+    sorted_rows = indices.sort(dim=1).values
+    if bool((sorted_rows[:, 1:] == sorted_rows[:, :-1]).any()):
+        raise ValueError("a row selects a KV block twice; the route needs six distinct blocks")
+
+
+def _make_bsr(*, mb: int, nb: int, pattern: str, generator):
+    """Build the ``(mb, 6)`` int32 table of selected KV blocks in kernel order."""
+    import torch
+
+    if pattern == "dense6":
+        if nb != SELECTED_BLOCKS:
+            raise ValueError("pattern 'dense6' needs exactly six KV blocks")
+        return torch.arange(SELECTED_BLOCKS, dtype=torch.int32).repeat(mb, 1)
+    if pattern in {"random_sorted", "random_unsorted"}:
+        rows = torch.stack(
+            [torch.randperm(nb, generator=generator)[:SELECTED_BLOCKS] for _ in range(mb)]
+        )
+        if pattern == "random_sorted":
+            rows = rows.sort(dim=1).values
+        elif bool((rows[:, 1:] > rows[:, :-1]).all(dim=1).all()):
+            raise ValueError("pattern 'random_unsorted' produced only sorted rows")
+        return rows.to(torch.int32)
+    if pattern == "kramp":
+        # Slot p picks one block inside band p; bands are six equal ranges of blocks.
+        edges = [nb * p // SELECTED_BLOCKS for p in range(SELECTED_BLOCKS + 1)]
+        columns = []
+        for p in range(SELECTED_BLOCKS):
+            lo, hi = edges[p], edges[p + 1]
+            if hi <= lo:
+                raise ValueError("pattern 'kramp' needs at least six KV blocks")
+            columns.append(lo + torch.randint(0, hi - lo, (mb,), generator=generator))
+        return torch.stack(columns, dim=1).to(torch.int32)
+    if pattern == "window":
+        centre = (torch.arange(mb) * nb) // mb
+        start = (centre - SELECTED_BLOCKS // 2).clamp(0, nb - SELECTED_BLOCKS)
+        return (start.unsqueeze(1) + torch.arange(SELECTED_BLOCKS)).to(torch.int32)
+    if pattern == "edges":
+        if nb < SELECTED_BLOCKS + 2:
+            raise ValueError("pattern 'edges' needs interior blocks to choose from")
+        rows = []
+        for _ in range(mb):
+            interior = 1 + torch.randperm(nb - 2, generator=generator)[: SELECTED_BLOCKS - 2]
+            rows.append(torch.cat([torch.tensor([0, nb - 1]), interior]).sort().values)
+        return torch.stack(rows).to(torch.int32)
+    raise ValueError(f"unknown BSR pattern {pattern!r}")
+
+
+def _kramp_row_amps(nb: int):
+    """Per-KV-token amplification of the ``kramp`` pattern (band of block b = b*6//nb)."""
+    import torch
+
+    band = (torch.arange(nb) * SELECTED_BLOCKS) // nb
+    amps = torch.tensor(_KRAMP_BAND_AMPS, dtype=torch.float32)[band]
+    return amps.repeat_interleave(BLOCK)  # (N,)
+
+
+def _driver_sm_count() -> int | None:
+    """SM count of device 0 through the CUDA driver API (no runtime context is created)."""
+    import ctypes
+
+    try:
+        lib = ctypes.CDLL("libcuda.so.1")
+    except OSError:
+        return None
+    if lib.cuInit(0) != 0:
+        return None
+    device = ctypes.c_int()
+    if lib.cuDeviceGet(ctypes.byref(device), 0) != 0:
+        return None
+    value = ctypes.c_int()
+    # CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT == 16
+    if lib.cuDeviceGetAttribute(ctypes.byref(value), 16, device) != 0:
+        return None
+    return int(value.value)
+
+
+def _sm_count() -> int:
+    """The ``multi_processor_count`` the upstream host uses for ``grid_x``.
+
+    The bench suite's CPU prepare must not initialise CUDA, so the repository's
+    ``hardware_num_sms`` (environment-provided compile profile, or torch once it is
+    initialised) is consulted first; outside the suite the driver API answers.
+    """
+    import os
+    import sys
+
+    from tirx_kernels.runner import PREPARE_NUM_SMS_ENV, hardware_num_sms
+
+    torch = sys.modules.get("torch")
+    if os.environ.get(PREPARE_NUM_SMS_ENV) is not None or (
+        torch is not None and torch.cuda.is_initialized()
+    ):
+        return hardware_num_sms()
+    count = _driver_sm_count()
+    return count if count else hardware_num_sms()
+
+
+def _grid_x(total_tiles: int) -> int:
+    """``min(total_tiles, sm_count)`` persistent CTAs, as ``_run_standard`` launches."""
+    return min(total_tiles, _sm_count())
+
+
+def prepare_data(**config: Any) -> dict[str, Any]:
+    """Allocate logical inputs plus independent TIRx and source output buffers."""
+    import torch
+
+    config = _without_label(config)
+    M, N = config["M"], config["N"]
+    mb, nb = _validate_shape(M, N)
+    num_heads = NUM_HEADS
+    return_lse = bool(config["return_lse"])
+    return_tlse = bool(config["return_temperature_lse"])
+    sm_scale = config["sm_scale"]
+    if sm_scale is None:
+        sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    generator = torch.Generator().manual_seed(int(config["seed"]))
+    device = torch.device("cuda")
+
+    q = torch.randn((M, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    q = (q * float(config["q_amp"])).to(torch.bfloat16).to(device)
+    k = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    if config["pattern"] == "kramp":
+        k = k * _kramp_row_amps(nb).view(N, 1, 1)
+    k = k.to(torch.bfloat16).to(device)
+    v = torch.randn((N, num_heads, HEAD_DIM), generator=generator, dtype=torch.float32)
+    v = v.to(torch.bfloat16).to(device)
+    indices = _make_bsr(mb=mb, nb=nb, pattern=config["pattern"], generator=generator)
+    _assert_ultrasparse_route(indices, mb=mb, nb=nb)
+    bsr_indices = indices.contiguous().to(device)
+    total_tiles = mb * num_heads
+
+    def outputs() -> dict[str, Any]:
+        out = torch.full(
+            (M, num_heads, HEAD_DIM), float("nan"), dtype=torch.bfloat16, device=device
+        )
+        if return_lse:
+            lse = torch.full((M, num_heads), float("nan"), dtype=torch.float32, device=device)
+        else:
+            lse = torch.full((1,), _LSE_SENTINEL, dtype=torch.float32, device=device)
+        if return_tlse:
+            tlse = torch.full((M, num_heads), float("nan"), dtype=torch.float32, device=device)
+        else:
+            tlse = lse  # upstream passes the same ``stats`` tensor for both slots
+        return {"out": out, "lse": lse, "tlse": tlse}
+
+    return {
+        "config": config,
+        "M": M,
+        "N": N,
+        "num_heads": num_heads,
+        "mb": mb,
+        "nb": nb,
+        "total_tiles": total_tiles,
+        "grid_x": _grid_x(total_tiles),
+        "q": q,
+        "k": k,
+        "v": v,
+        "bsr_indices": bsr_indices,
+        "sm_scale": float(sm_scale),
+        "softmax_scale_log2": float(sm_scale) / _LN2,
+        "lse_temperature_scale": float(config["lse_temperature_scale"]),
+        "return_lse": return_lse,
+        "return_temperature_lse": return_tlse,
+        "tirx": outputs(),
+        "source": outputs(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# TIRx kernel
+# ---------------------------------------------------------------------------
+# cuTensorMapEncodeTiled enum values (CUtensorMapInterleave / Swizzle /
+# L2promotion / FloatOOBfill) as used by the upstream host launcher.
+_TMA_INTERLEAVE_NONE = 0
+_TMA_SWIZZLE_128B = 3
+_TMA_L2_PROMOTION_NONE = 0
+_TMA_OOB_FILL_NONE = 0
+
+
+def _host_prelude(params):
+    """Encode the three upstream tensor maps from the runtime shape scalars.
+
+    Mirrors ``EncodeTma_q`` / ``EncodeTma_k`` / ``EncodeTma_v`` in the upstream
+    host launcher: rank-4 bf16 maps, 128-byte swizzle, no L2 promotion, no OOB
+    fill.  Q is ``{64, M, Hq, 2}`` with a ``{64, 128, 1, 2}`` box (one 32 KB
+    transaction covers both head-dim halves of the 128-row tile); K and V are
+    ``{64, N, 2, Hkv}`` with a ``{64, 64, 1, 1}`` box (8 KB per transaction).
+    """
+    mb = params["mb"]
+    nb = params["nb"]
+    num_q_heads = params["num_q_heads"]
+    num_kv_heads = params["num_kv_heads"]
+    elem_bytes = 2
+
+    def encode(tensor, dims, strides_bytes, box):
+        descriptor = K.stack_alloca("tensormap", 1)
+        K.call_packed(
+            "runtime.cuTensorMapEncodeTiled",
+            descriptor,
+            "bfloat16",
+            4,
+            tensor.data,
+            *dims,
+            *strides_bytes,
+            *box,
+            1,
+            1,
+            1,
+            1,
+            _TMA_INTERLEAVE_NONE,
+            _TMA_SWIZZLE_128B,
+            _TMA_L2_PROMOTION_NONE,
+            _TMA_OOB_FILL_NONE,
+        )
+        return descriptor
+
+    q_map = encode(
+        params["q"],
+        (64, mb * BLOCK, num_q_heads, HEAD_DIM // 64),
+        (num_q_heads * HEAD_DIM * elem_bytes, HEAD_DIM * elem_bytes, 64 * elem_bytes),
+        (64, BLOCK, 1, HEAD_DIM // 64),
+    )
+    kv_dims = (64, nb * BLOCK, HEAD_DIM // 64, num_kv_heads)
+    kv_strides = (num_kv_heads * HEAD_DIM * elem_bytes, 64 * elem_bytes, HEAD_DIM * elem_bytes)
+    kv_box = (64, 64, 1, 1)
+    k_map = encode(params["k"], kv_dims, kv_strides, kv_box)
+    v_map = encode(params["v"], kv_dims, kv_strides, kv_box)
+    return (q_map, k_map, v_map)
+
+
+# Byte offsets inside the 135424-byte dynamic SMEM arena (source macro table).
+_MBAR_Q_FULL = 0
+_MBAR_Q_EMPTY = 8
+_MBAR_UNION_READY = 16
+_MBAR_KV_FULL = 24  # 3 stages
+_MBAR_KV_EMPTY = 48  # 3 stages
+_MBAR_S_FULL = 72  # 2 instances
+_MBAR_P_FULL = 88  # 2 instances
+_MBAR_CORR_SIG = 104  # 2 instances
+_MBAR_CORR_DONE = 120  # 2 instances
+_MBAR_O_FULL = 136  # 2 instances
+_MBAR_TILE_DONE = 152
+_SMEM_TMEM_MAILBOX = 160
+_SMEM_Q = 1024  # 128 rows x 128: two 16 KB dim halves
+_SMEM_KV = 33792  # 3 x 32768, K and V share the ring
+_SMEM_KV_STAGE_BYTES = 32768
+_SMEM_SCALE = 132096  # 768 f32: acc_scale[256] / row_sum[256] / row_max[256]
+_SMEM_UNION_BLOCKS = 135172  # the six selected KV block indices of the tile
+# (offset, arrival count) in source order: q_full, q_empty, union_ready, kv_full x3,
+# kv_empty x3, s_full x2, p_full x2, corr_sig x2, corr_done x2, o_full x2, tile_done.
+_MBARRIER_INIT = (
+    (_MBAR_Q_FULL, 1),
+    (_MBAR_Q_EMPTY, 128),
+    (_MBAR_UNION_READY, 32),
+    (_MBAR_KV_FULL, 1),
+    (_MBAR_KV_FULL + 8, 1),
+    (_MBAR_KV_FULL + 16, 1),
+    (_MBAR_KV_EMPTY, 1),
+    (_MBAR_KV_EMPTY + 8, 1),
+    (_MBAR_KV_EMPTY + 16, 1),
+    (_MBAR_S_FULL, 1),
+    (_MBAR_S_FULL + 8, 1),
+    (_MBAR_P_FULL, 256),
+    (_MBAR_P_FULL + 8, 256),
+    (_MBAR_CORR_SIG, 128),
+    (_MBAR_CORR_SIG + 8, 128),
+    (_MBAR_CORR_DONE, 128),
+    (_MBAR_CORR_DONE + 8, 128),
+    (_MBAR_O_FULL, 1),
+    (_MBAR_O_FULL + 8, 1),
+    (_MBAR_TILE_DONE, 128),
+)
+# TMEM column bases per softmax instance: S (128 columns; P overwrites the upper 64
+# in place) and the O accumulator (128 columns).
+_TMEM_SCORES = (0, 128)
+_TMEM_OUTPUT = (256, 384)
+_TMEM_P_OFFSET = 64
+# UMMA descriptor words and instruction descriptors (source immediates).
+_DESC_HI = 0x40004040  # SBO 1024 B, base-offset bit, 128 B swizzle
+_QK_IDESC = 0x08200490  # bf16 x bf16 -> f32, M=128, N=128, K-major A and B
+_PV_IDESC = 0x08210490  # same with MN-major B (V is token-major)
+_QK_STEPS = (2, 2, 2, 1018, 2, 2, 2)  # Q and K low-word walk over K=128 (bytes/16)
+_V_LBO_BIT = 0x4000000  # LBO = 16384 B: dim-half stride of the V tile
+_PV_B_STEP = 128  # 2048 B = 16 tokens x 128 B per K16 step
+_PV_A_STEP = 8  # 16 bf16 P columns = 8 TMEM 32-bit columns per K16 step
+_KV_STAGES = 3
+_PUSHES_PER_TILE = 12  # K5 K4 V5 K3 V4 K2 V3 K1 V2 K0 V1 V0
+_REG_SOFTMAX = 192
+_REG_CORRECTION = 80
+_REG_OTHER = 48
+
+_TMA_G2S_4D = "cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::complete_tx::bytes"
+_MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
+_TCGEN05_COMMIT = "tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64"
+_TMEM_ALLOC = "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32"
+_TMEM_RELINQUISH = "tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned"
+_TMEM_DEALLOC = "tcgen05.dealloc.cta_group::1.sync.aligned.b32"
+_TMEM_LD_X32 = "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+_TMEM_LD_X16 = "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+_TMEM_LD_X8 = "tcgen05.ld.sync.aligned.32x32b.x8.b32"
+_TMEM_ST_X16 = "tcgen05.st.sync.aligned.32x32b.x16.b32"
+_LN2_F32 = 0.6931471805599453
+_NEG_INF = float("-inf")
+_FULL_MASK = 0xFFFFFFFF
+
+
+def _u32(value):
+    return K.uint32(value)
+
+
+def _i32(value):
+    return K.int32(value)
+
+
+def _f32(value):
+    return K.float32(value)
+
+
+def _mbar_wait(addr, phase):
+    """``mbarrier.try_wait.parity.acquire.cta`` retry loop with the source's suspend hint."""
+    K.cuda.mbarrier_wait(addr, phase)
+
+
+def _mbar_arrive(addr):
+    K.ptx.mbarrier.arrive.release.cta.shared__cta.b64(addr)
+
+
+def _mbar_expect_tx(addr, tx_bytes):
+    K.ptx.mbarrier.arrive.expect_tx.release.cta.shared__cta.b64(addr, _u32(tx_bytes))
+
+
+def _ld_shared_i32(addr):
+    value = K.local_scalar("int32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _ld_shared_f32(addr):
+    value = K.local_scalar("float32")
+    K.ptx.ld.shared.b32(value, addr)
+    return value
+
+
+def _flip(phase):
+    K.assign(phase, phase ^ _i32(1))
+
+
+def _ring_schedule(initial_parity: int):
+    """(stage, parity) of the 12 ring waits of one tile; 12 pushes are four full turns."""
+    return [
+        (i % _KV_STAGES, ((i // _KV_STAGES) & 1) ^ initial_parity) for i in range(_PUSHES_PER_TILE)
+    ]
+
+
+def _pack2(lo, hi):
+    packed = K.local_scalar("uint64")
+    K.ptx.mov.b64(packed, lo, hi)
+    return packed
+
+
+def _packed_fma_inplace(values, base, scale_pair, bias_pair):
+    """``fma.rn.ftz.f32x2`` on values[base:base+2] with packed scale and bias."""
+    result = K.local_scalar("uint64")
+    K.ptx.fma.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair, bias_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _packed_mul_inplace(values, base, scale_pair):
+    """``mul.rn.ftz.f32x2`` on values[base:base+2] with a packed scale."""
+    result = K.local_scalar("uint64")
+    K.ptx.mul.rn.ftz.f32x2(result, _pack2(values[base], values[base + 1]), scale_pair)
+    K.ptx.mov.b64(values[base], values[base + 1], result)
+
+
+def _max_f32(a, b):
+    out = K.local_scalar("float32")
+    K.ptx.max.f32(out, a, b)
+    return out
+
+
+def _tmem_load_x32(dst, base, taddr):
+    K.ptx[_TMEM_LD_X32](*(dst[base + i] for i in range(32)), taddr)
+
+
+def _tmem_load_x16(dst, taddr):
+    K.ptx[_TMEM_LD_X16](*(dst[i] for i in range(16)), taddr)
+
+
+def _tmem_load_x8(dst, taddr):
+    K.ptx[_TMEM_LD_X8](*(dst[i] for i in range(8)), taddr)
+
+
+def _tmem_store_x16(taddr, src):
+    K.ptx[_TMEM_ST_X16](taddr, *(src[i] for i in range(16)))
+
+
+def _row_max_128(values):
+    """``row_max_x32_accum`` x4 + ``row_max_reduce``: alternating accumulators over 64 pairs."""
+    acc0 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    acc1 = K.local_scalar("float32", init=_f32(_NEG_INF))
+    for quarter in range(4):
+        for j in range(16):
+            pair = _max_f32(values[32 * quarter + 2 * j], values[32 * quarter + 2 * j + 1])
+            if j % 2 == 0:
+                K.assign(acc0, _max_f32(acc0, pair))
+            else:
+                K.assign(acc1, _max_f32(acc1, pair))
+    return _max_f32(acc0, acc1)
+
+
+def _block_sum_128(values):
+    """``softmax_block_sum`` x4: 64 packed ``add.f32x2`` into one accumulator, then ``.x + .y``."""
+    acc = K.local_scalar("uint64")
+    K.ptx.mov.b64(acc, _f32(0.0), _f32(0.0))
+    for j in range(64):
+        K.ptx.add.f32x2(acc, acc, _pack2(values[2 * j], values[2 * j + 1]))
+    acc_x = K.local_scalar("float32")
+    acc_y = K.local_scalar("float32")
+    K.ptx.mov.b64(acc_x, acc_y, acc)
+    total = K.local_scalar("float32")
+    K.ptx.add.ftz.f32(total, acc_x, acc_y)
+    return total
+
+
+def _build_kernel():
+    sm_count = _sm_count()
+
+    @K.kernel(
+        warps=NUM_WARPS,
+        arch=CUDA_ARCH,
+        min_blocks_per_sm=1,
+        grid=lambda p: K.min(p["total_tiles"], K.int32(sm_count)),
+        host_prelude=_host_prelude,
+    )
+    def cake_vsa_ultrasparse_bsr_sm100(
+        q: K.gptr[K.bf16],
+        k: K.gptr[K.bf16],
+        v: K.gptr[K.bf16],
+        out: K.gptr[K.bf16],
+        lse: K.gptr[K.f32],
+        temperature_lse: K.gptr[K.f32],
+        bsr_indices: K.gptr[K.i32],
+        mb: K.i32,
+        nb: K.i32,
+        selected_blocks: K.i32,
+        total_tiles: K.i32,
+        num_q_heads: K.i32,
+        num_kv_heads: K.i32,
+        softmax_scale_log2: K.f32,
+        lse_temperature_scale: K.f32,
+        return_softmax_lse: K.i32,
+        return_temperature_lse: K.i32,
+        *,
+        host,
+    ):
+        q_map, k_map, v_map = host
+        # ``selected_blocks`` (host-checked to be 6), ``num_kv_heads`` (the CTA uses
+        # ``kv_head = q_head``) and ``lse_temperature_scale`` are ABI arguments the
+        # device never reads; q/k/v are reached only through the tensor maps.
+        del q, k, v, selected_blocks, num_kv_heads, lse_temperature_scale
+        # >>> kernel_flashinfer_blackwell_vsa_ultrasparse_bsr_sm100 body starts here
+        bid = K.cta_id()
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        def num_bids():
+            # ``gridDim.x``; read at every tile increment so no long-lived register is
+            # needed (the source's plain special-register read is rematerialised by ptxas).
+            return K.cast(K.cuda.mov_sreg(32, "nctaid.x"), "uint32")
+
+        arena = K.alloc_buffer((SMEM_TOTAL,), K.u8, scope="shared.dyn", align=1024)
+        smem = K.local_scalar("uint32", init=K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
+
+        def bar(offset):
+            return smem + _u32(offset)
+
+        # Mbarrier init (11 groups, 20 barriers) by one elected lane of warp 0.
+        with K.If(warp == 0), K.Then():
+            init_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+            with K.If(init_leader != _u32(0)), K.Then():
+                for offset, count in _MBARRIER_INIT:
+                    K.ptx.mbarrier.init.shared__cta.b64(bar(offset), _u32(count))
+                K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.bar.warp.sync(_u32(_FULL_MASK))
+
+        # TMEM alloc (512 columns) by warp 0; the address lands in the shared mailbox.
+        with K.If(warp == 0), K.Then():
+            K.ptx[_TMEM_ALLOC](bar(_SMEM_TMEM_MAILBOX), _u32(TMEM_COLS))
+            K.ptx[_TMEM_RELINQUISH]()
+        K.cuda.cta_sync()
+        K.ptx["tcgen05.fence::after_thread_sync"]()
+        taddr = K.local_scalar("uint32")
+        K.ptx.ld.volatile.shared.b32(taddr, bar(_SMEM_TMEM_MAILBOX))
+
+        total_tiles_u = K.cast(total_tiles, "uint32")
+        mb_u = K.cast(mb, "uint32")
+        kv_len = nb * 128
+
+        # Sibling role guards, as in the source.
+        roles = K.specialize(chain_dispatch=False)
+        other_regs = roles.register_scope("other", warps=range(12, 16), regs=_REG_OTHER)
+        r_softmax = roles.role("softmax", warps=range(0, 8), regs=_REG_SOFTMAX)
+        r_correction = roles.role("correction", warps=range(8, 12), regs=_REG_CORRECTION)
+        r_mma = roles.role("mma", warps=[12], register_scope=other_regs)
+        r_idle = roles.role("idle", warps=[13, 14], register_scope=other_regs)
+        r_load = roles.role("load", warps=[15], register_scope=other_regs)
+
+        # Register redistribution: warps 12..15 decrease first so the softmax
+        # increase can be granted.
+        with K.If(K.And(warp >= 12, warp <= 15)), K.Then():
+            other_regs.emit()
+
+        # ---- Role: softmax (warps 0..7, two four-warp instances over alternate blocks) ----
+        with r_softmax:
+            phase_union_ready = K.local_scalar("int32", init=_i32(0))
+            phase_s_full = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            phase_corr_done = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            scores = K.alloc_local((128,), "float32")
+            packed_p = K.alloc_local((16,), "uint32")
+            tile_idx = K.local_scalar("uint32", init=K.cast(bid, "uint32"))
+            with K.While(tile_idx < total_tiles_u):
+                q_tile = K.local_scalar("int32", init=K.cast(tile_idx % mb_u, "int32"))
+                q_valid = K.local_scalar("int32", init=_i32(128))
+                with K.If(q_tile >= mb), K.Then():
+                    K.assign(q_valid, _i32(0))
+                _mbar_wait(bar(_MBAR_UNION_READY), phase_union_ready)
+                _flip(phase_union_ready)
+                instance = K.uniform(warp // 4)
+                instance_tmem_offset = K.uniform(instance * 128)
+                instance_row_offset = K.uniform(instance * 128)
+                warp_in_instance = warp % 4
+                tmem_row_origin = warp_in_instance * 32
+                my_row = tmem_row_origin + lane
+                row_addr = K.shift_left(K.cast(tmem_row_origin, "uint32"), _u32(16))
+                row_valid = K.local_scalar("int32", init=K.cast(my_row < q_valid, "int32"))
+                row_max = K.local_scalar("float32", init=_f32(_NEG_INF))
+                row_sum = K.local_scalar("float32", init=_f32(0.0))
+                score_addr = K.local_scalar(
+                    "uint32", init=taddr + K.cast(instance_tmem_offset, "uint32") + row_addr
+                )
+                p_addr = K.local_scalar("uint32", init=score_addr + _u32(_TMEM_P_OFFSET))
+                scale_row_addr = bar(_SMEM_SCALE) + K.cast(
+                    instance_row_offset + my_row, "uint32"
+                ) * _u32(4)
+                for pair in range(3):
+                    # Instance ``i`` consumes slot 5 - i - 2*pair of the tile's block list.
+                    n_block = _ld_shared_i32(
+                        bar(_SMEM_UNION_BLOCKS + 4 * (5 - 2 * pair))
+                        - K.cast(instance, "uint32") * _u32(4)
+                    )
+                    with K.If(instance == 0):
+                        with K.Then():
+                            _mbar_wait(bar(_MBAR_S_FULL), phase_s_full[0])
+                            _flip(phase_s_full[0])
+                        with K.Else():
+                            _mbar_wait(bar(_MBAR_S_FULL + 8), phase_s_full[1])
+                            _flip(phase_s_full[1])
+                    valid_cols = K.local_scalar("int32", init=_i32(0))
+                    with K.If(row_valid != _i32(0)), K.Then():
+                        K.assign(valid_cols, kv_len - n_block * 128)
+                        with K.If(valid_cols > _i32(128)), K.Then():
+                            K.assign(valid_cols, _i32(128))
+                        with K.If(valid_cols < _i32(0)), K.Then():
+                            K.assign(valid_cols, _i32(0))
+                    for quarter in range(4):
+                        _tmem_load_x32(scores, 32 * quarter, score_addr + _u32(32 * quarter))
+                    # valid_cols is 0 or 128 (128*(nb - n_block) clamped), so the source's
+                    # per-lane masks are all-zero whenever this branch is taken: the whole
+                    # fragment becomes -inf, which is what nvcc emits for the source.
+                    with K.If(valid_cols < _i32(128)), K.Then():
+                        for j in range(128):
+                            K.assign(scores[j], _f32(_NEG_INF))
+                    tile_max = _row_max_128(scores)
+                    new_max = _max_f32(tile_max, row_max)
+                    safe_max = K.local_scalar(
+                        "float32",
+                        init=K.if_then_else(new_max == _f32(_NEG_INF), _f32(0.0), new_max),
+                    )
+                    new_max_scaled = K.local_scalar("float32")
+                    K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                    neg_new_max_scaled = K.local_scalar("float32")
+                    K.ptx.neg.ftz.f32(neg_new_max_scaled, new_max_scaled)
+                    acc_scale_log2 = K.local_scalar("float32")
+                    K.ptx.fma.rn.ftz.f32(
+                        acc_scale_log2, row_max, softmax_scale_log2, neg_new_max_scaled
+                    )
+                    acc_scale = K.local_scalar("float32")
+                    selected_max = K.local_scalar("float32")
+                    with K.If(acc_scale_log2 >= _f32(-8.0)):
+                        with K.Then():
+                            # The running max moves by less than 2^8: keep the old max, skip the rescale.
+                            K.assign(selected_max, row_max)
+                            K.assign(
+                                safe_max,
+                                K.if_then_else(row_max == _f32(_NEG_INF), _f32(0.0), row_max),
+                            )
+                            K.assign(acc_scale, _f32(1.0))
+                            K.ptx.mul.ftz.f32(new_max_scaled, safe_max, softmax_scale_log2)
+                        with K.Else():
+                            K.assign(selected_max, new_max)
+                            exp_scale = K.local_scalar("float32")
+                            K.ptx.ex2.approx.ftz.f32(exp_scale, acc_scale_log2)
+                            K.assign(
+                                acc_scale,
+                                K.if_then_else(row_max > _f32(_NEG_INF), exp_scale, _f32(1.0)),
+                            )
+                    K.assign(row_max, selected_max)
+                    K.ptx.st.shared.b32(scale_row_addr, acc_scale)
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    with K.If(instance == 0):
+                        with K.Then():
+                            _mbar_arrive(bar(_MBAR_CORR_SIG))
+                        with K.Else():
+                            _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+                    # The bias negates the (possibly re-selected) new_max_scaled after the branch.
+                    neg_bias = K.local_scalar("float32")
+                    K.ptx.neg.ftz.f32(neg_bias, new_max_scaled)
+                    scale_pair = _pack2(softmax_scale_log2, softmax_scale_log2)
+                    bias_pair = _pack2(neg_bias, neg_bias)
+                    for j in range(64):
+                        _packed_fma_inplace(scores, 2 * j, scale_pair, bias_pair)
+                    for quarter in range(4):
+                        base = 32 * quarter
+                        for j in range(32):
+                            K.ptx.ex2.approx.ftz.f32(scores[base + j], scores[base + j])
+                        for j in range(16):
+                            K.ptx.cvt.rn.bf16x2.f32(
+                                packed_p[j], scores[base + 2 * j + 1], scores[base + 2 * j]
+                            )
+                        _tmem_store_x16(p_addr + _u32(16 * quarter), packed_p)
+                    K.ptx.tcgen05.wait__st.sync.aligned()
+                    with K.If(instance == 0):
+                        with K.Then():
+                            _mbar_arrive(bar(_MBAR_P_FULL))
+                            _mbar_wait(bar(_MBAR_CORR_DONE), phase_corr_done[0])
+                            _flip(phase_corr_done[0])
+                        with K.Else():
+                            _mbar_arrive(bar(_MBAR_P_FULL + 8))
+                            _mbar_wait(bar(_MBAR_CORR_DONE + 8), phase_corr_done[1])
+                            _flip(phase_corr_done[1])
+                    block_sum = _block_sum_128(scores)
+                    K.ptx.fma.rn.ftz.f32(row_sum, row_sum, acc_scale, block_sum)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(256 * 4), row_sum)
+                K.ptx.st.shared.b32(scale_row_addr + _u32(512 * 4), row_max)
+                K.ptx.fence.proxy.async_.shared__cta()
+                with K.If(instance == 0):
+                    with K.Then():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG))
+                    with K.Else():
+                        _mbar_arrive(bar(_MBAR_CORR_SIG + 8))
+                K.assign(tile_idx, tile_idx + num_bids())
+
+        # ---- Role: correction and epilogue (warps 8..11) ----
+        with r_correction:
+            phase_union_ready_c = K.local_scalar("int32", init=_i32(0))
+            phase_corr_sig = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            phase_o_full = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            o16 = K.alloc_local((16,), "float32")
+            o0 = K.alloc_local((8,), "float32")
+            o1 = K.alloc_local((8,), "float32")
+            words = K.alloc_local((4,), "uint32")
+            tile_idx_c = K.local_scalar("uint32", init=K.cast(bid, "uint32"))
+            with K.While(tile_idx_c < total_tiles_u):
+                q_head = K.local_scalar("int32", init=K.cast(tile_idx_c // mb_u, "int32"))
+                q_tile = K.local_scalar("int32", init=K.cast(tile_idx_c, "int32") - q_head * mb)
+                query_base = q_tile * 128
+                q_valid = K.local_scalar("int32", init=_i32(128))
+                with K.If(q_tile >= mb), K.Then():
+                    K.assign(q_valid, _i32(0))
+                _mbar_wait(bar(_MBAR_UNION_READY), phase_union_ready_c)
+                _flip(phase_union_ready_c)
+                warp_in_role = warp - 8
+                tmem_row_origin = warp_in_role * 32
+                my_row = tmem_row_origin + lane
+                row_addr = K.local_scalar(
+                    "uint32", init=K.shift_left(K.cast(tmem_row_origin, "uint32"), _u32(16))
+                )
+                scale_base = bar(_SMEM_SCALE) + K.cast(my_row, "uint32") * _u32(4)
+                # Pair 0 needs no O rescale: the correction half of p_full arrives at once.
+                _mbar_arrive(bar(_MBAR_P_FULL))
+                _mbar_arrive(bar(_MBAR_P_FULL + 8))
+                for instance in range(2):
+                    _mbar_wait(bar(_MBAR_CORR_SIG + 8 * instance), phase_corr_sig[instance])
+                    _flip(phase_corr_sig[instance])
+                    _mbar_arrive(bar(_MBAR_CORR_DONE + 8 * instance))
+                for _pair in range(1, 3):
+                    for instance in range(2):
+                        _mbar_wait(bar(_MBAR_CORR_SIG + 8 * instance), phase_corr_sig[instance])
+                        _flip(phase_corr_sig[instance])
+                        acc_scale_c = _ld_shared_f32(scale_base + _u32(128 * 4 * instance))
+                        any_rescale = K.local_scalar("uint32")
+                        K.ptx.vote_sync.any.pred(
+                            any_rescale,
+                            K.ptx.pred(K.cast(acc_scale_c < _f32(1.0), "bool")),
+                            _u32(_FULL_MASK),
+                        )
+                        with K.If(any_rescale != _u32(0)), K.Then():
+                            scale_pair = _pack2(acc_scale_c, acc_scale_c)
+                            for chunk in range(8):
+                                cr_addr = (
+                                    taddr + _u32(_TMEM_OUTPUT[instance] + 16 * chunk) + row_addr
+                                )
+                                _tmem_load_x16(o16, cr_addr)
+                                for j in range(8):
+                                    _packed_mul_inplace(o16, 2 * j, scale_pair)
+                                _tmem_store_x16(cr_addr, o16)
+                            K.ptx.tcgen05.wait__st.sync.aligned()
+                        _mbar_arrive(bar(_MBAR_P_FULL + 8 * instance))
+                        _mbar_arrive(bar(_MBAR_CORR_DONE + 8 * instance))
+                for instance in range(2):
+                    _mbar_wait(bar(_MBAR_O_FULL + 8 * instance), phase_o_full[instance])
+                    _flip(phase_o_full[instance])
+                for instance in range(2):
+                    _mbar_wait(bar(_MBAR_CORR_SIG + 8 * instance), phase_corr_sig[instance])
+                    _flip(phase_corr_sig[instance])
+                K.ptx["tcgen05.fence::after_thread_sync"]()
+                final_sum0 = _ld_shared_f32(scale_base + _u32(256 * 4))
+                final_sum1 = _ld_shared_f32(scale_base + _u32(384 * 4))
+                final_max0 = _ld_shared_f32(scale_base + _u32(512 * 4))
+                final_max1 = _ld_shared_f32(scale_base + _u32(640 * 4))
+                valid0 = K.local_scalar("int32", init=K.cast(final_sum0 > _f32(0.0), "int32"))
+                valid1 = K.local_scalar("int32", init=K.cast(final_sum1 > _f32(0.0), "int32"))
+                max0 = K.local_scalar(
+                    "float32", init=K.if_then_else(valid0 != _i32(0), final_max0, _f32(_NEG_INF))
+                )
+                max1 = K.local_scalar(
+                    "float32", init=K.if_then_else(valid1 != _i32(0), final_max1, _f32(_NEG_INF))
+                )
+                final_max = _max_f32(max0, max1)
+                safe_max_c = K.local_scalar(
+                    "float32",
+                    init=K.if_then_else(final_max == _f32(_NEG_INF), _f32(0.0), final_max),
+                )
+                combine = []
+                for instance, (max_i, valid_i) in enumerate(((max0, valid0), (max1, valid1))):
+                    diff = K.local_scalar("float32")
+                    K.ptx.sub.ftz.f32(diff, max_i, safe_max_c)
+                    scaled = K.local_scalar("float32")
+                    K.ptx.mul.ftz.f32(scaled, diff, softmax_scale_log2)
+                    exp_i = K.local_scalar("float32")
+                    K.ptx.ex2.approx.ftz.f32(exp_i, scaled)
+                    combine.append(
+                        K.local_scalar(
+                            "float32", init=K.if_then_else(valid_i != _i32(0), exp_i, _f32(0.0))
+                        )
+                    )
+                prod1 = K.local_scalar("float32")
+                K.ptx.mul.ftz.f32(prod1, final_sum1, combine[1])
+                final_sum = K.local_scalar("float32")
+                K.ptx.fma.rn.ftz.f32(final_sum, final_sum0, combine[0], prod1)
+                rcp_sum = K.local_scalar("float32")
+                K.ptx.rcp.approx.ftz.f32(rcp_sum, final_sum)
+                sum_positive = K.local_scalar("int32", init=K.cast(final_sum > _f32(0.0), "int32"))
+                inv_sum = K.local_scalar(
+                    "float32", init=K.if_then_else(sum_positive != _i32(0), rcp_sum, _f32(0.0))
+                )
+                output_scale0 = K.local_scalar("float32")
+                K.ptx.mul.ftz.f32(output_scale0, combine[0], inv_sum)
+                output_scale1 = K.local_scalar("float32")
+                K.ptx.mul.ftz.f32(output_scale1, combine[1], inv_sum)
+                query = query_base + my_row
+                output_row = (query * num_q_heads + q_head) * 128
+                with K.If(my_row < q_valid), K.Then():
+                    scale0_pair = _pack2(output_scale0, output_scale0)
+                    scale1_pair = _pack2(output_scale1, output_scale1)
+                    one_pair = _pack2(_f32(1.0), _f32(1.0))
+                    for chunk in range(16):
+                        out_addr0 = taddr + _u32(_TMEM_OUTPUT[0] + 8 * chunk) + row_addr
+                        _tmem_load_x8(o0, out_addr0)
+                        _tmem_load_x8(o1, out_addr0 + _u32(128))
+                        for j in range(4):
+                            _packed_mul_inplace(o0, 2 * j, scale0_pair)
+                        for j in range(4):
+                            _packed_mul_inplace(o1, 2 * j, scale1_pair)
+                        for j in range(8):
+                            K.ptx.add.ftz.f32(o0[j], o0[j], o1[j])
+                        # The source multiplies the merged fragment by a packed 1.0 with
+                        # ``mul.rn.ftz.f32x2``; the ftz flush is part of the result.
+                        for j in range(4):
+                            _packed_mul_inplace(o0, 2 * j, one_pair)
+                        for j in range(4):
+                            K.ptx.cvt.rn.bf16x2.f32(words[j], o0[2 * j + 1], o0[2 * j])
+                        K.ptx.st.global_.v4.b32(
+                            out.ptr_to([output_row + 8 * chunk]),
+                            words[0],
+                            words[1],
+                            words[2],
+                            words[3],
+                        )
+                    stat_idx = query * num_q_heads + q_head
+                    log2_sum = K.local_scalar("float32")
+                    K.ptx.lg2.approx.ftz.f32(log2_sum, final_sum)
+                    max_scaled = K.local_scalar("float32")
+                    K.ptx.mul.ftz.f32(max_scaled, final_max, softmax_scale_log2)
+                    log_sum = K.local_scalar("float32")
+                    K.ptx.mul.ftz.f32(log_sum, log2_sum, _f32(_LN2_F32))
+                    lse_value = K.local_scalar("float32")
+                    K.ptx.fma.rn.ftz.f32(lse_value, max_scaled, _f32(_LN2_F32), log_sum)
+                    final_lse = K.local_scalar(
+                        "float32",
+                        init=K.if_then_else(sum_positive != _i32(0), lse_value, _f32(_NEG_INF)),
+                    )
+                    with K.If(return_softmax_lse != _i32(0)), K.Then():
+                        K.ptx.st.global_.b32(lse.ptr_to([stat_idx]), final_lse)
+                    with K.If(return_temperature_lse != _i32(0)), K.Then():
+                        K.ptx.st.global_.b32(temperature_lse.ptr_to([stat_idx]), final_lse)
+                K.ptx.tcgen05.wait__ld.sync.aligned()
+                K.ptx["tcgen05.fence::before_thread_sync"]()
+                _mbar_arrive(bar(_MBAR_Q_EMPTY))
+                _mbar_arrive(bar(_MBAR_TILE_DONE))
+                K.assign(tile_idx_c, tile_idx_c + num_bids())
+
+        # ---- Role: MMA issuer (warp 12) ----
+        with r_mma:
+            phase_union_ready_m = K.local_scalar("int32", init=_i32(0))
+            phase_q_full = K.local_scalar("int32", init=_i32(0))
+            phase_p_full = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            phase_tile_done = K.local_scalar("int32", init=_i32(0))
+            desc_hi = _u32(_DESC_HI)
+            ring = _ring_schedule(0)
+            tile_idx_m = K.local_scalar("uint32", init=K.cast(bid, "uint32"))
+            with K.While(tile_idx_m < total_tiles_u):
+                _mbar_wait(bar(_MBAR_UNION_READY), phase_union_ready_m)
+                _flip(phase_union_ready_m)
+                _mbar_wait(bar(_MBAR_Q_FULL), phase_q_full)
+                _flip(phase_q_full)
+                first_pv = [K.local_scalar("int32", init=_i32(1)) for _ in range(2)]
+
+                def wait_kv_full(push):
+                    stage, parity = ring[push]
+                    _mbar_wait(bar(_MBAR_KV_FULL + 8 * stage), _i32(parity))
+                    return stage
+
+                def qk_chain(instance, k_stage):
+                    a_lo = K.local_scalar(
+                        "uint32", init=K.uniform((bar(_SMEM_Q) >> 4) & _u32(0x3FFF))
+                    )
+                    b_lo = K.local_scalar(
+                        "uint32",
+                        init=K.uniform(
+                            ((bar(_SMEM_KV) >> 4) & _u32(0x3FFF)) + _u32(k_stage * 2048)
+                        ),
+                    )
+                    leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    d_tmem = taddr + _u32(_TMEM_SCORES[instance])
+                    for k16 in range(8):
+                        K.ptx[_MMA_F16](
+                            d_tmem,
+                            _pack2(a_lo, desc_hi),
+                            _pack2(b_lo, desc_hi),
+                            _u32(_QK_IDESC),
+                            _u32(0),
+                            _u32(0),
+                            _u32(0),
+                            _u32(0),
+                            K.ptx.pred(_u32(0 if k16 == 0 else 1)),
+                            pred=leader,
+                        )
+                        if k16 < 7:
+                            K.assign(a_lo, a_lo + _u32(_QK_STEPS[k16]))
+                            K.assign(b_lo, b_lo + _u32(_QK_STEPS[k16]))
+                    K.ptx[_TCGEN05_COMMIT](bar(_MBAR_S_FULL + 8 * instance), pred=leader)
+                    K.ptx[_TCGEN05_COMMIT](bar(_MBAR_KV_EMPTY + 8 * k_stage), pred=leader)
+
+                def pv_chain(instance, v_stage, last_pair):
+                    _mbar_wait(bar(_MBAR_P_FULL + 8 * instance), phase_p_full[instance])
+                    _flip(phase_p_full[instance])
+                    b_lo = K.local_scalar(
+                        "uint32",
+                        init=K.uniform(
+                            (((bar(_SMEM_KV) >> 4) & _u32(0x3FFF)) | _u32(_V_LBO_BIT))
+                            + _u32(v_stage * 2048)
+                        ),
+                    )
+                    leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    d_tmem = taddr + _u32(_TMEM_OUTPUT[instance])
+                    a_tmem = K.local_scalar(
+                        "uint32", init=taddr + _u32(_TMEM_SCORES[instance] + _TMEM_P_OFFSET)
+                    )
+                    enable_first = K.local_scalar(
+                        "uint32",
+                        init=K.if_then_else(first_pv[instance] != _i32(0), _u32(0), _u32(1)),
+                    )
+                    for k16 in range(8):
+                        K.ptx[_MMA_F16](
+                            d_tmem,
+                            a_tmem,
+                            _pack2(b_lo, desc_hi),
+                            _u32(_PV_IDESC),
+                            _u32(0),
+                            _u32(0),
+                            _u32(0),
+                            _u32(0),
+                            K.ptx.pred(enable_first if k16 == 0 else _u32(1)),
+                            pred=leader,
+                        )
+                        if k16 < 7:
+                            K.assign(a_tmem, a_tmem + _u32(_PV_A_STEP))
+                            K.assign(b_lo, b_lo + _u32(_PV_B_STEP))
+                    K.assign(first_pv[instance], _i32(0))
+                    if last_pair:
+                        K.ptx[_TCGEN05_COMMIT](bar(_MBAR_O_FULL + 8 * instance), pred=leader)
+                    K.ptx[_TCGEN05_COMMIT](bar(_MBAR_KV_EMPTY + 8 * v_stage), pred=leader)
+
+                push = 0
+                for instance in range(2):  # S5, S4
+                    k_stage = wait_kv_full(push)
+                    push += 1
+                    qk_chain(instance, k_stage)
+                for pair in range(3):
+                    for instance in range(2):
+                        v_stage = wait_kv_full(push)
+                        push += 1
+                        pv_chain(instance, v_stage, last_pair=(pair == 2))
+                        if pair < 2:  # S for slot 5 - instance - 2*(pair + 1)
+                            k_stage = wait_kv_full(push)
+                            push += 1
+                            qk_chain(instance, k_stage)
+                _mbar_wait(bar(_MBAR_TILE_DONE), phase_tile_done)
+                _flip(phase_tile_done)
+                K.assign(tile_idx_m, tile_idx_m + num_bids())
+            taddr_dealloc = K.local_scalar("uint32")
+            K.ptx.ld.volatile.shared.b32(taddr_dealloc, bar(_SMEM_TMEM_MAILBOX))
+            K.ptx[_TMEM_DEALLOC](taddr_dealloc, _u32(TMEM_COLS))
+
+        # ---- Role: idle (warps 13, 14) ----
+        with r_idle:
+            pass
+
+        # ---- Role: load warp (warp 15) ----
+        with r_load:
+            phase_q_empty = K.local_scalar("int32", init=_i32(1))
+            ring_l = _ring_schedule(1)
+            tile_idx_l = K.local_scalar("uint32", init=K.cast(bid, "uint32"))
+            with K.While(tile_idx_l < total_tiles_u):
+                _mbar_wait(bar(_MBAR_Q_EMPTY), phase_q_empty)
+                _flip(phase_q_empty)
+                q_head = K.local_scalar("int32", init=K.cast(tile_idx_l // mb_u, "int32"))
+                q_tile = K.local_scalar("int32", init=K.cast(tile_idx_l, "int32") - q_head * mb)
+                query_base = q_tile * 128
+                kv_head = q_head
+                load_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                with K.If(load_leader != _u32(0)), K.Then():
+                    _mbar_expect_tx(bar(_MBAR_Q_FULL), 32768)
+                    K.ptx[_TMA_G2S_4D](
+                        bar(_SMEM_Q),
+                        K.address_of(q_map),
+                        _i32(0),
+                        query_base,
+                        q_head,
+                        _i32(0),
+                        bar(_MBAR_Q_FULL),
+                    )
+                with K.If(lane < _i32(6)), K.Then():
+                    block_index = K.local_scalar("int32")
+                    K.ptx.ld.global_.nc.b32(block_index, bsr_indices.ptr_to([q_tile * 6 + lane]))
+                    K.ptx.st.shared.b32(
+                        bar(_SMEM_UNION_BLOCKS) + K.cast(lane, "uint32") * _u32(4), block_index
+                    )
+                K.ptx.barrier.sync(_u32(8), _u32(32))
+                K.ptx.fence.proxy.async_.shared__cta()
+                _mbar_arrive(bar(_MBAR_UNION_READY))
+
+                def push_tile(tensor_map, slot, push):
+                    stage, parity = ring_l[push]
+                    n_block = _ld_shared_i32(bar(_SMEM_UNION_BLOCKS + 4 * slot))
+                    token_base = n_block * 128
+                    _mbar_wait(bar(_MBAR_KV_EMPTY + 8 * stage), _i32(parity))
+                    push_leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
+                    with K.If(push_leader != _u32(0)), K.Then():
+                        full_bar = bar(_MBAR_KV_FULL + 8 * stage)
+                        _mbar_expect_tx(full_bar, 32768)
+                        stage_addr = bar(_SMEM_KV + stage * _SMEM_KV_STAGE_BYTES)
+                        token1 = token_base + _i32(64)
+                        for dim_half in range(2):
+                            for token_half, token in ((0, token_base), (1, token1)):
+                                K.ptx[_TMA_G2S_4D](
+                                    stage_addr + _u32(8192 * token_half + 16384 * dim_half),
+                                    K.address_of(tensor_map),
+                                    _i32(0),
+                                    token,
+                                    _i32(dim_half),
+                                    kv_head,
+                                    full_bar,
+                                )
+
+                push = 0
+                for instance in range(2):  # K5, K4
+                    push_tile(k_map, 5 - instance, push)
+                    push += 1
+                for pair in range(3):
+                    for instance in range(2):
+                        slot = 5 - instance - 2 * pair
+                        push_tile(v_map, slot, push)
+                        push += 1
+                        if slot - 2 >= 0:
+                            push_tile(k_map, slot - 2, push)
+                            push += 1
+                K.assign(tile_idx_l, tile_idx_l + num_bids())
+
+    return cake_vsa_ultrasparse_bsr_sm100
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return _build_kernel()
+
+
+def get_kernel(**config: Any):
+    """Return the TIRx PrimFunc; the kernel is shape-generic at runtime."""
+    if config:
+        cfg = _without_label(config)
+        _validate_shape(cfg["M"], cfg["N"])
+    return _kernel().func
+
+
+# ptxas ``--register-usage-level`` for this kernel.  The upstream cubin is built
+# with ptxas' native default (5).  TIRx's nvcc path defaults to 10, which here
+# schedules the 48-register MMA/load warps so aggressively that descriptor packs
+# and uniform values spill (stack 336 B, 120 LDL / 99 STL, 268 uniform spill and
+# fill pairs versus the source's 96 B / 48 / 34 / 23); level 5 reproduces the
+# source's allocation (88 B, 30 LDL / 27 STL, 23 pairs) and measured 6.7-7.2%
+# faster than level 10 on the two streaming benchmark shapes.
+_PTXAS_REG_LEVEL = "5"
+
+
+@lru_cache(maxsize=1)
+def _compiled_kernel():
+    import os
+
+    from tirx_kernels.runner import compile_kernel
+
+    # nvcc mode keeps the TIRx build on the CUDA toolkit on PATH (13.2, PTX ISA
+    # 9.2) -- the same toolchain the upstream ``nvcc -cubin`` build uses -- so
+    # both binaries share one PTX ISA for SASS and profiler comparisons.
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = _PTXAS_REG_LEVEL
+    try:
+        return compile_kernel(get_kernel(), cuda_compile_mode="nvcc")
+    finally:
+        if previous is None:
+            del os.environ["TVM_CUDA_PTXAS_REG_LEVEL"]
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
+def _tirx_args(data: dict[str, Any], slot: str = "tirx") -> tuple[Any, ...]:
+    buffers = data[slot]
+    return (
+        data["q"].view(-1),
+        data["k"].view(-1),
+        data["v"].view(-1),
+        buffers["out"].view(-1),
+        buffers["lse"].view(-1),
+        buffers["tlse"].view(-1),
+        data["bsr_indices"].view(-1),
+        data["mb"],
+        data["nb"],
+        SELECTED_BLOCKS,
+        data["total_tiles"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+    )
+
+
+def _tirx_launch(executable, data: dict[str, Any]):
+    arguments = _tirx_args(data)
+
+    def launch():
+        executable(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+# ---------------------------------------------------------------------------
+# Upstream source kernel (the reference for correctness and benchmarks)
+# ---------------------------------------------------------------------------
+@lru_cache(maxsize=1)
+def _source_module():
+    """Build the upstream cubin + tvm-ffi launcher exactly as FlashInfer does."""
+    from flashinfer import cake_vsa
+
+    return cake_vsa._load_module(PROFILE, CUDA_ARCH)
+
+
+def _source_args(data: dict[str, Any]) -> tuple[Any, ...]:
+    """The ``flashinfer.cake_vsa._run_standard`` argument list for ``ultrasparse_bsr``."""
+    buffers = data["source"]
+    return (
+        data["q"],
+        data["k"],
+        data["v"],
+        buffers["out"],
+        buffers["lse"],
+        buffers["tlse"],
+        data["bsr_indices"],
+        data["mb"],
+        data["nb"],
+        SELECTED_BLOCKS,
+        data["total_tiles"],
+        data["num_heads"],
+        data["num_heads"],
+        data["softmax_scale_log2"],
+        data["lse_temperature_scale"],
+        int(data["return_lse"]),
+        int(data["return_temperature_lse"]),
+        data["grid_x"],
+        1,
+        1,
+    )
+
+
+def _source_launch(data: dict[str, Any]):
+    import tvm_ffi
+
+    module = _source_module()
+    arguments = _source_args(data)
+
+    def launch():
+        with tvm_ffi.use_torch_stream():
+            module.run(*arguments)
+
+    launch._keep_alive = arguments
+    return launch
+
+
+def _dense_block_mask(data: dict[str, Any]):
+    """``(num_heads, mb, nb)`` boolean mask equivalent to the shared BSR table."""
+    import torch
+
+    mb, nb = data["mb"], data["nb"]
+    shared = torch.zeros((mb, nb), dtype=torch.bool, device=data["q"].device)
+    shared.scatter_(1, data["bsr_indices"].to(torch.int64), True)
+    return shared.unsqueeze(0).expand(data["num_heads"], -1, -1).contiguous()
+
+
+def _run_public_api(data: dict[str, Any], mode: str):
+    """Run the upstream public API (``plan_cake_vsa`` + ``run_cake_vsa``) without LSE.
+
+    ``mode == "block_mask"`` hands the dense mask over (the planner recompacts it
+    into sorted BSR columns); ``mode == "indices"`` hands ``indptr``/``indices``
+    over, which the planner trusts and forwards in caller order.
+    """
+    import torch
+    from flashinfer import cake_vsa
+
+    mb = data["mb"]
+    if mode == "indices":
+        indptr = torch.arange(0, (mb + 1) * SELECTED_BLOCKS, SELECTED_BLOCKS, dtype=torch.int32)
+        plan_args = (indptr.to(data["q"].device), data["bsr_indices"].view(-1), None)
+    elif mode == "block_mask":
+        plan_args = (None, None, _dense_block_mask(data))
+    else:
+        raise ValueError(f"unknown api_check mode {mode!r}")
+    plan = cake_vsa.plan_cake_vsa(
+        *plan_args,
+        None,
+        None,
+        None,
+        M=data["M"],
+        N=data["N"],
+        R=BLOCK,
+        C=BLOCK,
+        num_qo_heads=data["num_heads"],
+        num_kv_heads=data["num_heads"],
+        head_dim=HEAD_DIM,
+        q_data_type=torch.bfloat16,
+        sm_scale=data["sm_scale"],
+        device=data["q"].device,
+    )
+    if plan["indices"] is None or plan["max_selected_blocks"] != SELECTED_BLOCKS:
+        raise AssertionError("public API plan does not describe a six-block shared BSR pattern")
+    if not plan["uniform_selected_blocks"] or plan["mb"] < MIN_QUERY_BLOCKS:
+        raise AssertionError("public API plan would not dispatch to ultrasparse_bsr")
+    if not torch.equal(plan["indices"].view(mb, SELECTED_BLOCKS), data["bsr_indices"]):
+        raise AssertionError(
+            "public API plan reordered the BSR columns relative to the direct launch"
+        )
+    return cake_vsa.run_cake_vsa(
+        plan, data["q"], data["k"], data["v"], out=None, lse=None, return_lse=False, backend="cake"
+    )
+
+
+# ---------------------------------------------------------------------------
+# fp64 oracle and validation
+# ---------------------------------------------------------------------------
+def _bf16_order_key(values):
+    """Map bf16 bit patterns to integers ordered like the reals (for ULP distances)."""
+    import torch
+
+    bits = values.contiguous().view(torch.int16).to(torch.int32) & 0xFFFF
+    return torch.where(bits < 0x8000, bits + 0x8000, 0x8000 - (bits & 0x7FFF))
+
+
+def _assert_bitwise(name: str, ours, theirs) -> None:
+    import torch
+
+    if ours.dtype == torch.bfloat16:
+        ours_bits, theirs_bits = ours.view(torch.int16), theirs.view(torch.int16)
+    else:
+        ours_bits, theirs_bits = ours.view(torch.int32), theirs.view(torch.int32)
+    mismatch = ours_bits != theirs_bits
+    count = int(mismatch.sum())
+    if count:
+        index = mismatch.reshape(-1).nonzero()[0].item()
+        raise AssertionError(
+            f"{name}: {count} of {mismatch.numel()} elements differ bitwise from the source "
+            f"kernel (first at flat index {index}: tirx={ours.reshape(-1)[index].item()!r} "
+            f"source={theirs.reshape(-1)[index].item()!r})"
+        )
+
+
+class _OracleStats:
+    """Running error statistics of one implementation against the fp64 oracle."""
+
+    def __init__(self, cfg: dict[str, Any], *, return_lse: bool, return_tlse: bool):
+        self.cfg = cfg
+        self.return_lse = return_lse
+        self.return_tlse = return_tlse
+        self.out_max_abs_err = 0.0
+        self.out_max_rel_excess = 0.0
+        self.out_max_err_small_ref = 0.0
+        self.out_max_rel_err_large_ref = 0.0
+        self.ulp_max = 0.0
+        self.ulp_total = 0
+        self.ulp_le1 = 0
+        self.ulp_le2 = 0
+        self.lse_max_abs_err = 0.0
+        self.lse_max_rel_excess = 0.0
+        self.tlse_max_abs_err = 0.0
+        self.tlse_max_rel_excess = 0.0
+
+    def update(self, out_bf16, lse, tlse, ref_out, ref_lse):
+        import torch
+
+        cfg = self.cfg
+        out = out_bf16.double()
+        err = (out - ref_out).abs()
+        bound = cfg["oracle_atol"] + cfg["oracle_rtol"] * ref_out.abs()
+        self.out_max_abs_err = max(self.out_max_abs_err, float(err.max()))
+        self.out_max_rel_excess = max(self.out_max_rel_excess, float((err / bound).max()))
+        small = ref_out.abs() < _ORACLE_ULP_MIN_REF
+        large = ref_out.abs() >= 0.5
+        if bool(small.any()):
+            self.out_max_err_small_ref = max(self.out_max_err_small_ref, float(err[small].max()))
+        if bool(large.any()):
+            self.out_max_rel_err_large_ref = max(
+                self.out_max_rel_err_large_ref, float((err[large] / ref_out[large].abs()).max())
+            )
+        sizeable = ~small
+        if bool(sizeable.any()):
+            ulps = (_bf16_order_key(ref_out.to(torch.bfloat16)) - _bf16_order_key(out_bf16)).abs()[
+                sizeable
+            ]
+            self.ulp_max = max(self.ulp_max, float(ulps.max()))
+            self.ulp_total += ulps.numel()
+            self.ulp_le1 += int((ulps <= 1).sum())
+            self.ulp_le2 += int((ulps <= 2).sum())
+        for flag, values, attr in ((self.return_lse, lse, "lse"), (self.return_tlse, tlse, "tlse")):
+            if not flag:
+                continue
+            err = (values.double() - ref_lse).abs()
+            bound = cfg["oracle_lse_atol"] + cfg["oracle_lse_rtol"] * ref_lse.abs()
+            setattr(
+                self,
+                f"{attr}_max_abs_err",
+                max(getattr(self, f"{attr}_max_abs_err"), float(err.max())),
+            )
+            setattr(
+                self,
+                f"{attr}_max_rel_excess",
+                max(getattr(self, f"{attr}_max_rel_excess"), float((err / bound).max())),
+            )
+
+    def check(self, name: str, stats: dict[str, float]) -> None:
+        cfg = self.cfg
+        stats[f"{name}_out_max_abs_err"] = self.out_max_abs_err
+        stats[f"{name}_out_max_rel_excess"] = self.out_max_rel_excess
+        stats[f"{name}_out_max_err_small_ref"] = self.out_max_err_small_ref
+        stats[f"{name}_out_max_rel_err_large_ref"] = self.out_max_rel_err_large_ref
+        if self.out_max_rel_excess > 1.0:
+            raise AssertionError(
+                f"{name}: out mismatch vs fp64 oracle (max abs err {self.out_max_abs_err:.3e}, "
+                f"max err/bound {self.out_max_rel_excess:.3f})"
+            )
+        if self.ulp_total:
+            le1 = self.ulp_le1 / self.ulp_total
+            le2 = self.ulp_le2 / self.ulp_total
+            stats[f"{name}_out_ulp_max"] = self.ulp_max
+            stats[f"{name}_out_ulp_le1_frac"] = le1
+            stats[f"{name}_out_ulp_le2_frac"] = le2
+            if (
+                self.ulp_max > cfg["ulp_max"]
+                or le1 < cfg["ulp_le1_frac"]
+                or le2 < cfg["ulp_le2_frac"]
+            ):
+                raise AssertionError(
+                    f"{name}: bf16 ULP distribution vs oracle too wide (max {self.ulp_max:.0f}, "
+                    f"<=1 ULP {le1:.5f}, <=2 ULP {le2:.5f})"
+                )
+        for flag, attr in ((self.return_lse, "lse"), (self.return_tlse, "tlse")):
+            if not flag:
+                continue
+            stats[f"{name}_{attr}_max_abs_err"] = getattr(self, f"{attr}_max_abs_err")
+            stats[f"{name}_{attr}_max_rel_excess"] = getattr(self, f"{attr}_max_rel_excess")
+            if getattr(self, f"{attr}_max_rel_excess") > 1.0:
+                raise AssertionError(
+                    f"{name}: {attr} mismatch vs oracle (max abs err "
+                    f"{getattr(self, f'{attr}_max_abs_err'):.3e})"
+                )
+
+
+def _oracle_chunk(data: dict[str, Any], t0: int, t1: int):
+    """fp64 block-gather reference for query tiles ``[t0, t1)``.
+
+    Returns ``(out, lse)`` shaped ``(T, num_heads, 128, 128)`` and ``(T, num_heads, 128)``.
+    """
+    import torch
+
+    nb, num_heads = data["nb"], data["num_heads"]
+    idx = data["bsr_indices"][t0:t1].to(torch.int64)  # (T, 6)
+    T = t1 - t0
+    q = data["q"][t0 * BLOCK : t1 * BLOCK].double().view(T, BLOCK, num_heads, HEAD_DIM)
+    q = q.permute(0, 2, 1, 3)  # (T, H, 128, D)
+    k_blocks = data["k"].view(nb, BLOCK, num_heads, HEAD_DIM)[idx]  # (T, 6, 128, H, D)
+    v_blocks = data["v"].view(nb, BLOCK, num_heads, HEAD_DIM)[idx]
+    k_g = k_blocks.permute(0, 3, 1, 2, 4).reshape(T, num_heads, SELECTED_BLOCKS * BLOCK, HEAD_DIM)
+    v_g = v_blocks.permute(0, 3, 1, 2, 4).reshape(T, num_heads, SELECTED_BLOCKS * BLOCK, HEAD_DIM)
+    scores = torch.matmul(q, k_g.double().transpose(-1, -2)) * data["sm_scale"]
+    row_max = scores.amax(dim=-1, keepdim=True)
+    probs = torch.exp(scores - row_max)
+    sums = probs.sum(dim=-1, keepdim=True)
+    out = torch.matmul(probs / sums, v_g.double())
+    lse = (row_max + torch.log(sums)).squeeze(-1)
+    return out, lse
+
+
+def _validate_outputs(data: dict[str, Any], *, with_oracle: bool) -> dict[str, float]:
+    import torch
+
+    tirx, source = data["tirx"], data["source"]
+    return_lse, return_tlse = data["return_lse"], data["return_temperature_lse"]
+
+    for name, buffers in (("tirx", tirx), ("source", source)):
+        if not torch.isfinite(buffers["out"].float()).all():
+            raise AssertionError(f"{name}: non-finite values in out")
+        if return_lse and not torch.isfinite(buffers["lse"]).all():
+            raise AssertionError(f"{name}: non-finite values in lse")
+        if return_tlse and not torch.isfinite(buffers["tlse"]).all():
+            raise AssertionError(f"{name}: non-finite values in temperature lse")
+        if not return_lse and not bool((buffers["lse"] == _LSE_SENTINEL).all()):
+            raise AssertionError(f"{name}: lse sentinel was overwritten with return_lse=0")
+        if (
+            return_lse
+            and return_tlse
+            and not torch.equal(buffers["lse"].view(torch.int32), buffers["tlse"].view(torch.int32))
+        ):
+            raise AssertionError(f"{name}: temperature_lse differs from lse")
+
+    _assert_bitwise("out", tirx["out"], source["out"])
+    _assert_bitwise("lse", tirx["lse"], source["lse"])
+    if return_tlse:
+        _assert_bitwise("temperature_lse", tirx["tlse"], source["tlse"])
+
+    stats: dict[str, float] = {}
+    if not with_oracle:
+        return stats
+    cfg = data["config"]
+    mb, num_heads = data["mb"], data["num_heads"]
+    trackers = {
+        name: _OracleStats(cfg, return_lse=return_lse, return_tlse=return_tlse)
+        for name in ("tirx", "source")
+    }
+    for t0 in range(0, mb, _ORACLE_TILES_PER_CHUNK):
+        t1 = min(mb, t0 + _ORACLE_TILES_PER_CHUNK)
+        ref_out, ref_lse = _oracle_chunk(data, t0, t1)
+        T = t1 - t0
+        for name, buffers in (("tirx", tirx), ("source", source)):
+            out = buffers["out"][t0 * BLOCK : t1 * BLOCK].view(T, BLOCK, num_heads, HEAD_DIM)
+            out = out.permute(0, 2, 1, 3)
+            lse = (
+                buffers["lse"][t0 * BLOCK : t1 * BLOCK].view(T, BLOCK, num_heads).permute(0, 2, 1)
+                if return_lse
+                else None
+            )
+            tlse = (
+                buffers["tlse"][t0 * BLOCK : t1 * BLOCK].view(T, BLOCK, num_heads).permute(0, 2, 1)
+                if return_tlse
+                else None
+            )
+            trackers[name].update(out, lse, tlse, ref_out, ref_lse)
+    for name, tracker in trackers.items():
+        tracker.check(name, stats)
+    return stats
+
+
+def _skip_unless_supported() -> None:
+    from unittest import SkipTest
+
+    import torch
+
+    if not torch.cuda.is_available():
+        raise SkipTest("CUDA device required")
+    if torch.cuda.get_device_capability() != (10, 0):
+        raise SkipTest("cake_vsa ultrasparse_bsr sm_100a requires compute capability 10.0")
+
+
+def run_test(**config: Any) -> dict[str, float]:
+    """Compile, launch TIRx and the upstream kernel, and validate one config."""
+    import torch
+
+    _skip_unless_supported()
+    data = prepare_data(**config)
+    executable = _compiled_kernel()
+    tirx_launch = _tirx_launch(executable, data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    first_out = data["tirx"]["out"].clone()
+    first_lse = data["tirx"]["lse"].clone()
+
+    source_launch = _source_launch(data)
+    source_launch()
+    torch.cuda.synchronize()
+    stats = _validate_outputs(data, with_oracle=True)
+
+    # A second TIRx launch into the same buffers must reproduce the first bit for bit.
+    tirx_launch()
+    torch.cuda.synchronize()
+    _assert_bitwise("out (repeat launch)", data["tirx"]["out"], first_out)
+    _assert_bitwise("lse (repeat launch)", data["tirx"]["lse"], first_lse)
+
+    api_mode = data["config"]["api_check"]
+    if api_mode is not None:
+        # The public API must dispatch this pattern to ultrasparse_bsr and agree bitwise
+        # on the output (the LSE flags do not influence ``out``).
+        api_out = _run_public_api(data, api_mode)
+        _assert_bitwise("out (public API)", data["tirx"]["out"], api_out)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Benchmark entry points
+# ---------------------------------------------------------------------------
+def prepare_bench(**config: Any):
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    kernel_config = _without_label(config)
+    _validate_shape(kernel_config["M"], kernel_config["N"])
+    state = {"config": kernel_config, "executable": _compiled_kernel()}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **kwargs):
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
+
+    with defer_gpu_interrupts():
+        import torch
+
+    config = _without_label({**prepared["config"], **kwargs})
+    with_source = external_references_enabled()
+    gpu_state = prepared.get("gpu_state")
+    if gpu_state is None:
+        data = prepare_data(**config)
+        gpu_state = {
+            "data": data,
+            "tirx_launch": _tirx_launch(prepared["executable"], data),
+            "source_launch": None,
+            "validated": False,
+            "with_source": with_source,
+        }
+        prepared["gpu_state"] = gpu_state
+    elif gpu_state["with_source"] != with_source:
+        raise RuntimeError("reference timing mode changed within one prepared benchmark")
+
+    data = gpu_state["data"]
+    tirx_launch = gpu_state["tirx_launch"]
+    if not gpu_state["validated"]:
+        tirx_launch()
+        torch.cuda.synchronize()
+        if with_source:
+            with defer_gpu_interrupts():
+                source_launch = _source_launch(data)
+                gpu_state["source_launch"] = source_launch
+                source_launch()
+                torch.cuda.synchronize()
+            _validate_outputs(data, with_oracle=False)
+        gpu_state["validated"] = True
+
+    source_launch = gpu_state["source_launch"]
+    references = {"flashinfer": lambda: source_launch} if source_launch is not None else None
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(*, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=0.0, **config: Any):
+    return prepare_bench(**config).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]

--- a/tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py
+++ b/tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py
@@ -86,7 +86,10 @@ _DTYPE_LABEL = {
 
 _TRY_WAIT_TICKS = 10_000_000
 _SMEM_CAPACITY = 335_872
-_MAX_ACTIVE_CLUSTERS = {2: 74, 4: 33}
+# Stand-in for the source's ``HardwareInfo().get_max_active_clusters(cluster_size)``
+# query on the 200-SM sm_107a part, so the persistent grid stays a static
+# specialization fact: 100 two-CTA clusters and 40 four-CTA clusters.
+_MAX_ACTIVE_CLUSTERS = {2: 100, 4: 40}
 _SOURCE_ROOT = Path("/root-vol/aarch64-ws/kernel-libs/vr200/flashinfer")
 
 # (mma_tiler, mma_instruction, cluster_mn, raster)

--- a/tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py
+++ b/tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py
@@ -1,0 +1,2010 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ 012cfdb97f217e0d48bc9352c17a74068c9e495b)
+# SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""SM107 dense block-scaled FP4 GEMM transcribed from FlashInfer CuTeDSL.
+
+Upstream sources:
+- flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py
+- flashinfer/gemm/kernels/epilogue_utils.py
+- flashinfer/gemm/gemm_base.py
+- flashinfer/gemm/kernels/utils.py
+"""
+
+import hashlib
+import importlib
+import importlib.util
+import sys
+import types
+from functools import cache
+from pathlib import Path
+
+import tirx_kernels.kern as K
+
+KERNEL_META = {
+    "name": "dense_blockscaled_gemm_sm107",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "012cfdb97f217e0d48bc9352c17a74068c9e495b",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
+
+SOURCE_COMMIT = "012cfdb97f217e0d48bc9352c17a74068c9e495b"
+SOURCE_SHA256 = "c9def937d2bf76b363bb321aa4053ffd39055febdcef3c890572bd2c4f2946ad"
+SOURCE_DEPENDENCY_SHA256 = {
+    "epilogue_utils.py": "ae48ecfca2220975cd3e0e1d60803f8634aa72827857aaff3b2af24205c01c92",
+    "gemm_base.py": "ef5cb58d7d85e1391a4987327bdcd6f9e20ffcd1a849dc0b0b9a13ffce3d0d95",
+    "kernels/utils.py": "705a10946cb6ee68c132784fc48de7ce3bad07714ae5244c4058c970e1f02ed2",
+}
+CUTLASS_PARENT_COMMIT = "cdcf8d86daa9b417840fd99875a1b1af685d389d"
+CUTLASS_PARENT_SHA256 = "1517d4cde6b7988d5f44eca5fc2de4516b6f582ae60c37a5d1455a09c647453b"
+
+_SOURCE_ROOT = Path("/root-vol/aarch64-ws/kernel-libs/vr200/flashinfer")
+_CUTLASS_ROOT = Path(__file__).resolve().parents[3] / ".reference-deps" / "cutlass-v4.8.0dev"
+_CUTLASS_PARENT_RELATIVE = Path(
+    "examples/python/CuTeDSL/cute/blackwell/kernel/blockscaled_gemm/"
+    "dense_blockscaled_gemm_persistent.py"
+)
+_CUTLASS_PARENT_MODULE = (
+    "nvidia_cutlass_dsl.examples.CuTeDSL.cute.blackwell.kernel.blockscaled_gemm."
+    "dense_blockscaled_gemm_persistent"
+)
+
+_SMEM_CAPACITY = 334_848
+_TMEM_COLUMNS = 576
+_TRY_WAIT_TICKS = 10_000_000
+_MAX_ACTIVE_CLUSTERS = {1: 200, 2: 100, 4: 40}
+_SF_MODES = {"nvfp4": ("float8_e4m3fn", 16), "mxfp4": ("float8_e8m0fnu", 32)}
+_OUT_DTYPES = ("float16", "bfloat16")
+
+# (MMA tiler MN, MMA instruction MN, cluster MN, swap AB, prefetch distance)
+TACTICS = (
+    ((256, 128), (128, 128), (2, 1), False, 0),
+    ((256, 128), (256, 128), (2, 1), True, 2),
+    ((128, 192), (128, 192), (1, 2), False, None),
+    ((128, 64), (128, 64), (1, 1), True, 2),
+    ((256, 256), (256, 256), (2, 1), False, 0),
+)
+
+
+def _case(prefix, tactic, shape, sf_mode, out_dtype, alpha):
+    M, N, K_dim = shape
+    return {
+        "label": (
+            f"{prefix}_t{tactic}_{sf_mode}_{'fp16' if out_dtype == 'float16' else 'bf16'}"
+            f"_m{M}_n{N}_k{K_dim}"
+        ),
+        "M": M,
+        "N": N,
+        "K": K_dim,
+        "sf_mode": sf_mode,
+        "out_dtype": out_dtype,
+        "alpha": alpha,
+        "tactic": tactic,
+    }
+
+
+CONFIGS = [
+    _case("guard", 0, (520, 520, 512), "nvfp4", "float16", 0.75),
+    _case("guard", 0, (520, 520, 512), "mxfp4", "bfloat16", 0.3333),
+    _case("guard", 1, (520, 272, 512), "mxfp4", "bfloat16", 0.3333),
+    _case("guard", 2, (272, 392, 768), "nvfp4", "float16", 0.75),
+    _case("guard", 2, (272, 392, 768), "mxfp4", "bfloat16", 0.3333),
+    _case("guard", 3, (136, 272, 512), "mxfp4", "float16", 0.75),
+    _case("guard", 4, (272, 520, 512), "nvfp4", "bfloat16", 0.3333),
+]
+
+BENCH_CONFIGS = [
+    _case("bench", 0, (4096, 2048, 7168), "nvfp4", "float16", 1.0),
+    _case("bench", 1, (4096, 1024, 3072), "mxfp4", "bfloat16", 1.0),
+    _case("bench", 2, (1024, 4096, 3072), "nvfp4", "float16", 1.0),
+    _case("bench", 3, (256, 10304, 2688), "mxfp4", "float16", 1.0),
+    _case("bench", 4, (4096, 2048, 7168), "nvfp4", "bfloat16", 1.0),
+]
+
+
+def _ceil_div(value, divisor):
+    return (value + divisor - 1) // divisor
+
+
+def _align_up(value, alignment):
+    return _ceil_div(value, alignment) * alignment
+
+
+def _descriptor_base(ldo, sdo, swizzle):
+    arrangement_type = {0: 0, 1: 6, 2: 4, 3: 2, 4: 1}[swizzle]
+    value = 0
+    value |= (ldo & 0x3FFF) << 16
+    value |= (sdo & 0x3FFF) << 32
+    value |= 1 << 46
+    value |= (arrangement_type & 0x7) << 61
+    return value & 0xFFFFFFFFFFFFFFFF
+
+
+def _descriptor_with_address(base, shared_address):
+    address_field = K.cast(
+        K.bitwise_and(K.shift_right(shared_address, K.uint32(4)), K.uint32(0x7FFF)), "uint64"
+    )
+    return K.bitwise_or(K.uint64(base), address_field)
+
+
+def _instruction_descriptor(inst_m, inst_n, sf_dtype):
+    sf_format = {"float8_e4m3fn": 0, "float8_e8m0fnu": 1}[sf_dtype]
+    value = (1 << 3) | (1 << 7) | (1 << 10)
+    value |= ((inst_n >> 3) & 0x3F) << 17
+    value |= (sf_format & 1) << 23
+    value |= ((inst_m >> 4) & 0x1F) << 24
+    return value & 0xFFFFFFFF
+
+
+def _advance(state):
+    state.advance()
+
+
+def _try_wait_acquire(dst, barrier, phase):
+    K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
+        dst, barrier, K.cast(phase, "uint32")
+    )
+
+
+def _wait_plain(barrier, phase):
+    ready = K.local_scalar("uint32", init=K.uint32(0))
+    with K.While(ready == K.uint32(0)):
+        K.ptx.mbarrier.try_wait.parity.shared.b64(
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
+        )
+
+
+def _wait_plain_if_needed(barrier, phase, speculative_ready):
+    with K.If(speculative_ready == K.uint32(0)):
+        with K.Then():
+            _wait_plain(barrier, phase)
+
+
+def _elected():
+    elected_lane = K.local_scalar("uint32")
+    elected_pred = K.local_scalar("uint32")
+    K.ptx.elect_sync(elected_lane, elected_pred, K.uint32(0xFFFFFFFF))
+    return elected_pred == K.uint32(1)
+
+
+def _validate_problem(M, N, K_dim, sf_mode, out_dtype, alpha, tactic):
+    if not 0 <= tactic < len(TACTICS):
+        raise ValueError(f"tactic must be in [0, {len(TACTICS) - 1}], got {tactic}")
+    if sf_mode not in _SF_MODES:
+        raise ValueError(f"unsupported scale mode {sf_mode!r}")
+    if out_dtype not in _OUT_DTYPES:
+        raise ValueError(f"unsupported output dtype {out_dtype!r}")
+    if min(M, N, K_dim) <= 0 or M % 8 or N % 8 or K_dim % 32:
+        raise ValueError("source requires positive M/N multiples of 8 and K multiple of 32")
+    if not isinstance(alpha, float | int):
+        raise TypeError("alpha must be a host scalar")
+    (tile_m, tile_n), (inst_m, inst_n), (cluster_m, cluster_n), swap, _ = TACTICS[tactic]
+    if tile_m not in (128, 256) or tile_n not in (64, 128, 192, 256):
+        raise ValueError("invalid source MMA tile")
+    if inst_m not in (128, 256) or inst_n != tile_n or tile_m not in (inst_m, 2 * inst_m):
+        raise ValueError("invalid source instruction/tile relation")
+    cta_group = inst_m // 128
+    if cluster_m % cta_group:
+        raise ValueError("cluster M must be divisible by the CTA group")
+    kernel_m, kernel_n = (N, M) if swap else (M, N)
+    cta_m = tile_m // cta_group
+    if kernel_m < cta_m * cluster_m or kernel_n < tile_n * cluster_n:
+        raise ValueError("problem does not fill the selected source cluster")
+
+
+@cache
+def _make_kernel(M, N, K_dim, sf_mode, out_dtype, alpha, tactic):
+    _validate_problem(M, N, K_dim, sf_mode, out_dtype, alpha, tactic)
+    (tile_m, n_tile), (inst_m, inst_n), (cluster_m, cluster_n), swap, prefetch = TACTICS[tactic]
+    sf_dtype, sf_vec_size = _SF_MODES[sf_mode]
+    cta_group = inst_m // 128
+    b_reuse = tile_m == 2 * inst_m
+    cta_m = tile_m // cta_group
+    b_rows = n_tile // cta_group
+    cluster_size = cluster_m * cluster_n
+    cluster_m_groups = cluster_m // cta_group
+    kernel_m, kernel_n = (N, M) if swap else (M, N)
+    m_tiles = _ceil_div(kernel_m, cta_m)
+    n_tiles = _ceil_div(kernel_n, n_tile)
+    cluster_m_tiles = _ceil_div(m_tiles, cluster_m)
+    cluster_n_tiles = _ceil_div(n_tiles, cluster_n)
+    cluster_work = cluster_m_tiles * cluster_n_tiles
+    num_clusters = min(cluster_work, _MAX_ACTIVE_CLUSTERS[cluster_size])
+    k_tile = 256
+    k_tiles = _ceil_div(K_dim, k_tile)
+
+    acc_stages = 1 if b_reuse and n_tile in (192, 256) else 2
+    a_stage_bytes = cta_m * k_tile // 2
+    b_stage_bytes = b_rows * k_tile // 2
+    sfa_stage_bytes = cta_m * k_tile // sf_vec_size
+    sfb_stage_bytes = _align_up(n_tile, 128) * k_tile // sf_vec_size
+    ab_stage_bytes = a_stage_bytes + b_stage_bytes + sfa_stage_bytes + sfb_stage_bytes
+    epi_n = 32
+    c_stage_bytes = 128 * epi_n * 2
+    ab_stages = (_SMEM_CAPACITY - (1024 + 2 * c_stage_bytes)) // ab_stage_bytes
+    c_stages = (
+        2
+        + (_SMEM_CAPACITY - ab_stages * ab_stage_bytes - (1024 + 2 * c_stage_bytes))
+        // c_stage_bytes
+    )
+    prefetch_distance = 0 if tactic in (2, 3) else (ab_stages if prefetch is None else prefetch)
+    alpha_is_one = float(alpha) == 1.0
+
+    ab_full_offset = 0
+    ab_empty_offset = ab_stages * 8
+    acc_full_offset = 2 * ab_stages * 8
+    acc_empty_offset = acc_full_offset + acc_stages * 8
+    tmem_dealloc_offset = acc_empty_offset + acc_stages * 8
+    tmem_ptr_offset = tmem_dealloc_offset + 8
+    c_offset = 1024
+    a_offset = c_offset + c_stages * c_stage_bytes
+    b_offset = a_offset + ab_stages * a_stage_bytes
+    sfa_offset = b_offset + ab_stages * b_stage_bytes
+    sfb_offset = _align_up(sfa_offset + ab_stages * sfa_stage_bytes, 1024)
+    shared_bytes = _align_up(sfb_offset + ab_stages * sfb_stage_bytes, 1024)
+    if shared_bytes > _SMEM_CAPACITY:
+        raise ValueError(f"dynamic shared memory {shared_bytes} exceeds {_SMEM_CAPACITY}")
+
+    ab_empty_arrivals = cluster_n + cluster_m_groups - 1
+    acc_empty_arrivals = 4 * cta_group
+    num_tma_load_bytes = ab_stage_bytes * cta_group
+    acc_columns = n_tile * acc_stages * (2 if b_reuse else 1)
+    sfa_chunks = sfa_stage_bytes // 512
+    sfb_chunks = sfb_stage_bytes // 512
+    sfa_tmem_column = acc_columns
+    sfb_tmem_column = sfa_tmem_column + sfa_chunks * 4
+    tmem_columns = _TMEM_COLUMNS
+    if sfb_tmem_column + sfb_chunks * 4 + (2 if n_tile in (64, 192) else 0) > tmem_columns:
+        raise ValueError("source TMEM intervals exceed the SM107 allocation")
+
+    a_desc_base = _descriptor_base(1, 64, 3)
+    b_desc_base = _descriptor_base(1, 64, 3)
+    sf_desc_base = _descriptor_base(1, 8, 0)
+    instr_desc = _instruction_descriptor(inst_m, inst_n, sf_dtype)
+    sf_k_box = k_tile // (4 * sf_vec_size)
+    sfb_n_box = _ceil_div(n_tile, 128)
+    a_cluster_piece = cta_m // cluster_n
+    b_cluster_piece = b_rows // cluster_m_groups
+    a_piece_bytes = a_stage_bytes // cluster_n
+    b_piece_bytes = b_stage_bytes // cluster_m_groups
+    sfa_piece_values = 256 * sf_k_box // cluster_n
+    sfa_m_box = cta_m // 128
+    sfb_piece_values = 256 * sf_k_box * sfb_n_box // cluster_m
+    epilogue_subtiles = (cta_m // 128) * (n_tile // epi_n)
+    tma_cache_hint = 0
+
+    def host_prelude(params):
+        a = params["a"]
+        b = params["b"]
+        c = params["c"]
+        sfa = params["sfa"]
+        sfb = params["sfb"]
+        a_map = K.stack_alloca("tensormap", 1)
+        b_map = K.stack_alloca("tensormap", 1)
+        sfa_map = K.stack_alloca("tensormap", 1)
+        sfb_map = K.stack_alloca("tensormap", 1)
+        c_map = K.stack_alloca("tensormap", 1)
+
+        def encode(descriptor, dtype, rank, data, *fields):
+            K.call_packed("runtime.cuTensorMapEncodeTiled", descriptor, dtype, rank, data, *fields)
+
+        encode(
+            a_map,
+            "float4_e2m1fn",
+            2,
+            a.data,
+            K_dim,
+            kernel_m,
+            K_dim // 2,
+            k_tile,
+            a_cluster_piece,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+            13,
+        )
+        encode(
+            b_map,
+            "float4_e2m1fn",
+            2,
+            b.data,
+            K_dim,
+            kernel_n,
+            K_dim // 2,
+            k_tile,
+            b_cluster_piece,
+            1,
+            1,
+            0,
+            3,
+            2,
+            0,
+            13,
+        )
+        sf_k_groups = _ceil_div(K_dim, 4 * sf_vec_size)
+        sf_m_groups = _ceil_div(kernel_m, 128)
+        sf_n_groups = _ceil_div(kernel_n, 128)
+        sfa_box_0 = min(256, sfa_piece_values)
+        sfa_box_1 = sfa_piece_values // sfa_box_0
+        encode(
+            sfa_map,
+            "uint16",
+            3,
+            sfa.data,
+            256,
+            sf_k_groups,
+            sf_m_groups,
+            512,
+            sf_k_groups * 512,
+            sfa_box_0,
+            sfa_box_1,
+            sfa_m_box,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        sfb_box_0 = min(256, sfb_piece_values)
+        sfb_remaining = sfb_piece_values // sfb_box_0
+        sfb_box_1 = min(sf_k_box, sfb_remaining)
+        sfb_box_2 = sfb_remaining // sfb_box_1
+        encode(
+            sfb_map,
+            "uint16",
+            3,
+            sfb.data,
+            256,
+            sf_k_groups,
+            sf_n_groups,
+            512,
+            sf_k_groups * 512,
+            sfb_box_0,
+            sfb_box_1,
+            sfb_box_2,
+            1,
+            1,
+            1,
+            0,
+            0,
+            2,
+            0,
+        )
+        if swap:
+            encode(
+                c_map,
+                out_dtype,
+                2,
+                c.data,
+                kernel_m,
+                kernel_n,
+                kernel_m * 2,
+                64,
+                epi_n,
+                1,
+                1,
+                0,
+                3,
+                2,
+                0,
+            )
+        else:
+            encode(
+                c_map,
+                out_dtype,
+                2,
+                c.data,
+                kernel_n,
+                kernel_m,
+                kernel_n * 2,
+                epi_n,
+                128,
+                1,
+                1,
+                0,
+                2,
+                2,
+                0,
+            )
+        return a_map, b_map, sfa_map, sfb_map, c_map
+
+    def kernel(a, b, sfa, sfb, c, alpha_ptr, *, host):
+        del a, b, sfa, sfb, c
+        required_block_size = K.attr({"tirx.required_block_size": 1})
+        required_block_size.__enter__()
+        a_map, b_map, sfa_map, sfb_map, c_map = host
+
+        if alpha_is_one:
+            alpha_value = K.local_scalar("float32", init=K.float32(1.0))
+        else:
+            alpha_raw = K.local_scalar("float32")
+            K.ptx.ld.global_.f32(alpha_raw, alpha_ptr.ptr_to([0]))
+            alpha_bits = K.local_scalar("uint16")
+            alpha_value = K.local_scalar("float32")
+            if out_dtype == "float16":
+                K.ptx.cvt.rn.f16.f32(alpha_bits, alpha_raw)
+                K.ptx.cvt.f32.f16(alpha_value, alpha_bits)
+            else:
+                K.ptx.cvt.rn.bf16.f32(alpha_bits, alpha_raw)
+                K.ptx.cvt.f32.bf16(alpha_value, alpha_bits)
+
+        _block_x, _block_y, cluster_work_id = K.cta_id()
+        cluster_x_scope, cluster_y_scope = K.cta_id_in_cluster(
+            [cluster_m, cluster_n], preferred=[cluster_m, cluster_n]
+        )
+        del _block_x, _block_y, cluster_x_scope, cluster_y_scope
+        cluster_rank = K.local_scalar("int32", init=K.cuda.mov_sreg(32, "cluster_ctarank"))
+        if cluster_m == 1:
+            cluster_x = K.local_scalar("int32", init=0)
+        else:
+            cluster_x = K.local_scalar("int32", init=cluster_rank & (cluster_m - 1))
+        if cluster_n == 1:
+            cluster_y = K.local_scalar("int32", init=0)
+        else:
+            cluster_y = K.local_scalar("int32", init=cluster_rank >> (cluster_m.bit_length() - 1))
+        if cta_group == 2:
+            cta_v = cluster_x & 1
+            leader_cta = cta_v == 0
+            cluster_m_group = cluster_x >> 1
+            pair_leader_x = cluster_m_group << 1
+            leader_rank = pair_leader_x + cluster_m * cluster_y
+        else:
+            cta_v = K.local_scalar("int32", init=0)
+            leader_cta = K.bool(True)
+            cluster_m_group = cluster_x
+            pair_leader_x = cluster_x
+            leader_rank = cluster_rank
+        warp = K.warp_id()
+        lane = K.lane_id()
+
+        roles = K.specialize(chain_dispatch=True)
+        epilogue_role = roles.role("epilogue", warps=[0, 1, 2, 3])
+        mma_role = roles.role("mma", warps=[4])
+        tma_role = roles.role("tma", warps=[5])
+
+        smem = K.alloc_buffer((shared_bytes,), K.u8, scope="shared.dyn", align=1024)
+        protocol_pool = K.smem_pool(base=smem)
+        ab_pipe = K.Pipeline(
+            protocol_pool,
+            ab_stages,
+            full="tma",
+            empty="tcgen05",
+            init_empty=ab_empty_arrivals,
+            leader=K.bool(False),
+        )
+        acc_pipe = K.Pipeline(
+            protocol_pool,
+            acc_stages,
+            full="tcgen05",
+            empty="mbar",
+            init_empty=acc_empty_arrivals,
+            leader=K.bool(False),
+        )
+        if protocol_pool.bytes != tmem_dealloc_offset:
+            raise AssertionError("protocol storage offsets changed")
+        tmem_dealloc = protocol_pool.alloc((1,), K.u64, align=8)
+        tmem_slot = protocol_pool.alloc((1,), K.u32, align=4)
+        if protocol_pool.bytes != tmem_ptr_offset + 4:
+            raise AssertionError("protocol storage header changed")
+
+        with tma_role:
+            K.ptx.prefetch.tensormap(K.address_of(a_map))
+            K.ptx.prefetch.tensormap(K.address_of(b_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfa_map))
+            K.ptx.prefetch.tensormap(K.address_of(sfb_map))
+            K.ptx.prefetch.tensormap(K.address_of(c_map))
+
+        with K.If(warp == 0):
+            with K.Then():
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, ab_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                ab_pipe.empty.ptr_to([stage]), K.uint32(ab_empty_arrivals)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.full.ptr_to([stage]), K.uint32(1)
+                            )
+                with K.If(_elected()):
+                    with K.Then():
+                        with K.unroll(0, acc_stages) as stage:
+                            K.ptx.mbarrier.init.shared.b64(
+                                acc_pipe.empty.ptr_to([stage]), K.uint32(acc_empty_arrivals)
+                            )
+        if cta_group == 2:
+            with K.If(warp == 0):
+                with K.Then():
+                    with K.If(_elected()):
+                        with K.Then():
+                            K.ptx.mbarrier.init.shared.b64(tmem_dealloc.ptr_to([0]), K.uint32(32))
+            K.ptx.fence.mbarrier_init.release.cluster()
+        K.ptx.fence.mbarrier_init.release.cluster()
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.arrive.relaxed()
+
+        smem_base = K.local_scalar("uint32")
+        K.assign(smem_base, K.cuda.cvta_generic_to_shared(smem.ptr_to([0])))
+        tmem_slot_addr = K.uniform(smem_base + K.uint32(tmem_ptr_offset))
+        cluster_smem_u64 = K.local_scalar("uint64")
+        K.ptx.cvta.to.shared__cluster.u64(cluster_smem_u64, smem.ptr_to([0]))
+        cluster_smem = K.local_scalar("uint32", init=K.cast(cluster_smem_u64, "uint32"))
+        a_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(a_desc_base, smem_base + a_offset)
+        )
+        b_descriptor = K.local_scalar(
+            "uint64", init=_descriptor_with_address(b_desc_base, smem_base + b_offset)
+        )
+
+        a_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_n in range(cluster_n):
+            K.assign(
+                a_mcast_mask,
+                K.bitwise_or(
+                    a_mcast_mask, K.uint32(1) << K.cast(cluster_x + cluster_m * peer_n, "uint32")
+                ),
+            )
+        b_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_group in range(cluster_m_groups):
+            peer_x = cta_v + cta_group * peer_group
+            K.assign(
+                b_mcast_mask,
+                K.bitwise_or(
+                    b_mcast_mask, K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32")
+                ),
+            )
+        sfb_mcast_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for peer_x in range(cluster_m):
+            K.assign(
+                sfb_mcast_mask,
+                K.bitwise_or(
+                    sfb_mcast_mask, K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32")
+                ),
+            )
+        ab_consumer_mask = K.local_scalar("uint32", init=K.uint32(0))
+        for pair_v in range(cta_group):
+            for peer_n in range(cluster_n):
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1)
+                        << K.cast(pair_leader_x + pair_v + cluster_m * peer_n, "uint32"),
+                    ),
+                )
+            for peer_group in range(cluster_m_groups):
+                peer_x = pair_v + cta_group * peer_group
+                K.assign(
+                    ab_consumer_mask,
+                    K.bitwise_or(
+                        ab_consumer_mask,
+                        K.uint32(1) << K.cast(peer_x + cluster_m * cluster_y, "uint32"),
+                    ),
+                )
+        if cta_group == 2:
+            acc_producer_mask = K.local_scalar(
+                "uint32", init=K.uint32(3) << K.cast(leader_rank, "uint32")
+            )
+        else:
+            acc_producer_mask = K.local_scalar(
+                "uint32", init=K.uint32(1) << K.cast(cluster_rank, "uint32")
+            )
+        ab_full_leader = ab_pipe.full.remote_view(leader_rank)
+        acc_empty_leader = acc_pipe.empty.remote_view(leader_rank)
+        if cluster_size > 1:
+            K.ptx.barrier.cluster.wait()
+        else:
+            K.ptx.bar.sync(K.uint32(0), K.uint32(192))
+
+        def scheduler_coords(work):
+            cluster_m_idx = work % cluster_m_tiles
+            cluster_n_idx = work // cluster_m_tiles
+            tile_m_idx = cluster_m_idx * cluster_m + cluster_x
+            tile_n_idx = cluster_n_idx * cluster_n + cluster_y
+            return tile_m_idx, tile_n_idx
+
+        def advance_work(work):
+            K.assign(work, work + num_clusters)
+
+        def cta2_tma_barrier(stage):
+            # Bit 24 is the CTA-in-pair selector; CTA2 completions target rank 0.
+            return K.bitwise_and(
+                K.cuda.cvta_generic_to_shared(ab_pipe.full.ptr_to([stage])), K.uint32(0xFEFFFFF8)
+            )
+
+        def prefetch_inputs(tile_m_idx, tile_n_idx, future_k):
+            a_coord_m = tile_m_idx * cta_m + cluster_y * a_cluster_piece
+            a_coord_k = future_k * k_tile
+            b_coord_n = tile_n_idx * n_tile + cta_v * b_rows + cluster_m_group * b_cluster_piece
+            b_coord_k = future_k * k_tile
+            sfa_linear = cluster_y * sfa_piece_values
+            sfa_coord_0 = sfa_linear % 256
+            sfa_coord_1 = future_k * sf_k_box + sfa_linear // 256
+            sfb_linear = cluster_x * sfb_piece_values
+            sfb_coord_0 = sfb_linear % 256
+            sfb_quotient = sfb_linear // 256
+            sfb_coord_1 = future_k * sf_k_box + sfb_quotient % sf_k_box
+            sfb_tile_group = tile_n_idx * n_tile // 128
+            sfb_coord_2 = sfb_tile_group + sfb_quotient // sf_k_box
+            K.ptx["cp.async.bulk.prefetch.tensor.2d.L2.global.tile.L2::cache_hint"](
+                K.address_of(a_map),
+                K.cast(a_coord_k, "int32"),
+                K.cast(a_coord_m, "int32"),
+                K.uint64(tma_cache_hint),
+            )
+            K.ptx["cp.async.bulk.prefetch.tensor.2d.L2.global.tile.L2::cache_hint"](
+                K.address_of(b_map),
+                K.cast(b_coord_k, "int32"),
+                K.cast(b_coord_n, "int32"),
+                K.uint64(tma_cache_hint),
+            )
+            K.ptx["cp.async.bulk.prefetch.tensor.3d.L2.global.tile.L2::cache_hint"](
+                K.address_of(sfa_map),
+                K.cast(sfa_coord_0, "int32"),
+                K.cast(sfa_coord_1, "int32"),
+                K.cast(tile_m_idx * sfa_m_box, "int32"),
+                K.uint64(tma_cache_hint),
+            )
+            K.ptx["cp.async.bulk.prefetch.tensor.3d.L2.global.tile.L2::cache_hint"](
+                K.address_of(sfb_map),
+                K.cast(sfb_coord_0, "int32"),
+                K.cast(sfb_coord_1, "int32"),
+                K.cast(sfb_coord_2, "int32"),
+                K.uint64(tma_cache_hint),
+            )
+
+        with tma_role:
+            tma_state = K.PipelineState(ab_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx = scheduler_coords(work)
+                if prefetch_distance > 0:
+                    prefetch_k = K.local_scalar("int32", init=0)
+                    with K.While((prefetch_k < prefetch_distance) & (prefetch_k < k_tiles)):
+                        prefetch_inputs(tile_m_idx, tile_n_idx, prefetch_k)
+                        K.assign(prefetch_k, prefetch_k + 1)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If(count < k_tiles):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase
+                        )
+                with K.While(count < k_tiles):
+                    _wait_plain_if_needed(
+                        ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase, speculative
+                    )
+                    with K.If(leader_cta):
+                        with K.Then():
+                            with K.If(_elected()):
+                                with K.Then():
+                                    K.ptx.mbarrier.arrive.expect_tx.shared.b64(
+                                        ab_pipe.full.ptr_to([tma_state.stage]),
+                                        K.uint32(num_tma_load_bytes),
+                                    )
+                    with K.If(_elected()):
+                        with K.Then():
+                            a_coord_m = tile_m_idx * cta_m + cluster_y * a_cluster_piece
+                            a_coord_k = count * k_tile
+                            a_smem_offset = (
+                                a_offset
+                                + tma_state.stage * a_stage_bytes
+                                + cluster_y * a_piece_bytes
+                            )
+                            if cta_group == 2:
+                                a_barrier = cta2_tma_barrier(tma_state.stage)
+                                if cluster_n == 1:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2"
+                                    ](
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_k, "int32"),
+                                        K.cast(a_coord_m, "int32"),
+                                        a_barrier,
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint.cta_group::2"
+                                    ](
+                                        cluster_smem + a_smem_offset,
+                                        K.address_of(a_map),
+                                        K.cast(a_coord_k, "int32"),
+                                        K.cast(a_coord_m, "int32"),
+                                        a_barrier,
+                                        K.cast(a_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                            elif cluster_n == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.2d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                ](
+                                    smem.ptr_to([a_smem_offset]),
+                                    K.address_of(a_map),
+                                    K.cast(a_coord_k, "int32"),
+                                    K.cast(a_coord_m, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint"
+                                ](
+                                    cluster_smem + a_smem_offset,
+                                    K.address_of(a_map),
+                                    K.cast(a_coord_k, "int32"),
+                                    K.cast(a_coord_m, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    with K.If(_elected()):
+                        with K.Then():
+                            b_coord_n = (
+                                tile_n_idx * n_tile
+                                + cta_v * b_rows
+                                + cluster_m_group * b_cluster_piece
+                            )
+                            b_coord_k = count * k_tile
+                            b_smem_offset = (
+                                b_offset
+                                + tma_state.stage * b_stage_bytes
+                                + cluster_m_group * b_piece_bytes
+                            )
+                            if cta_group == 2:
+                                b_barrier = cta2_tma_barrier(tma_state.stage)
+                                if cluster_m_groups == 1:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2"
+                                    ](
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_k, "int32"),
+                                        K.cast(b_coord_n, "int32"),
+                                        b_barrier,
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint.cta_group::2"
+                                    ](
+                                        cluster_smem + b_smem_offset,
+                                        K.address_of(b_map),
+                                        K.cast(b_coord_k, "int32"),
+                                        K.cast(b_coord_n, "int32"),
+                                        b_barrier,
+                                        K.cast(b_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                            elif cluster_m_groups == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.2d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                ](
+                                    smem.ptr_to([b_smem_offset]),
+                                    K.address_of(b_map),
+                                    K.cast(b_coord_k, "int32"),
+                                    K.cast(b_coord_n, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint"
+                                ](
+                                    cluster_smem + b_smem_offset,
+                                    K.address_of(b_map),
+                                    K.cast(b_coord_k, "int32"),
+                                    K.cast(b_coord_n, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+
+                    with K.If(_elected()):
+                        with K.Then():
+                            sfa_linear = cluster_y * sfa_piece_values
+                            sfa_coord_0 = sfa_linear % 256
+                            sfa_coord_1 = count * sf_k_box + sfa_linear // 256
+                            sfa_smem_offset = (
+                                sfa_offset
+                                + tma_state.stage * sfa_stage_bytes
+                                + cluster_y * (sfa_stage_bytes // cluster_n)
+                            )
+                            if cta_group == 2:
+                                if cluster_n == 1:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.L2::cache_hint.cta_group::2"
+                                    ](
+                                        cluster_smem + sfa_smem_offset,
+                                        K.address_of(sfa_map),
+                                        K.cast(sfa_coord_0, "int32"),
+                                        K.cast(sfa_coord_1, "int32"),
+                                        K.cast(tile_m_idx * sfa_m_box, "int32"),
+                                        cta2_tma_barrier(tma_state.stage),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                                else:
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                        ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                        ".L2::cache_hint.cta_group::2"
+                                    ](
+                                        cluster_smem + sfa_smem_offset,
+                                        K.address_of(sfa_map),
+                                        K.cast(sfa_coord_0, "int32"),
+                                        K.cast(sfa_coord_1, "int32"),
+                                        K.cast(tile_m_idx * sfa_m_box, "int32"),
+                                        cta2_tma_barrier(tma_state.stage),
+                                        K.cast(a_mcast_mask, "uint16"),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                            elif cluster_n == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                ](
+                                    smem.ptr_to([sfa_smem_offset]),
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx * sfa_m_box, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster.L2::cache_hint"
+                                ](
+                                    cluster_smem + sfa_smem_offset,
+                                    K.address_of(sfa_map),
+                                    K.cast(sfa_coord_0, "int32"),
+                                    K.cast(sfa_coord_1, "int32"),
+                                    K.cast(tile_m_idx * sfa_m_box, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(a_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+
+                    with K.If(_elected()):
+                        with K.Then():
+                            sfb_linear = cluster_x * sfb_piece_values
+                            sfb_coord_0 = sfb_linear % 256
+                            sfb_quotient = sfb_linear // 256
+                            sfb_coord_1 = count * sf_k_box + sfb_quotient % sf_k_box
+                            sfb_tile_group = tile_n_idx * n_tile // 128
+                            sfb_coord_2 = sfb_tile_group + sfb_quotient // sf_k_box
+                            sfb_smem_offset = (
+                                sfb_offset
+                                + tma_state.stage * sfb_stage_bytes
+                                + cluster_x * (sfb_stage_bytes // cluster_m)
+                            )
+                            if cta_group == 2:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster"
+                                    ".L2::cache_hint.cta_group::2"
+                                ](
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    cta2_tma_barrier(tma_state.stage),
+                                    K.cast(sfb_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            elif cluster_m_groups == 1:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cta.global.tile"
+                                    ".mbarrier::complete_tx::bytes.L2::cache_hint"
+                                ](
+                                    smem.ptr_to([sfb_smem_offset]),
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+                                    ".mbarrier::complete_tx::bytes.multicast::cluster.L2::cache_hint"
+                                ](
+                                    cluster_smem + sfb_smem_offset,
+                                    K.address_of(sfb_map),
+                                    K.cast(sfb_coord_0, "int32"),
+                                    K.cast(sfb_coord_1, "int32"),
+                                    K.cast(sfb_coord_2, "int32"),
+                                    ab_pipe.full.ptr_to([tma_state.stage]),
+                                    K.cast(b_mcast_mask, "uint16"),
+                                    K.uint64(tma_cache_hint),
+                                )
+                    if prefetch_distance > 0:
+                        with K.If(count < k_tiles - prefetch_distance):
+                            with K.Then():
+                                prefetch_inputs(tile_m_idx, tile_n_idx, count + prefetch_distance)
+                    _advance(tma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If(count < k_tiles):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative,
+                                ab_pipe.empty.ptr_to([tma_state.stage]),
+                                tma_state.phase,
+                            )
+                advance_work(work)
+            with K.unroll(0, ab_stages) as unused_stage:
+                _wait_plain(ab_pipe.empty.ptr_to([tma_state.stage]), tma_state.phase)
+                _advance(tma_state)
+            del unused_stage
+
+        with mma_role:
+            K.ptx.bar.sync(K.uint32(2), K.uint32(160))
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot_addr)
+            sfa_descriptor = K.local_scalar(
+                "uint64", init=_descriptor_with_address(sf_desc_base, smem_base + sfa_offset)
+            )
+            sfb_descriptor = K.local_scalar(
+                "uint64", init=_descriptor_with_address(sf_desc_base, smem_base + sfb_offset)
+            )
+            mma_state = K.PipelineState(ab_stages, phase=0)
+            acc_state = K.PipelineState(acc_stages, phase=1)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            count = K.local_scalar("int32")
+            speculative = K.local_scalar("uint32")
+            accumulate = K.local_scalar("uint32")
+
+            def runtime_descriptor(sfa_addr, sfb_addr):
+                desc = K.bitwise_and(K.uint32(instr_desc), K.uint32(0x9FFFFFCF))
+                desc = K.bitwise_or(
+                    desc, K.bitwise_and(K.shift_right(sfa_addr, K.uint32(1)), K.uint32(0x60000000))
+                )
+                return K.bitwise_or(
+                    desc, K.bitwise_and(K.shift_right(sfb_addr, K.uint32(26)), K.uint32(0x30))
+                )
+
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx = scheduler_coords(work)
+                K.assign(count, 0)
+                K.assign(speculative, K.uint32(1))
+                with K.If((count < k_tiles) & leader_cta):
+                    with K.Then():
+                        _try_wait_acquire(
+                            speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                        )
+                with K.If(leader_cta):
+                    with K.Then():
+                        _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+                K.assign(accumulate, K.uint32(0))
+                with K.While(count < k_tiles):
+                    with K.If(leader_cta):
+                        with K.Then():
+                            _wait_plain_if_needed(
+                                ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase, speculative
+                            )
+                            sfb_odd_shift = K.local_scalar(
+                                "uint32",
+                                init=K.Select(
+                                    (tile_n_idx & 1) != 0,
+                                    K.uint32(2 if n_tile in (64, 192) else 0),
+                                    K.uint32(0),
+                                ),
+                            )
+                            if b_reuse:
+                                sf_layout_scale = sf_vec_size // 16
+                                sfa_segment_chunks = 2
+                                sfb_kblock_chunks = sfb_chunks // 2
+                                for kblock in range(2):
+                                    for chunk in range(sfa_segment_chunks):
+                                        with K.If(_elected()):
+                                            with K.Then():
+                                                K.ptx[
+                                                    f"tcgen05.cp.cta_group::{cta_group}.32x128b.warpx4"
+                                                ](
+                                                    K.cast(
+                                                        tmem_base
+                                                        + sfa_tmem_column
+                                                        + kblock * (8 // sf_layout_scale)
+                                                        + chunk * (16 // sf_layout_scale),
+                                                        "uint32",
+                                                    ),
+                                                    sfa_descriptor
+                                                    + K.cast(
+                                                        mma_state.stage * (sfa_stage_bytes // 16)
+                                                        + kblock * (64 // sf_layout_scale)
+                                                        + chunk * (128 // sf_layout_scale),
+                                                        "uint64",
+                                                    ),
+                                                )
+                                    for chunk in range(sfb_kblock_chunks):
+                                        with K.If(_elected()):
+                                            with K.Then():
+                                                K.ptx[
+                                                    f"tcgen05.cp.cta_group::{cta_group}.32x128b.warpx4"
+                                                ](
+                                                    K.cast(
+                                                        tmem_base
+                                                        + sfb_tmem_column
+                                                        + kblock * sfb_kblock_chunks * 4
+                                                        + chunk * 4,
+                                                        "uint32",
+                                                    ),
+                                                    sfb_descriptor
+                                                    + K.cast(
+                                                        mma_state.stage * (sfb_stage_bytes // 16)
+                                                        + kblock * (64 // sf_layout_scale)
+                                                        + chunk * 32,
+                                                        "uint64",
+                                                    ),
+                                                )
+                                    for chunk in range(sfa_segment_chunks):
+                                        with K.If(_elected()):
+                                            with K.Then():
+                                                K.ptx[
+                                                    f"tcgen05.cp.cta_group::{cta_group}.32x128b.warpx4"
+                                                ](
+                                                    K.cast(
+                                                        tmem_base
+                                                        + sfa_tmem_column
+                                                        + (4 if sf_vec_size == 16 else 0)
+                                                        + kblock * (8 // sf_layout_scale)
+                                                        + chunk * (16 // sf_layout_scale),
+                                                        "uint32",
+                                                    ),
+                                                    sfa_descriptor
+                                                    + K.cast(
+                                                        mma_state.stage * (sfa_stage_bytes // 16)
+                                                        + kblock * (64 // sf_layout_scale)
+                                                        + (32 if sf_vec_size == 16 else 0)
+                                                        + chunk * (128 // sf_layout_scale),
+                                                        "uint64",
+                                                    ),
+                                                )
+                                    sfb_addr = K.cast(
+                                        tmem_base
+                                        + sfb_tmem_column
+                                        + kblock * sfb_kblock_chunks * 4,
+                                        "uint32",
+                                    )
+                                    sfa_keep = K.cast(
+                                        tmem_base
+                                        + sfa_tmem_column
+                                        + kblock * (8 // sf_layout_scale),
+                                        "uint32",
+                                    )
+                                    sfa_reuse = K.cast(sfa_keep + 16 // sf_layout_scale, "uint32")
+                                    keep_desc = runtime_descriptor(sfa_keep, sfb_addr)
+                                    reuse_desc = runtime_descriptor(sfa_reuse, sfb_addr)
+                                    with K.If(_elected()):
+                                        with K.Then():
+                                            K.ptx[
+                                                f"tcgen05.mma.cta_group::{cta_group}.kind::mxf4nvf4"
+                                                f".block_scale.block{sf_vec_size}"
+                                                ".collector::a::discard.collector::b::fill"
+                                            ](
+                                                K.cast(
+                                                    tmem_base + acc_state.stage * n_tile * 2,
+                                                    "uint32",
+                                                ),
+                                                a_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (a_stage_bytes // 16)
+                                                    + kblock * 4,
+                                                    "uint64",
+                                                ),
+                                                b_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (b_stage_bytes // 16)
+                                                    + kblock * 4,
+                                                    "uint64",
+                                                ),
+                                                keep_desc,
+                                                sfa_keep,
+                                                sfb_addr,
+                                                K.ptx.pred(K.cast(accumulate, "bool")),
+                                            )
+                                    with K.If(_elected()):
+                                        with K.Then():
+                                            K.ptx[
+                                                f"tcgen05.mma.cta_group::{cta_group}.kind::mxf4nvf4"
+                                                f".block_scale.block{sf_vec_size}"
+                                                ".collector::a::discard.collector::b::lastuse"
+                                            ](
+                                                K.cast(
+                                                    tmem_base
+                                                    + acc_state.stage * n_tile * 2
+                                                    + n_tile,
+                                                    "uint32",
+                                                ),
+                                                a_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (a_stage_bytes // 16)
+                                                    + 1024
+                                                    + kblock * 4,
+                                                    "uint64",
+                                                ),
+                                                b_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (b_stage_bytes // 16)
+                                                    + kblock * 4,
+                                                    "uint64",
+                                                ),
+                                                reuse_desc,
+                                                sfa_reuse,
+                                                sfb_addr,
+                                                K.ptx.pred(K.cast(accumulate, "bool")),
+                                            )
+                                    K.assign(accumulate, K.uint32(1))
+                            else:
+                                mma_name = (
+                                    f"tcgen05.mma.cta_group::{cta_group}.kind::mxf4nvf4"
+                                    f".block_scale.block{sf_vec_size}.collector::a::discard"
+                                )
+                                for sf_chunk in range(sfa_chunks):
+                                    with K.If(_elected()):
+                                        with K.Then():
+                                            K.ptx[
+                                                f"tcgen05.cp.cta_group::{cta_group}.32x128b.warpx4"
+                                            ](
+                                                K.cast(
+                                                    tmem_base + sfa_tmem_column + sf_chunk * 4,
+                                                    "uint32",
+                                                ),
+                                                sfa_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (sfa_stage_bytes // 16)
+                                                    + sf_chunk * 32,
+                                                    "uint64",
+                                                ),
+                                            )
+                                for sf_chunk in range(sfb_chunks):
+                                    sfb_shared_chunk = (
+                                        sf_chunk % sfb_n_box
+                                    ) * sf_k_box + sf_chunk // sfb_n_box
+                                    with K.If(_elected()):
+                                        with K.Then():
+                                            K.ptx[
+                                                f"tcgen05.cp.cta_group::{cta_group}.32x128b.warpx4"
+                                            ](
+                                                K.cast(
+                                                    tmem_base + sfb_tmem_column + sf_chunk * 4,
+                                                    "uint32",
+                                                ),
+                                                sfb_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (sfb_stage_bytes // 16)
+                                                    + sfb_shared_chunk * 32,
+                                                    "uint64",
+                                                ),
+                                            )
+                                for kblock in range(2):
+                                    sfa_addr = K.cast(
+                                        tmem_base
+                                        + sfa_tmem_column
+                                        + kblock * (sfa_chunks // 2) * 4,
+                                        "uint32",
+                                    )
+                                    sfb_addr = K.cast(
+                                        tmem_base
+                                        + sfb_tmem_column
+                                        + sfb_odd_shift
+                                        + kblock * (sfb_chunks // 2) * 4,
+                                        "uint32",
+                                    )
+                                    mma_desc = runtime_descriptor(sfa_addr, sfb_addr)
+                                    with K.If(_elected()):
+                                        with K.Then():
+                                            K.ptx[mma_name](
+                                                K.cast(
+                                                    tmem_base + acc_state.stage * n_tile, "uint32"
+                                                ),
+                                                a_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (a_stage_bytes // 16)
+                                                    + kblock * 4,
+                                                    "uint64",
+                                                ),
+                                                b_descriptor
+                                                + K.cast(
+                                                    mma_state.stage * (b_stage_bytes // 16)
+                                                    + kblock * 4,
+                                                    "uint64",
+                                                ),
+                                                mma_desc,
+                                                sfa_addr,
+                                                sfb_addr,
+                                                K.ptx.pred(K.cast(accumulate, "bool")),
+                                            )
+                                    K.assign(accumulate, K.uint32(1))
+                            with K.If(_elected()):
+                                with K.Then():
+                                    if cluster_size == 1:
+                                        K.ptx[
+                                            f"tcgen05.commit.cta_group::{cta_group}.mbarrier::"
+                                            "arrive::one.shared::cluster.b64"
+                                        ](ab_pipe.empty.ptr_to([mma_state.stage]))
+                                    else:
+                                        K.ptx[
+                                            f"tcgen05.commit.cta_group::{cta_group}.mbarrier::"
+                                            "arrive::one.shared::cluster.multicast::cluster.b64"
+                                        ](
+                                            ab_pipe.empty.ptr_to([mma_state.stage]),
+                                            K.cast(ab_consumer_mask, "uint16"),
+                                        )
+                    _advance(mma_state)
+                    K.assign(count, count + 1)
+                    K.assign(speculative, K.uint32(1))
+                    with K.If((count < k_tiles) & leader_cta):
+                        with K.Then():
+                            _try_wait_acquire(
+                                speculative, ab_pipe.full.ptr_to([mma_state.stage]), mma_state.phase
+                            )
+                with K.If(leader_cta):
+                    with K.Then():
+                        with K.If(_elected()):
+                            with K.Then():
+                                if cluster_size == 1:
+                                    K.ptx[
+                                        f"tcgen05.commit.cta_group::{cta_group}.mbarrier::"
+                                        "arrive::one.shared::cluster.b64"
+                                    ](acc_pipe.full.ptr_to([acc_state.stage]))
+                                else:
+                                    K.ptx[
+                                        f"tcgen05.commit.cta_group::{cta_group}.mbarrier::"
+                                        "arrive::one.shared::cluster.multicast::cluster.b64"
+                                    ](
+                                        acc_pipe.full.ptr_to([acc_state.stage]),
+                                        K.cast(acc_producer_mask, "uint16"),
+                                    )
+                _advance(acc_state)
+                advance_work(work)
+            with K.If(leader_cta):
+                with K.Then():
+                    for _ in range(acc_stages - 1):
+                        _advance(acc_state)
+                    _wait_plain(acc_pipe.empty.ptr_to([acc_state.stage]), acc_state.phase)
+
+        with epilogue_role:
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx[
+                        f"tcgen05.alloc.exclusive.cta_group::{cta_group}.sync.aligned."
+                        "shared::cta.b32"
+                    ](tmem_slot_addr, K.uint32(tmem_columns))
+            K.ptx.bar.sync(K.uint32(2), K.uint32(160))
+            tmem_base = K.local_scalar("uint32")
+            K.ptx.ld.shared.b32(tmem_base, tmem_slot_addr)
+            acc_state = K.PipelineState(acc_stages, phase=0)
+            work = K.local_scalar("int32", init=cluster_work_id)
+            executed_subtiles = K.local_scalar("int32", init=0)
+            values = K.alloc_local((32,), "float32")
+            words = K.alloc_local((16,), "uint32")
+            offsets = K.alloc_local((4,), "int32")
+
+            def scale_and_pack():
+                if not alpha_is_one:
+                    for index in range(0, 32, 2):
+                        packed = K.local_scalar("uint64")
+                        scale_pair = K.local_scalar("uint64")
+                        K.ptx.mov.b64(packed, values[index], values[index + 1])
+                        K.ptx.mov.b64(scale_pair, alpha_value, alpha_value)
+                        K.ptx.mul.f32x2(packed, scale_pair, packed)
+                        K.ptx.mov.b64(values[index], values[index + 1], packed)
+                for index in range(16):
+                    if out_dtype == "float16":
+                        K.ptx.cvt.rn.f16x2.f32(
+                            words[index], values[index * 2 + 1], values[index * 2]
+                        )
+                    else:
+                        K.ptx.cvt.rn.bf16x2.f32(
+                            words[index], values[index * 2 + 1], values[index * 2]
+                        )
+
+            def row_major_output_offset(stage, vector):
+                row_bytes = epi_n * 2
+                unswizzled = (
+                    smem_base
+                    + c_offset
+                    + stage * c_stage_bytes
+                    + warp * (32 * row_bytes)
+                    + lane * row_bytes
+                    + vector * 16
+                )
+                swizzled = K.bitwise_xor(
+                    unswizzled, K.bitwise_and(K.shift_right(unswizzled, K.uint32(3)), K.uint32(48))
+                )
+                return K.cast(swizzled - smem_base, "int32")
+
+            with K.While(work < cluster_work):
+                tile_m_idx, tile_n_idx = scheduler_coords(work)
+                _wait_plain(acc_pipe.full.ptr_to([acc_state.stage]), acc_state.phase)
+                subtile = K.local_scalar("int32", init=0)
+                with K.While(subtile < epilogue_subtiles):
+                    m_subtile = subtile % (cta_m // 128)
+                    n_subtile = subtile // (cta_m // 128)
+                    tmem_address = K.local_scalar(
+                        "uint32",
+                        init=(
+                            tmem_base
+                            + (warp << 21)
+                            + acc_state.stage * n_tile * (2 if b_reuse else 1)
+                            + m_subtile * n_tile
+                            + n_subtile * epi_n
+                        ),
+                    )
+                    if swap:
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x4.b32"](
+                            *[values[index] for index in range(16)], tmem_address
+                        )
+                        K.ptx["tcgen05.ld.sync.aligned.16x256b.x4.b32"](
+                            *[values[index] for index in range(16, 32)],
+                            tmem_address + K.uint32(1 << 20),
+                        )
+                    else:
+                        K.ptx["tcgen05.ld.sync.aligned.32x32b.x32.b32"](
+                            *[values[index] for index in range(32)], tmem_address
+                        )
+                    scale_and_pack()
+                    output_stage = executed_subtiles % c_stages
+                    if not swap:
+                        for vector in range(4):
+                            K.assign(offsets[vector], row_major_output_offset(output_stage, vector))
+                        for vector in range(4):
+                            K.ptx.st.shared.v4.b32(
+                                smem.ptr_to([offsets[vector]]),
+                                words[vector * 4],
+                                words[vector * 4 + 1],
+                                words[vector * 4 + 2],
+                                words[vector * 4 + 3],
+                            )
+                    else:
+                        thread = warp * 32 + lane
+                        temporary = K.bitwise_or(
+                            K.bitwise_and(thread << 5, K.int32(6144)),
+                            K.bitwise_and(thread, K.int32(40)),
+                        )
+                        raw_address = K.bitwise_or(
+                            K.bitwise_or(K.bitwise_and(thread << 7, K.int32(896)), temporary << 1),
+                            K.bitwise_and(thread << 6, K.int32(1024)),
+                        )
+                        first_unswizzled = (
+                            smem_base + c_offset + output_stage * c_stage_bytes + raw_address
+                        )
+                        first_swizzled = K.bitwise_xor(
+                            first_unswizzled,
+                            K.bitwise_and(
+                                K.shift_right(first_unswizzled, K.uint32(3)), K.uint32(112)
+                            ),
+                        )
+                        second_unswizzled = first_unswizzled + 32
+                        second_swizzled = K.bitwise_xor(
+                            second_unswizzled,
+                            K.bitwise_and(
+                                K.shift_right(second_unswizzled, K.uint32(3)), K.uint32(112)
+                            ),
+                        )
+                        K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                            smem.ptr_to([K.cast(first_swizzled - smem_base, "int32")]),
+                            words[0],
+                            words[1],
+                            words[2],
+                            words[3],
+                        )
+                        K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                            smem.ptr_to([K.cast(first_swizzled - smem_base + 2048, "int32")]),
+                            words[4],
+                            words[5],
+                            words[6],
+                            words[7],
+                        )
+                        K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                            smem.ptr_to([K.cast(second_swizzled - smem_base, "int32")]),
+                            words[8],
+                            words[9],
+                            words[10],
+                            words[11],
+                        )
+                        K.ptx.stmatrix.sync.aligned.m8n8.x4.trans.shared.b16(
+                            smem.ptr_to([K.cast(second_swizzled - smem_base + 2048, "int32")]),
+                            words[12],
+                            words[13],
+                            words[14],
+                            words[15],
+                        )
+                    K.ptx.fence.proxy.async_.shared__cta()
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    with K.If(warp == 0):
+                        with K.Then():
+                            if swap:
+                                for row_copy in range(2):
+                                    K.ptx[
+                                        "cp.async.bulk.tensor.2d.global.shared::cta.tile"
+                                        ".bulk_group.L2::cache_hint"
+                                    ](
+                                        K.address_of(c_map),
+                                        K.cast(
+                                            tile_m_idx * cta_m + m_subtile * 128 + row_copy * 64,
+                                            "int32",
+                                        ),
+                                        K.cast(tile_n_idx * n_tile + n_subtile * epi_n, "int32"),
+                                        smem.ptr_to(
+                                            [
+                                                c_offset
+                                                + output_stage * c_stage_bytes
+                                                + row_copy * 4096
+                                            ]
+                                        ),
+                                        K.uint64(tma_cache_hint),
+                                    )
+                            else:
+                                K.ptx[
+                                    "cp.async.bulk.tensor.2d.global.shared::cta.tile"
+                                    ".bulk_group.L2::cache_hint"
+                                ](
+                                    K.address_of(c_map),
+                                    K.cast(tile_n_idx * n_tile + n_subtile * epi_n, "int32"),
+                                    K.cast(tile_m_idx * cta_m + m_subtile * 128, "int32"),
+                                    smem.ptr_to([c_offset + output_stage * c_stage_bytes]),
+                                    K.uint64(tma_cache_hint),
+                                )
+                            K.ptx.cp.async_.bulk.commit_group()
+                            K.ptx.cp.async_.bulk.wait_group.read(c_stages - 1)
+                    K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                    K.assign(executed_subtiles, executed_subtiles + 1)
+                    K.assign(subtile, subtile + 1)
+                K.ptx.bar.sync(K.uint32(1), K.uint32(128))
+                with K.If(_elected()):
+                    with K.Then():
+                        if cta_group == 2:
+                            K.ptx.mbarrier.arrive.shared__cluster.b64(
+                                acc_empty_leader.ptr_to([acc_state.stage]), K.uint32(1)
+                            )
+                        else:
+                            K.ptx.mbarrier.arrive.shared.b64(
+                                acc_pipe.empty.ptr_to([acc_state.stage]), K.uint32(1)
+                            )
+                _advance(acc_state)
+                advance_work(work)
+
+            K.ptx.cp.async_.bulk.wait_group.read(0)
+            with K.If(warp == 0):
+                with K.Then():
+                    K.ptx[f"tcgen05.relinquish_alloc_permit.cta_group::{cta_group}.sync.aligned"]()
+            with K.If(warp == 0):
+                with K.Then():
+                    if cta_group == 2:
+                        remote_dealloc = K.local_scalar("uint32")
+                        K.ptx.mapa.shared__cluster.u32(
+                            remote_dealloc,
+                            K.cuda.cvta_generic_to_shared(tmem_dealloc.ptr_to([0])),
+                            K.cast(cluster_rank ^ 1, "uint32"),
+                        )
+                        K.ptx.mbarrier.arrive.shared__cluster.b64(remote_dealloc, K.uint32(1))
+                        _wait_plain(tmem_dealloc.ptr_to([0]), K.uint32(0))
+                    K.ptx[f"tcgen05.dealloc.exclusive.cta_group::{cta_group}.sync.aligned.b32"](
+                        tmem_base, K.uint32(tmem_columns)
+                    )
+
+        required_block_size.__exit__(None, None, None)
+
+    kernel.__annotations__ = {
+        "a": K.gptr[K.u8, (kernel_m * K_dim // 2,)],
+        "b": K.gptr[K.u8, (kernel_n * K_dim // 2,)],
+        "sfa": K.gptr[K.u8, (_ceil_div(kernel_m, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "sfb": K.gptr[K.u8, (_ceil_div(kernel_n, 128) * _ceil_div(K_dim, 4 * sf_vec_size) * 512,)],
+        "c": K.gptr[K.u8, (kernel_m * kernel_n * 2,)],
+        "alpha_ptr": K.gptr[K.f32, (1,)],
+    }
+    return K.kernel(
+        warps=6,
+        arch="sm_107a",
+        min_blocks_per_sm=1,
+        grid=[cluster_m, cluster_n, num_clusters],
+        host_prelude=host_prelude,
+    )(kernel)
+
+
+def get_kernel(M, N, K, sf_mode, out_dtype, alpha, tactic):
+    """Return the concrete batchless SM107 kernel specialization."""
+    return _make_kernel(M, N, K, sf_mode, out_dtype, alpha, tactic).func
+
+
+_FP4_VALUES = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+_PAYLOAD_VALUES = (-2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0)
+_SF_VALUES = (1.0, 2.0)
+_OUTPUT_GUARD = 256
+
+
+def _torch_dtype(torch, dtype):
+    return {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float8_e4m3fn": torch.float8_e4m3fn,
+        "float8_e8m0fnu": torch.float8_e8m0fnu,
+    }[dtype]
+
+
+def _generator(torch, seed):
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    return generator
+
+
+def _packed_operand(torch, rows, K_dim, seed):
+    table = torch.tensor(_PAYLOAD_VALUES, dtype=torch.float32, device="cuda")
+    indices = torch.randint(
+        0,
+        len(_PAYLOAD_VALUES),
+        (rows, K_dim),
+        device="cuda",
+        generator=_generator(torch, seed),
+        dtype=torch.int64,
+    )
+    values = table[indices]
+    magnitudes = torch.tensor(_FP4_VALUES[:8], dtype=torch.float32, device="cuda")
+    matches = values.abs().unsqueeze(-1) == magnitudes
+    codes = matches.to(torch.uint8).argmax(dim=-1).to(torch.uint8)
+    codes = codes | ((values < 0).to(torch.uint8) << 3)
+    packed = (codes[:, 0::2] | (codes[:, 1::2] << 4)).contiguous()
+    return {"raw": packed.reshape(-1), "matrix": packed, "values": values}
+
+
+def _scale_factors(torch, rows, K_dim, sf_dtype, sf_vec_size, seed):
+    rest_m = _ceil_div(rows, 128)
+    sf_k = _ceil_div(K_dim, sf_vec_size)
+    rest_k = _ceil_div(sf_k, 4)
+    values = torch.tensor(_SF_VALUES, dtype=torch.float32, device="cuda")
+    indices = torch.randint(
+        0,
+        len(_SF_VALUES),
+        (1, rest_m, rest_k, 32, 4, 4),
+        device="cuda",
+        generator=_generator(torch, seed),
+        dtype=torch.int64,
+    )
+    storage = values[indices].to(_torch_dtype(torch, sf_dtype)).contiguous()
+    row = torch.arange(rows, device="cuda", dtype=torch.int64)
+    group = torch.arange(sf_k, device="cuda", dtype=torch.int64)
+    logical = storage[
+        0,
+        (row // 128)[:, None],
+        (group // 4)[None, :],
+        (row % 32)[:, None],
+        ((row // 32) % 4)[:, None],
+        (group % 4)[None, :],
+    ].float()
+    return {"storage": storage, "raw": storage.view(torch.uint8).reshape(-1), "values": logical}
+
+
+def _guarded_output(torch, M, N, dtype, fill_byte):
+    payload_bytes = M * N * 2
+    allocation = torch.full(
+        (payload_bytes + 2 * _OUTPUT_GUARD,), fill_byte, dtype=torch.uint8, device="cuda"
+    )
+    raw = allocation[_OUTPUT_GUARD : _OUTPUT_GUARD + payload_bytes]
+    output = raw.view(dtype).reshape(M, N)
+    output.fill_(float("nan"))
+    return {"allocation": allocation, "raw": raw, "output": output, "fill": fill_byte}
+
+
+def prepare_data(M, N, K, sf_mode, out_dtype, alpha, tactic):
+    """Allocate deterministic exact-valued inputs shared by TIRx, source, and oracle."""
+    _validate_problem(M, N, K, sf_mode, out_dtype, alpha, tactic)
+    import torch
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 7):
+        raise RuntimeError("dense_blockscaled_gemm_sm107 requires an SM107 CUDA device")
+    sf_dtype, sf_vec_size = _SF_MODES[sf_mode]
+    a = _packed_operand(torch, M, K, 101)
+    b = _packed_operand(torch, N, K, 211)
+    sfa = _scale_factors(torch, M, K, sf_dtype, sf_vec_size, 307)
+    sfb = _scale_factors(torch, N, K, sf_dtype, sf_vec_size, 401)
+    output_dtype = _torch_dtype(torch, out_dtype)
+    tirx = _guarded_output(torch, M, N, output_dtype, 0xA5)
+    source = _guarded_output(torch, M, N, output_dtype, 0x5A)
+    alpha_tensor = torch.tensor([float(alpha)], dtype=torch.float32, device="cuda")
+    return {
+        "a": a,
+        "b": b,
+        "sfa": sfa,
+        "sfb": sfb,
+        "tirx": tirx,
+        "source": source,
+        "alpha": alpha_tensor,
+        "config": {
+            "M": M,
+            "N": N,
+            "K": K,
+            "sf_mode": sf_mode,
+            "out_dtype": out_dtype,
+            "alpha": alpha,
+            "tactic": tactic,
+        },
+    }
+
+
+@cache
+def _compile_executable(M, N, K_dim, sf_mode, out_dtype, alpha, tactic):
+    from tirx_kernels.runner import compile_kernel
+
+    return compile_kernel(get_kernel(M, N, K_dim, sf_mode, out_dtype, alpha, tactic))
+
+
+def _tirx_launch(executable, data):
+    swap = TACTICS[data["config"]["tactic"]][3]
+    a_raw = data["b"]["raw"] if swap else data["a"]["raw"]
+    b_raw = data["a"]["raw"] if swap else data["b"]["raw"]
+    sfa_raw = data["sfb"]["raw"] if swap else data["sfa"]["raw"]
+    sfb_raw = data["sfa"]["raw"] if swap else data["sfb"]["raw"]
+
+    def launch():
+        executable(a_raw, b_raw, sfa_raw, sfb_raw, data["tirx"]["raw"], data["alpha"])
+
+    launch._keep_alive = data
+    return launch
+
+
+def _register_package(name, path):
+    module = types.ModuleType(name)
+    module.__package__ = name
+    module.__path__ = [str(path)]
+    sys.modules[name] = module
+
+
+@cache
+def _install_cutlass_parent():
+    parent_path = _CUTLASS_ROOT / _CUTLASS_PARENT_RELATIVE
+    if not parent_path.is_file():
+        raise RuntimeError(f"missing pinned CUTLASS parent: {parent_path}")
+    actual = hashlib.sha256(parent_path.read_bytes()).hexdigest()
+    if actual != CUTLASS_PARENT_SHA256:
+        raise RuntimeError(f"CUTLASS parent hash mismatch: sha256={actual}")
+    package_paths = (
+        ("nvidia_cutlass_dsl.examples", _CUTLASS_ROOT / "examples/python"),
+        ("nvidia_cutlass_dsl.examples.CuTeDSL", _CUTLASS_ROOT / "examples/python/CuTeDSL"),
+        (
+            "nvidia_cutlass_dsl.examples.CuTeDSL.cute",
+            _CUTLASS_ROOT / "examples/python/CuTeDSL/cute",
+        ),
+        (
+            "nvidia_cutlass_dsl.examples.CuTeDSL.cute.blackwell",
+            _CUTLASS_ROOT / "examples/python/CuTeDSL/cute/blackwell",
+        ),
+        (
+            "nvidia_cutlass_dsl.examples.CuTeDSL.cute.blackwell.kernel",
+            _CUTLASS_ROOT / "examples/python/CuTeDSL/cute/blackwell/kernel",
+        ),
+        (
+            "nvidia_cutlass_dsl.examples.CuTeDSL.cute.blackwell.kernel.blockscaled_gemm",
+            _CUTLASS_ROOT / "examples/python/CuTeDSL/cute/blackwell/kernel/blockscaled_gemm",
+        ),
+    )
+    for name, path in package_paths:
+        _register_package(name, path)
+    spec = importlib.util.spec_from_file_location(_CUTLASS_PARENT_MODULE, parent_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load pinned CUTLASS parent: {parent_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_CUTLASS_PARENT_MODULE] = module
+    spec.loader.exec_module(module)
+
+
+@cache
+def _source_runner(out_dtype, sf_mode):
+    source_files = {
+        "flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py": SOURCE_SHA256,
+        "flashinfer/gemm/kernels/epilogue_utils.py": SOURCE_DEPENDENCY_SHA256["epilogue_utils.py"],
+        "flashinfer/gemm/gemm_base.py": SOURCE_DEPENDENCY_SHA256["gemm_base.py"],
+        "flashinfer/gemm/kernels/utils.py": SOURCE_DEPENDENCY_SHA256["kernels/utils.py"],
+    }
+    for relative, expected in source_files.items():
+        source = _SOURCE_ROOT / relative
+        if not source.is_file():
+            raise RuntimeError(f"frozen FlashInfer source is unavailable: {source}")
+        actual = hashlib.sha256(source.read_bytes()).hexdigest()
+        if actual != expected:
+            raise RuntimeError(f"frozen source hash mismatch: {source} sha256={actual}")
+    _install_cutlass_parent()
+    loaded = sys.modules.get("flashinfer")
+    loaded_file = Path(getattr(loaded, "__file__", "")).resolve() if loaded else None
+    if loaded_file is not None and _SOURCE_ROOT not in loaded_file.parents:
+        for name in tuple(sys.modules):
+            if name == "flashinfer" or name.startswith("flashinfer."):
+                del sys.modules[name]
+    source_root = str(_SOURCE_ROOT)
+    if source_root not in sys.path:
+        sys.path.insert(0, source_root)
+    import torch
+
+    gemm_base = importlib.import_module("flashinfer.gemm.gemm_base")
+    return gemm_base._cute_dsl_gemm_fp4_runner(
+        10, 7, False, _torch_dtype(torch, out_dtype), sf_mode == "nvfp4"
+    )
+
+
+def _source_launch(data):
+    config = data["config"]
+    runner = _source_runner(config["out_dtype"], config["sf_mode"])
+    (tile_m, tile_n), (inst_m, inst_n), cluster, swap, prefetch = TACTICS[config["tactic"]]
+    tactic_tuple = (
+        (tile_m, tile_n),
+        cluster,
+        swap,
+        False,
+        "sm107",
+        (inst_m, inst_n, 128, 256, prefetch),
+    )
+    inputs = [
+        data["a"]["matrix"],
+        data["b"]["matrix"].T,
+        data["sfa"]["raw"],
+        data["sfb"]["raw"],
+        data["alpha"],
+        None,
+        data["source"]["output"],
+        None,
+        None,
+        None,
+    ]
+
+    def launch():
+        runner.forward(inputs, tactic=tactic_tuple)
+
+    launch._keep_alive = (data, inputs, runner)
+    return launch
+
+
+def _assert_guards(data):
+    for name in ("tirx", "source"):
+        guarded = data[name]
+        allocation = guarded["allocation"]
+        expected = guarded["fill"]
+        prefix = allocation[:_OUTPUT_GUARD]
+        suffix = allocation[-_OUTPUT_GUARD:]
+        if not bool(((prefix == expected).all() & (suffix == expected).all()).item()):
+            raise AssertionError(f"{name} output guard was modified")
+
+
+def _oracle(data):
+    import torch
+
+    config = data["config"]
+    sf_vec_size = _SF_MODES[config["sf_mode"]][1]
+    a_scales = data["sfa"]["values"].repeat_interleave(sf_vec_size, dim=1)[:, : config["K"]]
+    b_scales = data["sfb"]["values"].repeat_interleave(sf_vec_size, dim=1)[:, : config["K"]]
+    effective_a = data["a"]["values"].double() * a_scales.double()
+    effective_b = data["b"]["values"].double() * b_scales.double()
+    rounded_alpha = (
+        torch.tensor(
+            float(config["alpha"]), dtype=_torch_dtype(torch, config["out_dtype"]), device="cuda"
+        )
+        .float()
+        .double()
+    )
+    return (effective_a @ effective_b.T * rounded_alpha).to(
+        _torch_dtype(torch, config["out_dtype"])
+    )
+
+
+def _validate_outputs(data, *, with_source, with_oracle):
+    import torch
+
+    actual = data["tirx"]["output"]
+    if not bool(torch.isfinite(actual.float()).all().item()):
+        raise AssertionError("TIRx output contains a non-finite value")
+    _assert_guards(data)
+    result = {"bitwise_source": None, "bitwise_oracle": None, "max_abs_diff": 0.0}
+    if with_source:
+        expected = data["source"]["output"]
+        if not bool(torch.isfinite(expected.float()).all().item()):
+            raise AssertionError("source output contains a non-finite value")
+        if not torch.equal(actual, expected):
+            delta = (actual.float() - expected.float()).abs()
+            worst = int(torch.argmax(delta).item())
+            raise AssertionError(
+                "bitwise mismatch against frozen FlashInfer source: "
+                f"differing={int((actual != expected).sum().item())}, "
+                f"max_abs_diff={float(delta.max().item())}, flat_index={worst}"
+            )
+        result["bitwise_source"] = True
+    if with_oracle:
+        oracle = _oracle(data)
+        if not torch.equal(actual, oracle):
+            delta = (actual.float() - oracle.float()).abs()
+            worst = int(torch.argmax(delta).item())
+            raise AssertionError(
+                "zero-tolerance mismatch against independent FP64 oracle: "
+                f"differing={int((actual != oracle).sum().item())}, "
+                f"max_abs_diff={float(delta.max().item())}, flat_index={worst}"
+            )
+        result["bitwise_oracle"] = True
+    return result
+
+
+def run_test(M, N, K, sf_mode, out_dtype, alpha, tactic):
+    import torch
+
+    data = prepare_data(M, N, K, sf_mode, out_dtype, alpha, tactic)
+    executable = _compile_executable(M, N, K, sf_mode, out_dtype, alpha, tactic)
+    tirx_launch = _tirx_launch(executable, data)
+    source_launch = _source_launch(data)
+    tirx_launch()
+    source_launch()
+    torch.cuda.synchronize()
+    first = data["tirx"]["output"].clone()
+    data["tirx"]["output"].fill_(float("nan"))
+    tirx_launch()
+    torch.cuda.synchronize()
+    if not torch.equal(first, data["tirx"]["output"]):
+        raise AssertionError("TIRx output is not deterministic across identical launches")
+    return _validate_outputs(data, with_source=True, with_oracle=True)
+
+
+def prepare_bench(M, N, K, sf_mode, out_dtype, alpha, tactic):
+    from tirx_kernels.runner import prepared_gpu_benchmark
+
+    _validate_problem(M, N, K, sf_mode, out_dtype, alpha, tactic)
+    state = {
+        "config": {
+            "M": M,
+            "N": N,
+            "K": K,
+            "sf_mode": sf_mode,
+            "out_dtype": out_dtype,
+            "alpha": alpha,
+            "tactic": tactic,
+        },
+        "executable": _compile_executable(M, N, K, sf_mode, out_dtype, alpha, tactic),
+    }
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
+    import torch
+
+    from tirx_kernels.runner import bench, external_references_enabled
+
+    config = {**prepared["config"], **kwargs}
+    data = prepare_data(**config)
+    tirx_launch = _tirx_launch(prepared["executable"], data)
+    tirx_launch()
+    torch.cuda.synchronize()
+    references = None
+    with_source = external_references_enabled()
+    if with_source:
+        source_launch = _source_launch(data)
+        source_launch()
+        torch.cuda.synchronize()
+        references = {"flashinfer": lambda: source_launch}
+    _validate_outputs(data, with_source=with_source, with_oracle=False)
+    return bench(
+        {"tirx": tirx_launch},
+        references=references,
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(
+    M,
+    N,
+    K,
+    sf_mode,
+    out_dtype,
+    alpha,
+    tactic,
+    *,
+    warmup=None,
+    repeat=None,
+    timer=None,
+    rounds=1,
+    cooldown_s=1.0,
+):
+    return prepare_bench(M, N, K, sf_mode, out_dtype, alpha, tactic).run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+__all__ = [
+    "BENCH_CONFIGS",
+    "CONFIGS",
+    "KERNEL_META",
+    "TACTICS",
+    "get_kernel",
+    "prepare_bench",
+    "prepare_data",
+    "run_bench",
+    "run_gpu",
+    "run_test",
+]


### PR DESCRIPTION
## Summary

Eight new kernel ports plus the registry, bench-suite, reference-dependency and licensing updates they need.

### New ports

| Registry name | Upstream | Runtime arch |
|---|---|---|
| `cake_vsa_blk128_compact_sm100` | FlashInfer `csrc/cake_vsa/cake_vsa_blk128_compact_sm_100a.cu` @ c5365737 | sm_100a |
| `cake_vsa_longseq_sm100` | FlashInfer `csrc/cake_vsa/cake_vsa_longseq_sm_100a.cu` @ c5365737 | sm_100a |
| `cake_vsa_ultrasparse_bsr_sm100` | FlashInfer `csrc/cake_vsa/cake_vsa_ultrasparse_bsr_sm_100a.cu` @ c5365737 | sm_100a |
| `cake_vsa_longseq_sm103` | FlashInfer `csrc/cake_vsa/cake_vsa_longseq_sm_103a.cu` @ cc6e8794 | sm_103a |
| `flash_attention4_fp4` | hao-ai-lab/flash-attention-fp4 `flash_attn/cute/flash_fwd_sm100_fp4.py` @ 5aa37a96 (NVFP4 / MXFP8 QK, BF16 / FP8 / NVFP4 / MXFP8 V, head dim 64 and 128) | sm_103a |
| `fastcu_nvfp4_gemm_gb300` | pranjalssh/fast.cu `gb300/nvfp4/gemm9.cuh` @ 2dfe5e26 | sm_103a |
| `dense_blockscaled_gemm_sm107` | FlashInfer `flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py` (CuTeDSL) | sm_107a |
| `cudnn_sm100_gdn2_recompute_f16` | cuDNN Frontend `frost/kernel/gdn2_recompute_f16.py` @ aded9909 | sm_100a / sm_103a / sm_107a |

Each port ships its bench-suite yaml under `tirx_kernels/bench_suite/config/` and a porting sketch under `.agents/sketch/`.

### Registry and bench suite

- Registry tests now cover sm_103a-only kernels; the per-arch-set counts are 9 (sm_100a), 3 (sm_103a), 2 (sm_107a) and 90 (all three).
- Cake VSA ports pin only `flashinfer-python`: the reference loads a prebuilt cubin through FlashInfer's own tvm-ffi launcher. `flash_attention4_fp4` pins `flash-attn-4`, `nvidia-cutlass-dsl` and `flashinfer-python` (FlashInfer quantizes its correctness inputs).
- Bench suite grows from 263 rows / 90 kernels to 284 rows / 97 kernels: an SM107 run selects 266 rows, SM100 and SM103 runs select 269. `agent_evolved_kda_forward_b1_t8192.yaml` gains explicit `selection_role`s and a rationale.
- `bmm_fp8_rubin`: `_MAX_ACTIVE_CLUSTERS` now stands in for `HardwareInfo().get_max_active_clusters()` on the 200-SM sm_107a part (100 two-CTA / 40 four-CTA clusters).

### Reference dependencies

- `reference-dependencies.json` pins `hao-ai-lab/flash-attention-fp4` @ 5aa37a96.
- `scripts/install_reference_dependencies.py` can apply repo-tracked patches on top of a pinned revision, detects an already-patched checkout, and reports missing patches.

### Licensing

- `LICENSE` / `README.md`: fast.cu (MIT; text in `licenses/LICENSE.fast-cu.txt`) and flash-attention-fp4 (BSD-3-Clause; same LICENSE and AUTHORS as flash-attention) added to the third-party map.
- `tests/lint/check_license_headers.py` binds the `tirx_kernels/fastcu/` path to the fast.cu citation and accepts the flash-attention-fp4 fork citation for the FP4 FA4 port.

### Agent notes

- New and updated entries in the codegen-diagnostics references db (`.agents/skills/tirx-codegen-diagnostics/references/db/`).

## Dependencies

`flash_attention4_fp4` uses `tcgen05.ld.red...max.f32` and needs the `redval` output binding from apache/tvm#20266 (https://github.com/apache/tvm/pull/20266).

## Verification

`pre-commit run` on every changed file passes (ruff check, ruff format, clang-format, license headers).
