### PR TITLE
[CUDA][Thor] Enable FP16 and BF16 GEMM on SM110

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,202 +6,316 @@ High-performance GPU kernels authored in
 
 ## Kernels
 
-Unless marked otherwise, every kernel below runs on `sm_100a` (B200), `sm_103a`
-(GB300) and `sm_107a` (Rubin). A kernel restricted to one architecture carries an
-inline tag such as **[sm_103a]**. Each linked name is the public registry name
-accepted by `--kernel`; the link opens its implementation.
-`KERNEL_META["runtime_cuda_archs"]` is the authority;
-`python -m tirx_kernels.registry --format json` prints it together with the
-config list, and `tests/lint/check_readme_kernels.py` keeps this section in sync
-with the registry.
+Each architecture section lists every public registry kernel supported on
+that target. A kernel appears in every section declared by its
+`KERNEL_META["runtime_cuda_archs"]`. Each linked name is accepted by
+`--kernel`; the link opens its implementation. Run
+`python -m tirx_kernels.registry --format json` for the authoritative
+metadata. `tests/lint/check_readme_kernels.py` keeps these lists in sync.
 
-| Architecture | Kernels | Only on this architecture |
-|---|---:|---|
-| `sm_100a` (B200) | 101 | `allgather_gemm`, `blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`, `blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`, `cake_vsa_blk128_compact_sm100`, `cake_vsa_longseq_sm100`, `cake_vsa_ultrasparse_bsr_sm100`, `deepep_combine`, `deepep_dispatch`, `flash_mla_sparse_fwd`, `flashinfer_fused_add_rmsnorm`, `gemm_reduce_scatter` |
-| `sm_103a` (GB300) | 96 | `blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`, `blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`, `blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`, `cake_vsa_longseq_sm103`, `fastcu_nvfp4_gemm_gb300`, `flash_attention4_fp4` |
-| `sm_107a` (Rubin) | 94 | `blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`, `bmm_fp8_rubin`, `dense_blockscaled_gemm_sm107`, `grouped_gemm_masked_rubin` |
+### `sm_110a` (Thor)
 
-### Native TIRx
+- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
 
-- **GEMM:**
-  [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py),
-  [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
-- **Normalization:**
-  [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
-- **Distributed:**
-  [`allgather_gemm`](tirx_kernels/basic/allgather_gemm.py) **[sm_100a]**,
-  [`gemm_reduce_scatter`](tirx_kernels/basic/gemm_reduce_scatter.py) **[sm_100a]**
+### `sm_100a` (B200)
 
-### Agent-evolved TIRx
+- [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py)
+- [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
+- [`allgather_gemm`](tirx_kernels/basic/allgather_gemm.py)
+- [`blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py)
+- [`blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100.py)
+- [`cake_vsa_blk128_compact_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py)
+- [`cake_vsa_longseq_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py)
+- [`cake_vsa_ultrasparse_bsr_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py)
+- [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py)
+- [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
+- [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py)
+- [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py)
+- [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
+- [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
+- [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py)
+- [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
+- [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
+- [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py)
+- [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py)
+- [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
+- [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py)
+- [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py)
+- [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py)
+- [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
+- [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
+- [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
+- [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
+- [`deepep_combine`](tirx_kernels/deepep/combine.py)
+- [`deepep_dispatch`](tirx_kernels/deepep/dispatch.py)
+- [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py)
+- [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py)
+- [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py)
+- [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py)
+- [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py)
+- [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
+- [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py)
+- [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py)
+- [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py)
+- [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
+- [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py)
+- [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py)
+- [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
+- [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
+- [`flash_mla_sparse_fwd`](tirx_kernels/flashmla/flash_mla_sparse_fwd.py)
+- [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py)
+- [`flashinfer_fused_add_rmsnorm`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py)
+- [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py)
+- [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py)
+- [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py)
+- [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
+- [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py)
+- [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py)
+- [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py)
+- [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py)
+- [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py)
+- [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py)
+- [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py)
+- [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py)
+- [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py)
+- [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
+- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
+- [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
+- [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py)
+- [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py)
+- [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py)
+- [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
+- [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py)
+- [`gemm_reduce_scatter`](tirx_kernels/basic/gemm_reduce_scatter.py)
+- [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
+- [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py)
+- [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py)
+- [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py)
+- [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
+- [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py)
+- [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
+- [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
+- [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py)
+- [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py)
+- [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py)
+- [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py)
+- [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py)
+- [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py)
+- [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
+- [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
+- [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py)
+- [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py)
+- [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py)
+- [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py)
+- [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py)
+- [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
+- [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
+- [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
+- [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py)
+- [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
+- [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py)
+- [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
+- [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py)
 
-Curated kernels selected from measured agent-evolution runs. Their canonical
-modules retain the supported workload and stable provenance; run logs and
-intermediate candidates remain outside this package. See the
-[measured speedups](tirx_kernels/agent_evolved/README.md) for the benchmark
-contract and results.
+### `sm_103a` (GB300)
 
-- **KDA forward:**
-  [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
+- [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py)
+- [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
+- [`blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py)
+- [`blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103.py)
+- [`blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py)
+- [`cake_vsa_longseq_sm103`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py)
+- [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py)
+- [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
+- [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py)
+- [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py)
+- [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
+- [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
+- [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py)
+- [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
+- [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
+- [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py)
+- [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py)
+- [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
+- [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py)
+- [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py)
+- [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py)
+- [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
+- [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
+- [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
+- [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
+- [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py)
+- [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py)
+- [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py)
+- [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py)
+- [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py)
+- [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
+- [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py)
+- [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py)
+- [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py)
+- [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
+- [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py)
+- [`fastcu_nvfp4_gemm_gb300`](tirx_kernels/fastcu/nvfp4_gemm_gb300.py)
+- [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py)
+- [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
+- [`flash_attention4_fp4`](tirx_kernels/flashattention/flash_attention4_fp4.py)
+- [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
+- [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py)
+- [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py)
+- [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py)
+- [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py)
+- [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
+- [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py)
+- [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py)
+- [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py)
+- [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py)
+- [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py)
+- [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py)
+- [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py)
+- [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py)
+- [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py)
+- [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
+- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
+- [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
+- [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py)
+- [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py)
+- [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py)
+- [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
+- [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py)
+- [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
+- [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py)
+- [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py)
+- [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py)
+- [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
+- [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py)
+- [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
+- [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
+- [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py)
+- [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py)
+- [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py)
+- [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py)
+- [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py)
+- [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py)
+- [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
+- [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
+- [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py)
+- [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py)
+- [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py)
+- [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py)
+- [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py)
+- [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
+- [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
+- [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
+- [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py)
+- [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
+- [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py)
+- [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
+- [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py)
 
-### cuDNN Frontend ports
+### `sm_107a` (Rubin)
 
-- **Persistent GEMM:**
-  [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py),
-  [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py),
-  [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py),
-  [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py),
-  [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py),
-  [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py),
-  [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
-- **Grouped GEMM:**
-  [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py),
-  [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
-- **Linear attention:**
-  [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
-  [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py),
-  [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
-  [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
-  [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py),
-  [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),
-  [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
-- **CSA compression:**
-  [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
-- **Sparse attention:**
-  [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py),
-  [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py),
-  [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py),
-  [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py),
-  [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py),
-  [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
-
-### FlashAttention ports
-
-- **Forward:**
-  [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py),
-  [`flash_attention4_fp4`](tirx_kernels/flashattention/flash_attention4_fp4.py) **[sm_103a]**
-- **Backward:**
-  [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
-
-### FlashInfer ports
-
-Grouped by the FlashInfer Python entry point each port backs.
-
-- **`flashinfer.activation`:**
-  [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py),
-  [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
-- **`flashinfer.quantization`:**
-  [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py),
-  [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py),
-  [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py),
-  [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
-- **`flashinfer.norm`:**
-  [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py),
-  [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py),
-  [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py),
-  [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py),
-  [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py),
-  [`flashinfer_fused_add_rmsnorm`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py) **[sm_100a]**,
-  [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py),
-  [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py),
-  [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
-- **`flashinfer.mamba`:**
-  [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py),
-  [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py),
-  [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py),
-  [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py),
-  [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py),
-  [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
-- **`flashinfer.kda`:**
-  [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py),
-  [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py),
-  [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py),
-  [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py),
-  [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py),
-  [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py),
-  [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py),
-  [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py),
-  [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
-- **`flashinfer.gdn_decode`:**
-  [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py),
-  [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py),
-  [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py),
-  [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
-- **`flashinfer.gdn_prefill`:**
-  [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py),
-  [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
-- **`flashinfer.cake_vsa`:**
-  [`cake_vsa_blk128_compact_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py) **[sm_100a]**,
-  [`cake_vsa_ultrasparse_bsr_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py) **[sm_100a]**,
-  [`cake_vsa_longseq_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py) **[sm_100a]**,
-  [`cake_vsa_longseq_sm103`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py) **[sm_103a]**
-- **`flashinfer.msa_ops`:**
-  [`blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py) **[sm_103a]**,
-  [`blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py) **[sm_100a]**,
-  [`blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100.py) **[sm_100a]**,
-  [`blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103.py) **[sm_103a]**,
-  [`blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py) **[sm_103a]**
-- **`flashinfer.gemm`:**
-  [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py),
-  [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py) **[sm_107a]**,
-  [`dense_blockscaled_gemm_sm107`](tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py) **[sm_107a]**,
-  [`grouped_gemm_masked_rubin`](tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py) **[sm_107a]**
-- **`flashinfer.fused_moe`:**
-  [`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`](tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py) **[sm_107a]**
-- **`flashinfer.topk`:**
-  [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py),
-  [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py),
-  [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py),
-  [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py),
-  [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
-
-### FlashMLA ports
-
-- **Sparse prefill:**
-  [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py),
-  [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py),
-  [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
-- **Sparse decode:**
-  [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
-- **Sparse forward:**
-  [`flash_mla_sparse_fwd`](tirx_kernels/flashmla/flash_mla_sparse_fwd.py) **[sm_100a]**
-
-### DeepGEMM ports
-
-- **Dense and grouped GEMM:**
-  [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py),
-  [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py),
-  [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py),
-  [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py),
-  [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py),
-  [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
-- **MQA logits:**
-  [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py),
-  [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py),
-  [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py),
-  [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
-- **MoE:**
-  [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
-
-### DeepEP ports
-
-- **Elastic communication:**
-  [`deepep_dispatch`](tirx_kernels/deepep/dispatch.py) **[sm_100a]**,
-  [`deepep_combine`](tirx_kernels/deepep/combine.py) **[sm_100a]**
-
-### fast.cu ports
-
-- **NVFP4 GEMM:**
-  [`fastcu_nvfp4_gemm_gb300`](tirx_kernels/fastcu/nvfp4_gemm_gb300.py) **[sm_103a]**
-
-### MSA ports
-
-- **Sparse-attention preparation:**
-  [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py),
-  [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
-- **Sparse-attention forward:**
-  [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py),
-  [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py),
-  [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
+- [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py)
+- [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
+- [`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`](tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py)
+- [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py)
+- [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py)
+- [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
+- [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py)
+- [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py)
+- [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
+- [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
+- [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
+- [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py)
+- [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
+- [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
+- [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py)
+- [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py)
+- [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
+- [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py)
+- [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py)
+- [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py)
+- [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
+- [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
+- [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
+- [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
+- [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py)
+- [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py)
+- [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py)
+- [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py)
+- [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py)
+- [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
+- [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py)
+- [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py)
+- [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py)
+- [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
+- [`dense_blockscaled_gemm_sm107`](tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py)
+- [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py)
+- [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py)
+- [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
+- [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
+- [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py)
+- [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py)
+- [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py)
+- [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py)
+- [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
+- [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py)
+- [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py)
+- [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py)
+- [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py)
+- [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py)
+- [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py)
+- [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py)
+- [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py)
+- [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py)
+- [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
+- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
+- [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
+- [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py)
+- [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py)
+- [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py)
+- [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
+- [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py)
+- [`grouped_gemm_masked_rubin`](tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py)
+- [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
+- [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py)
+- [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py)
+- [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py)
+- [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
+- [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py)
+- [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
+- [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
+- [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py)
+- [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py)
+- [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py)
+- [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py)
+- [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py)
+- [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py)
+- [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
+- [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
+- [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py)
+- [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py)
+- [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py)
+- [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py)
+- [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py)
+- [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
+- [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
+- [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
+- [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py)
+- [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
+- [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py)
+- [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
+- [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py)
 
 ## Performance
 

--- a/tests/lint/check_readme_kernels.py
+++ b/tests/lint/check_readme_kernels.py
@@ -2,31 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""Check that the README kernel section matches the kernel registry.
+"""Check that each README architecture list matches the kernel registry.
 
-Three things must hold:
-
-* every registered kernel is linked exactly once, and the link opens its module;
-* a kernel restricted to one CUDA architecture carries an inline ``**[sm_xxx]**``
-  tag after its link, and a kernel that runs everywhere carries none;
-* the architecture overview table lists the correct kernel count and the exact
-  set of single-architecture kernels for each architecture.
-
-``KERNEL_META["runtime_cuda_archs"]`` is the authority for all three.
+Every supported CUDA architecture has its own section. Each section must list
+exactly the public kernels whose ``KERNEL_META["runtime_cuda_archs"]`` contains
+that architecture, and every link must open the registered module.
 """
 
 from __future__ import annotations
 
 import re
 import sys
+from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 README = REPO_ROOT / "README.md"
-ALL_ARCHS = ("sm_100a", "sm_103a", "sm_107a")
+ARCHITECTURES = ("sm_110a", "sm_100a", "sm_103a", "sm_107a")
 
-_LINK = re.compile(r"\[`([^`]+)`\]\((tirx_kernels/[^)]+\.py)\)( \*\*\[(sm_[0-9]+[af]?)\]\*\*)?")
-_TABLE_ROW = re.compile(r"^\| `(sm_[0-9]+[af]?)`[^|]*\| (\d+) \|([^|]*)\|$", re.MULTILINE)
+_ARCH_HEADING = re.compile(r"^### `(sm_[0-9]+[af]?)` \([^)]+\)$", re.MULTILINE)
+_LINK = re.compile(r"^- \[`([^`]+)`\]\((tirx_kernels/[^)]+\.py)\)$", re.MULTILINE)
 
 
 def _registry() -> dict[str, tuple[str, tuple[str, ...]]]:
@@ -47,43 +42,48 @@ def main() -> int:
     text = README.read_text()
     errors: list[str] = []
 
-    linked: dict[str, tuple[str, str | None]] = {}
-    for name, path, _, tag in _LINK.findall(text):
-        if name in linked:
-            errors.append(f"{name}: linked more than once")
-        linked[name] = (path, tag or None)
+    _, kernel_marker, remainder = text.partition("## Kernels\n")
+    kernel_text, performance_marker, _ = remainder.partition("\n## Performance")
+    if not kernel_marker or not performance_marker:
+        errors.append("README.md must contain Kernels and Performance sections")
+        headings = []
+    else:
+        headings = list(_ARCH_HEADING.finditer(kernel_text))
 
-    for name, (path, archs) in sorted(kernels.items()):
-        if name not in linked:
-            errors.append(f"{name}: not linked in README.md")
-            continue
-        readme_path, tag = linked[name]
-        if readme_path != path:
-            errors.append(f"{name}: README links {readme_path}, module is {path}")
-        expected_tag = None if archs == ALL_ARCHS else archs[0] if len(archs) == 1 else None
-        if archs != ALL_ARCHS and len(archs) != 1:
-            errors.append(f"{name}: runtime_cuda_archs {archs} needs a README convention")
-        elif tag != expected_tag:
-            errors.append(
-                f"{name}: README tag is {tag}, runtime_cuda_archs {archs} needs {expected_tag}"
-            )
-    for name in sorted(set(linked) - set(kernels)):
-        errors.append(f"{name}: linked in README.md but not registered")
+    listed_archs = tuple(match.group(1) for match in headings)
+    if listed_archs != ARCHITECTURES:
+        errors.append(f"architecture sections must be {ARCHITECTURES}, found {listed_archs}")
 
-    table = {
-        arch: (int(count), set(re.findall(r"`([^`]+)`", names)))
-        for arch, count, names in _TABLE_ROW.findall(text)
-    }
-    for arch in ALL_ARCHS:
-        count = sum(arch in archs for _, archs in kernels.values())
-        only = {name for name, (_, archs) in kernels.items() if archs == (arch,)}
-        if arch not in table:
-            errors.append(f"overview table: missing row for {arch}")
-        elif table[arch] != (count, only):
-            errors.append(
-                f"overview table: {arch} row should list {count} kernels and "
-                f"{sorted(only)}, found {table[arch][0]} and {sorted(table[arch][1])}"
-            )
+    registry_archs = {arch for _, archs in kernels.values() for arch in archs}
+    for arch in sorted(registry_archs - set(ARCHITECTURES)):
+        errors.append(f"registry architecture {arch} has no README section")
+
+    parsed_link_count = 0
+    for index, heading in enumerate(headings):
+        arch = heading.group(1)
+        body_end = headings[index + 1].start() if index + 1 < len(headings) else len(kernel_text)
+        body = kernel_text[heading.end() : body_end]
+        links = _LINK.findall(body)
+        parsed_link_count += len(links)
+
+        counts = Counter(name for name, _ in links)
+        for name, count in sorted(counts.items()):
+            if count > 1:
+                errors.append(f"{arch}: {name} is linked {count} times")
+
+        found = dict(links)
+        expected = {name: path for name, (path, archs) in kernels.items() if arch in archs}
+        for name in sorted(set(expected) - set(found)):
+            errors.append(f"{arch}: {name} is not linked")
+        for name in sorted(set(found) - set(expected)):
+            errors.append(f"{arch}: {name} is linked but not supported")
+        for name in sorted(set(expected) & set(found)):
+            if found[name] != expected[name]:
+                errors.append(f"{arch}: {name} links {found[name]}, module is {expected[name]}")
+
+    all_kernel_links = re.findall(r"\[`[^`]+`\]\(tirx_kernels/[^)]+\.py\)", kernel_text)
+    if len(all_kernel_links) != parsed_link_count:
+        errors.append("kernel links must be plain bullets inside architecture sections")
 
     for error in errors:
         print(error, file=sys.stderr)

--- a/tests/test_bench_suite_run.py
+++ b/tests/test_bench_suite_run.py
@@ -108,6 +108,25 @@ def test_gpu_compile_profile_supports_sm103(monkeypatch):
     }
 
 
+def test_gpu_compile_profile_supports_sm110(monkeypatch):
+    fake_nvml = SimpleNamespace(
+        nvmlInit=lambda: None,
+        nvmlShutdown=lambda: None,
+        nvmlDeviceGetHandleByIndex=lambda index: index,
+        nvmlDeviceGetName=lambda _handle: "NVIDIA Thor",
+        nvmlDeviceGetCudaComputeCapability=lambda _handle: (11, 0),
+        nvmlDeviceGetNumGpuCores=lambda _handle: 20 * 128,
+    )
+    monkeypatch.setitem(sys.modules, "pynvml", fake_nvml)
+
+    assert bench_run.gpu_compile_profile({"0"}) == {
+        "name": "NVIDIA Thor",
+        "compute_capability": [11, 0],
+        "cuda_arch": "sm_110a",
+        "num_sms": 20,
+    }
+
+
 def test_gpu_compile_profile_rejects_mixed_arch_pool(monkeypatch):
     fake_nvml = SimpleNamespace(
         nvmlInit=lambda: None,
@@ -201,14 +220,15 @@ def test_default_roster_is_available_on_sm103_and_sm107():
     def kernels(rows):
         return {workload["kernel"] for workload in rows}
 
-    # 262 rows run everywhere; twelve single-architecture kernels contribute three default rows
+    # 262 rows run on these architectures; thirteen restricted kernels contribute three rows
     # each: cake_vsa_{blk128_compact,longseq,ultrasparse_bsr}_sm100 (sm_100a),
-    # {bmm_fp8_rubin,dense_blockscaled_gemm_sm107,grouped_gemm_masked_rubin} (sm_107a), and
+    # {bmm_fp8_rubin,dense_blockscaled_gemm_sm107,grouped_gemm_masked_rubin,
+    # blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin} (sm_107a), and
     # blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103,
     # blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103,
     # blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103, cake_vsa_longseq_sm103,
     # fastcu_nvfp4_gemm_gb300, and flash_attention4_fp4 (sm_103a).
-    assert len(sm107) == 271
+    assert len(sm107) == 274
     assert len(sm107_incompatible) == 27
     assert kernels(sm107_incompatible) == {
         "blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103",
@@ -222,8 +242,9 @@ def test_default_roster_is_available_on_sm103_and_sm107():
         "flash_attention4_fp4",
     }
     assert len(sm103) == 280
-    assert len(sm103_incompatible) == 18
+    assert len(sm103_incompatible) == 21
     assert kernels(sm103_incompatible) == {
+        "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin",
         "bmm_fp8_rubin",
         "cake_vsa_blk128_compact_sm100",
         "cake_vsa_longseq_sm100",
@@ -232,8 +253,9 @@ def test_default_roster_is_available_on_sm103_and_sm107():
         "grouped_gemm_masked_rubin",
     }
     assert len(sm100) == 271
-    assert len(sm100_incompatible) == 27
+    assert len(sm100_incompatible) == 30
     assert kernels(sm100_incompatible) == {
+        "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin",
         "blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103",
         "blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103",
         "bmm_fp8_rubin",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -49,13 +49,20 @@ def test_exact_architectures_are_stored_in_source_index():
     assert index["dense_blockscaled_gemm_sm107"].runtime_cuda_archs == ("sm_107a",)
     counts = {
         archs: sum(record.runtime_cuda_archs == archs for record in index.values())
-        for archs in (("sm_100a",), ("sm_103a",), ("sm_107a",), ("sm_100a", "sm_103a", "sm_107a"))
+        for archs in (
+            ("sm_100a",),
+            ("sm_103a",),
+            ("sm_107a",),
+            ("sm_100a", "sm_103a", "sm_107a"),
+            ("sm_100a", "sm_103a", "sm_107a", "sm_110a"),
+        )
     }
     assert counts == {
         ("sm_100a",): 11,
         ("sm_103a",): 6,
         ("sm_107a",): 4,
-        ("sm_100a", "sm_103a", "sm_107a"): 90,
+        ("sm_100a", "sm_103a", "sm_107a"): 89,
+        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 1,
     }
 
 

--- a/tirx_kernels/basic/fp16_bf16_gemm.py
+++ b/tirx_kernels/basic/fp16_bf16_gemm.py
@@ -650,7 +650,7 @@ def make_kernel(dtype: str, M: int, N: int, Kdim: int):
 KERNEL_META = {
     "name": "fp16_bf16_gemm",
     "category": "basic",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
 }
 CONFIGS = [
     {"dtype": d, "M": s, "N": s, "K": s, "label": f"{d}_{s}x{s}x{s}"}
@@ -703,7 +703,8 @@ def run_gpu(prepared: PreparedBench, *, warmup=None, repeat=None, timer=None, **
         return lambda: torch.matmul(A, B.T, out=C_out)
 
     references = {"torch-cublas": _torch_cublas}
-    if prepared.dtype == "bf16":
+    # DeepGEMM's BF16 references reject Thor; cuBLAS supports the device.
+    if prepared.dtype == "bf16" and torch.cuda.get_device_capability() != (11, 0):
 
         def _deepgemm_cublaslt():
             import deep_gemm

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -520,3 +520,13 @@ Grouped workloads show one row per config and one timing column per implementati
 - `stable_sort_topk_by_value/f32_r4_k128`: prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True
 - `stable_sort_topk_by_value/f32_r64_k2048`: prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True
 - `stable_sort_topk_by_value/f32_r64_k256`: prepare: RuntimeError: CPU prepare changed CUDA initialization state from False to True
+
+## Jetson AGX Thor (`sm_110a`)
+
+### fp16_bf16_gemm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bf16_4096x4096x4096` | tir | 1889.1804 | torch-cublas | 1768.7883 | 0.936 | — |
+| `fp16_1024x1024x1024` | tir | 108.0997 | torch-cublas | 111.0238 | 1.027 | — |
+| `fp16_16384x16384x16384` | tir | 348158.6372 | torch-cublas | 334817.1432 | 0.962 | — |

--- a/tirx_kernels/bench_suite/run.py
+++ b/tirx_kernels/bench_suite/run.py
@@ -655,6 +655,9 @@ def gpu_compile_profile(indices: set[str]) -> dict:
             elif compute_capability == (10, 7):
                 cores_per_sm = 128
                 cuda_arch = "sm_107a"
+            elif compute_capability == (11, 0):
+                cores_per_sm = 128
+                cuda_arch = "sm_110a"
             else:
                 raise ValueError(
                     f"GPU {index} {name!r} has unsupported compile profile "


### PR DESCRIPTION
Enable fp16_bf16_gemm on Thor (sm_110a) and use cuBLAS as its Thor reference. Add the required bench-suite support, align the README architecture listing, and record all three default configurations in baseline.md.
Validation: all 10 FP16/BF16 correctness configurations, 55 CPU tests, and pre-commit checks passed. The latest default-suite run achieved a 1.064× geometric-mean baseline/TIRx ratio.