### PR TITLE
chore(kernel): tag README kernels by architecture and drop source SHA gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,9 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: check-readme-kernels
+        name: check README kernel listing
+        entry: python tests/lint/check_readme_kernels.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -6,10 +6,20 @@ High-performance GPU kernels authored in
 
 ## Kernels
 
-Registered kernels declare their CUDA target architecture in `KERNEL_META`.
-Each linked name below is the public registry name accepted by `--kernel`; the
-link opens its implementation. Run `python -m tirx_kernels.registry --format json`
-for the authoritative config list.
+Unless marked otherwise, every kernel below runs on `sm_100a` (B200), `sm_103a`
+(GB300) and `sm_107a` (Rubin). A kernel restricted to one architecture carries an
+inline tag such as **[sm_103a]**. Each linked name is the public registry name
+accepted by `--kernel`; the link opens its implementation.
+`KERNEL_META["runtime_cuda_archs"]` is the authority;
+`python -m tirx_kernels.registry --format json` prints it together with the
+config list, and `tests/lint/check_readme_kernels.py` keeps this section in sync
+with the registry.
+
+| Architecture | Kernels | Only on this architecture |
+|---|---:|---|
+| `sm_100a` (B200) | 101 | `allgather_gemm`, `blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`, `blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`, `cake_vsa_blk128_compact_sm100`, `cake_vsa_longseq_sm100`, `cake_vsa_ultrasparse_bsr_sm100`, `deepep_combine`, `deepep_dispatch`, `flash_mla_sparse_fwd`, `flashinfer_fused_add_rmsnorm`, `gemm_reduce_scatter` |
+| `sm_103a` (GB300) | 96 | `blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`, `blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`, `blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`, `cake_vsa_longseq_sm103`, `fastcu_nvfp4_gemm_gb300`, `flash_attention4_fp4` |
+| `sm_107a` (Rubin) | 94 | `blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`, `bmm_fp8_rubin`, `dense_blockscaled_gemm_sm107`, `grouped_gemm_masked_rubin` |
 
 ### Native TIRx
 
@@ -19,8 +29,8 @@ for the authoritative config list.
 - **Normalization:**
   [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
 - **Distributed:**
-  [`allgather_gemm`](tirx_kernels/basic/allgather_gemm.py),
-  [`gemm_reduce_scatter`](tirx_kernels/basic/gemm_reduce_scatter.py)
+  [`allgather_gemm`](tirx_kernels/basic/allgather_gemm.py) **[sm_100a]**,
+  [`gemm_reduce_scatter`](tirx_kernels/basic/gemm_reduce_scatter.py) **[sm_100a]**
 
 ### Agent-evolved TIRx
 
@@ -67,7 +77,8 @@ contract and results.
 ### FlashAttention ports
 
 - **Forward:**
-  [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
+  [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py),
+  [`flash_attention4_fp4`](tirx_kernels/flashattention/flash_attention4_fp4.py) **[sm_103a]**
 - **Backward:**
   [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
 
@@ -89,7 +100,7 @@ Grouped by the FlashInfer Python entry point each port backs.
   [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py),
   [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py),
   [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py),
-  [`flashinfer_fused_add_rmsnorm`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py),
+  [`flashinfer_fused_add_rmsnorm`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py) **[sm_100a]**,
   [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py),
   [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py),
   [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
@@ -119,21 +130,23 @@ Grouped by the FlashInfer Python entry point each port backs.
   [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py),
   [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
 - **`flashinfer.cake_vsa`:**
-  [`cake_vsa_blk128_compact_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py),
-  [`cake_vsa_ultrasparse_bsr_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py),
-  [`cake_vsa_longseq_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py),
-  [`cake_vsa_longseq_sm103`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py)
+  [`cake_vsa_blk128_compact_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py) **[sm_100a]**,
+  [`cake_vsa_ultrasparse_bsr_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py) **[sm_100a]**,
+  [`cake_vsa_longseq_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py) **[sm_100a]**,
+  [`cake_vsa_longseq_sm103`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py) **[sm_103a]**
 - **`flashinfer.msa_ops`:**
-  [`blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py),
-  [`blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py),
-  [`blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100.py),
-  [`blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py)
+  [`blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py) **[sm_103a]**,
+  [`blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py) **[sm_100a]**,
+  [`blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100.py) **[sm_100a]**,
+  [`blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103.py) **[sm_103a]**,
+  [`blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py) **[sm_103a]**
 - **`flashinfer.gemm`:**
   [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py),
-  [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py),
-  [`grouped_gemm_masked_rubin`](tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py)
+  [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py) **[sm_107a]**,
+  [`dense_blockscaled_gemm_sm107`](tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py) **[sm_107a]**,
+  [`grouped_gemm_masked_rubin`](tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py) **[sm_107a]**
 - **`flashinfer.fused_moe`:**
-  [`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`](tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py)
+  [`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`](tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py) **[sm_107a]**
 - **`flashinfer.topk`:**
   [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py),
   [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py),
@@ -150,7 +163,7 @@ Grouped by the FlashInfer Python entry point each port backs.
 - **Sparse decode:**
   [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
 - **Sparse forward:**
-  [`flash_mla_sparse_fwd`](tirx_kernels/flashmla/flash_mla_sparse_fwd.py)
+  [`flash_mla_sparse_fwd`](tirx_kernels/flashmla/flash_mla_sparse_fwd.py) **[sm_100a]**
 
 ### DeepGEMM ports
 
@@ -172,8 +185,13 @@ Grouped by the FlashInfer Python entry point each port backs.
 ### DeepEP ports
 
 - **Elastic communication:**
-  [`deepep_dispatch`](tirx_kernels/deepep/dispatch.py),
-  [`deepep_combine`](tirx_kernels/deepep/combine.py)
+  [`deepep_dispatch`](tirx_kernels/deepep/dispatch.py) **[sm_100a]**,
+  [`deepep_combine`](tirx_kernels/deepep/combine.py) **[sm_100a]**
+
+### fast.cu ports
+
+- **NVFP4 GEMM:**
+  [`fastcu_nvfp4_gemm_gb300`](tirx_kernels/fastcu/nvfp4_gemm_gb300.py) **[sm_103a]**
 
 ### MSA ports
 
@@ -222,13 +240,13 @@ remain externally managed runtime/compiler dependencies.
 | `torch`          | all kernels                        | CUDA build matching your GPU.                          |
 | `deep_gemm`      | FP8 GEMM and `deepgemm_*` baselines | Used for optimized reference kernels and the MegaMoE timer. |
 | cuDNN Frontend (`cudnn`) | `cudnn_*` correctness and baselines | Source install pinned in the lock (v1.28.0); replaces any released `nvidia-cudnn-frontend` wheel, which lacks the CuTeDSL kernel sources. |
-| `flashinfer`     | `nvfp4_gemm` baseline | Used for reference implementations. |
+| `flashinfer`     | all `flashinfer.*` ports, `tinygemm2_sm100`, `nvfp4_gemm` and `rmsnorm` baselines | Correctness reference and optimized baseline. |
 | `flash-attn` + CUTLASS DSL | `flash_attention_backward_sm100` baseline | Current SM100 forward/backward reference. |
 | `sglang` (+ CUTLASS DSL) | `deepgemm_sm100_fp8_paged_mqa_logits` reference | Optional `sglang_cutedsl` benchmark reference. |
 | `flash_mla`      | `sparse_flashmla_*` / `flash_mla_sparse_fwd` baselines | Reference impls. |
 | `deep_ep`        | `deepep_*` correctness and baselines | Reference implementation. |
 | `flash-linear-attention` | `agent_evolved_kda_forward_b1_t8192` correctness | Independent FLA BF16/Triton chunk reference. |
-| `flash_kda`      | `flashkda_*` optional baselines | Raw FlashKDA benchmark peer. |
+| `flash_kda`      | `flashkda_*` and `agent_evolved_kda_forward_b1_t8192` optional baselines | Raw FlashKDA benchmark peer. |
 | `fmha_sm100` (MSA) | `msa_*` correctness and baselines | Reference implementation; set `MSA_PATH` to use a checkout elsewhere. |
 | NVSHMEM          | `allgather_gemm`, `gemm_reduce_scatter` | Required to compile/run the GemmComm kernels. |
 
@@ -289,7 +307,7 @@ License 2.0; see [LICENSE](LICENSE). Required Apache attribution notices are
 collected in [NOTICE](NOTICE).
 
 Every Python source file carries SPDX tags. Kernel ports derived from third-party projects
-(cuDNN Frontend, DeepGEMM, fast.cu, FlashMLA, flash-attention, flash-attention-fp4, FlashInfer, MSA) additionally cite the upstream
+(cuDNN Frontend, DeepGEMM, DeepEP, fast.cu, FlashMLA, flash-attention, flash-attention-fp4, FlashInfer, MSA) additionally cite the upstream
 project and the exact commit ported, retain the upstream copyright notice, and
 declare the combined terms — for example `Apache-2.0 AND MIT`. Where an upstream
 license requires its conditions text to travel with the source, that text is kept

--- a/tests/lint/check_readme_kernels.py
+++ b/tests/lint/check_readme_kernels.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Check that the README kernel section matches the kernel registry.
+
+Three things must hold:
+
+* every registered kernel is linked exactly once, and the link opens its module;
+* a kernel restricted to one CUDA architecture carries an inline ``**[sm_xxx]**``
+  tag after its link, and a kernel that runs everywhere carries none;
+* the architecture overview table lists the correct kernel count and the exact
+  set of single-architecture kernels for each architecture.
+
+``KERNEL_META["runtime_cuda_archs"]`` is the authority for all three.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README = REPO_ROOT / "README.md"
+ALL_ARCHS = ("sm_100a", "sm_103a", "sm_107a")
+
+_LINK = re.compile(r"\[`([^`]+)`\]\((tirx_kernels/[^)]+\.py)\)( \*\*\[(sm_[0-9]+[af]?)\]\*\*)?")
+_TABLE_ROW = re.compile(r"^\| `(sm_[0-9]+[af]?)`[^|]*\| (\d+) \|([^|]*)\|$", re.MULTILINE)
+
+
+def _registry() -> dict[str, tuple[str, tuple[str, ...]]]:
+    sys.path.insert(0, str(REPO_ROOT))
+    from tirx_kernels import registry
+
+    index, diagnostics = registry._build_kernel_index(registry._source_snapshot())
+    if diagnostics:
+        raise SystemExit("\n".join(diagnostics))
+    return {
+        name: (str(record.source_path.relative_to(REPO_ROOT)), tuple(record.runtime_cuda_archs))
+        for name, record in index.items()
+    }
+
+
+def main() -> int:
+    kernels = _registry()
+    text = README.read_text()
+    errors: list[str] = []
+
+    linked: dict[str, tuple[str, str | None]] = {}
+    for name, path, _, tag in _LINK.findall(text):
+        if name in linked:
+            errors.append(f"{name}: linked more than once")
+        linked[name] = (path, tag or None)
+
+    for name, (path, archs) in sorted(kernels.items()):
+        if name not in linked:
+            errors.append(f"{name}: not linked in README.md")
+            continue
+        readme_path, tag = linked[name]
+        if readme_path != path:
+            errors.append(f"{name}: README links {readme_path}, module is {path}")
+        expected_tag = None if archs == ALL_ARCHS else archs[0] if len(archs) == 1 else None
+        if archs != ALL_ARCHS and len(archs) != 1:
+            errors.append(f"{name}: runtime_cuda_archs {archs} needs a README convention")
+        elif tag != expected_tag:
+            errors.append(
+                f"{name}: README tag is {tag}, runtime_cuda_archs {archs} needs {expected_tag}"
+            )
+    for name in sorted(set(linked) - set(kernels)):
+        errors.append(f"{name}: linked in README.md but not registered")
+
+    table = {
+        arch: (int(count), set(re.findall(r"`([^`]+)`", names)))
+        for arch, count, names in _TABLE_ROW.findall(text)
+    }
+    for arch in ALL_ARCHS:
+        count = sum(arch in archs for _, archs in kernels.values())
+        only = {name for name, (_, archs) in kernels.items() if archs == (arch,)}
+        if arch not in table:
+            errors.append(f"overview table: missing row for {arch}")
+        elif table[arch] != (count, only):
+            errors.append(
+                f"overview table: {arch} row should list {count} kernels and "
+                f"{sorted(only)}, found {table[arch][0]} and {sorted(table[arch][1])}"
+            )
+
+    for error in errors:
+        print(error, file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tirx_kernels/fastcu/nvfp4_gemm_gb300.py
+++ b/tirx_kernels/fastcu/nvfp4_gemm_gb300.py
@@ -22,8 +22,6 @@ KERNEL_META = {
     "runtime_cuda_archs": ["sm_103a"],
 }
 
-SOURCE_COMMIT = "2dfe5e26aecfd9e5f27bf9d5837deea01acda24b"
-SOURCE_SHA256 = "b9ec1b3f07ed934728499421b7a90bb7f31cbc179960fd2707ecefbf2ec8606c"
 _SOURCE_RELATIVE = Path("gb300/nvfp4/gemm9.cuh")
 _REFERENCE_ADAPTER = Path(__file__).with_name("nvfp4_gemm_gb300_reference.cu")
 
@@ -998,26 +996,10 @@ def _fastcu_source_root() -> Path:
         )
     )
     for root in candidates:
-        source = root / _SOURCE_RELATIVE
-        if not source.is_file():
-            continue
-        actual = hashlib.sha256(source.read_bytes()).hexdigest()
-        if actual != SOURCE_SHA256:
-            raise RuntimeError(f"frozen fast.cu source hash mismatch: {source} sha256={actual}")
-        try:
-            commit = subprocess.run(
-                ["git", "-C", str(root), "rev-parse", "HEAD"],
-                check=True,
-                capture_output=True,
-                text=True,
-            ).stdout.strip()
-        except (OSError, subprocess.CalledProcessError) as error:
-            raise RuntimeError(f"cannot verify fast.cu checkout {root}: {error}") from error
-        if commit != SOURCE_COMMIT:
-            raise RuntimeError(f"frozen fast.cu checkout mismatch: {root} commit={commit}")
-        return root
+        if (root / _SOURCE_RELATIVE).is_file():
+            return root
     tried = ", ".join(str(root) for root in candidates)
-    raise RuntimeError(f"frozen fast.cu source is unavailable; tried: {tried}")
+    raise RuntimeError(f"fast.cu source is unavailable; tried: {tried}")
 
 
 @functools.lru_cache(maxsize=1)

--- a/tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py
+++ b/tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py
@@ -29,24 +29,12 @@ Upstream source:
   blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py
 """
 
-import hashlib
 import importlib
 import sys
 from functools import cache
 from pathlib import Path
 
 import tirx_kernels.kern as K
-
-SOURCE_SHA256 = "6393684e152bdf6d5cd3666666054641eb0b952737f0db2f20018260af1ac97c"
-SOURCE_DEPENDENCY_SHA256 = {
-    "custom_pipeline.py": "97210fb00b05db803cbad6418e2e9d1b7059b13d5cb1473f12f72a696f04083b",
-    "inline_ptx.py": "b35fca3bf8173fbbe71472e3626293be2738c9669d07d90e5827e58a4628c944",
-    "utils.py": "87ef7c7199abb652a6b7660e047ac9876c6941c8574f90a8c4fd912ac4832e98",
-    "blockscaled_contiguous_gather_grouped_gemm_act_fusion.py": (
-        "eeaadde0c52e636159e5b34a20c37cfa7585a2d90d9178252c8232e5322cae0a"
-    ),
-    "tuner.py": "e91e57be076514e9fe24ef5d5c87746487dcc296f5b01398821beb80557397cf",
-}
 
 KERNEL_META = {
     "name": "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin",
@@ -1200,28 +1188,14 @@ def get_kernel(**raw_config):
     ).func
 
 
-_SOURCE_FILES = {
-    _SOURCE_ROOT / "flashinfer/fused_moe/cute_dsl/rubin/"
-    "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py": SOURCE_SHA256,
-    **{
-        _SOURCE_ROOT / "flashinfer/fused_moe/cute_dsl/rubin" / name: digest
-        for name, digest in SOURCE_DEPENDENCY_SHA256.items()
-        if name in {"custom_pipeline.py", "inline_ptx.py", "utils.py"}
-    },
-    **{
-        _SOURCE_ROOT / "flashinfer/fused_moe/cute_dsl" / name: digest
-        for name, digest in SOURCE_DEPENDENCY_SHA256.items()
-        if name in {"blockscaled_contiguous_gather_grouped_gemm_act_fusion.py", "tuner.py"}
-    },
-}
-
-
 @cache
 def _source_module():
-    for path, expected in _SOURCE_FILES.items():
-        actual = hashlib.sha256(path.read_bytes()).hexdigest()
-        if actual != expected:
-            raise RuntimeError(f"frozen FlashInfer source hash mismatch: {path} sha256={actual}")
+    source = (
+        _SOURCE_ROOT / "flashinfer/fused_moe/cute_dsl/rubin/"
+        "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py"
+    )
+    if not source.is_file():
+        raise RuntimeError(f"FlashInfer source is unavailable: {source}")
     source_root = str(_SOURCE_ROOT)
     if source_root not in sys.path:
         sys.path.insert(0, source_root)

--- a/tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py
+++ b/tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py
@@ -40,7 +40,6 @@ Upstream sources:
 """
 
 # K.kernel traces concrete annotation objects; postponed annotations would turn them into strings.
-import hashlib
 import importlib
 import sys
 from functools import cache
@@ -64,14 +63,6 @@ KERNEL_META = {
         },
         {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
     ),
-}
-
-SOURCE_COMMIT = "012cfdb97f217e0d48bc9352c17a74068c9e495b"
-SOURCE_SHA256 = "f10b5ee03096af8394b57cfbe7abb6ee3103baf87c6a58a60f576ead3f4386f3"
-SOURCE_DEPENDENCY_SHA256 = {
-    "bmm_fp8_blackwell.py": "1b24de919897ef7ede911661150d67b044aa917ff50965dc08107b1aa9cacf30",
-    "bmm_fp8_wrapper.py": "f6981c4891403fd204c3bc53e716ef75ad883c904c83828d7c05526854366530",
-    "epilogue_utils.py": "ae48ecfca2220975cd3e0e1d60803f8634aa72827857aaff3b2af24205c01c92",
 }
 
 _AB_DTYPES = ("float8_e4m3fn", "float8_e5m2")
@@ -943,20 +934,9 @@ def _tirx_launch(executable, data):
 
 @cache
 def _source_bmm_op():
-    source_files = {
-        "flashinfer/gemm/kernels/bmm_fp8_rubin.py": SOURCE_SHA256,
-        **{
-            f"flashinfer/gemm/kernels/{name}": digest
-            for name, digest in SOURCE_DEPENDENCY_SHA256.items()
-        },
-    }
-    for relative, expected in source_files.items():
-        source = _SOURCE_ROOT / relative
-        if not source.is_file():
-            raise RuntimeError(f"frozen FlashInfer source is unavailable: {source}")
-        actual = hashlib.sha256(source.read_bytes()).hexdigest()
-        if actual != expected:
-            raise RuntimeError(f"frozen FlashInfer source hash mismatch: {source} sha256={actual}")
+    source = _SOURCE_ROOT / "flashinfer/gemm/kernels/bmm_fp8_rubin.py"
+    if not source.is_file():
+        raise RuntimeError(f"FlashInfer source is unavailable: {source}")
     loaded = sys.modules.get("flashinfer")
     loaded_file = Path(getattr(loaded, "__file__", "")).resolve() if loaded is not None else None
     if loaded_file is not None and _SOURCE_ROOT not in loaded_file.parents:

--- a/tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py
+++ b/tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py
@@ -39,7 +39,6 @@ Upstream sources:
 - flashinfer/gemm/kernels/utils.py
 """
 
-import hashlib
 import importlib
 import importlib.util
 import sys
@@ -65,16 +64,6 @@ KERNEL_META = {
         {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
     ),
 }
-
-SOURCE_COMMIT = "012cfdb97f217e0d48bc9352c17a74068c9e495b"
-SOURCE_SHA256 = "c9def937d2bf76b363bb321aa4053ffd39055febdcef3c890572bd2c4f2946ad"
-SOURCE_DEPENDENCY_SHA256 = {
-    "epilogue_utils.py": "ae48ecfca2220975cd3e0e1d60803f8634aa72827857aaff3b2af24205c01c92",
-    "gemm_base.py": "ef5cb58d7d85e1391a4987327bdcd6f9e20ffcd1a849dc0b0b9a13ffce3d0d95",
-    "kernels/utils.py": "705a10946cb6ee68c132784fc48de7ce3bad07714ae5244c4058c970e1f02ed2",
-}
-CUTLASS_PARENT_COMMIT = "cdcf8d86daa9b417840fd99875a1b1af685d389d"
-CUTLASS_PARENT_SHA256 = "1517d4cde6b7988d5f44eca5fc2de4516b6f582ae60c37a5d1455a09c647453b"
 
 _SOURCE_ROOT = Path("/root-vol/aarch64-ws/kernel-libs/vr200/flashinfer")
 _CUTLASS_ROOT = Path(__file__).resolve().parents[3] / ".reference-deps" / "cutlass-v4.8.0dev"
@@ -1744,9 +1733,6 @@ def _install_cutlass_parent():
     parent_path = _CUTLASS_ROOT / _CUTLASS_PARENT_RELATIVE
     if not parent_path.is_file():
         raise RuntimeError(f"missing pinned CUTLASS parent: {parent_path}")
-    actual = hashlib.sha256(parent_path.read_bytes()).hexdigest()
-    if actual != CUTLASS_PARENT_SHA256:
-        raise RuntimeError(f"CUTLASS parent hash mismatch: sha256={actual}")
     package_paths = (
         ("nvidia_cutlass_dsl.examples", _CUTLASS_ROOT / "examples/python"),
         ("nvidia_cutlass_dsl.examples.CuTeDSL", _CUTLASS_ROOT / "examples/python/CuTeDSL"),
@@ -1779,19 +1765,9 @@ def _install_cutlass_parent():
 
 @cache
 def _source_runner(out_dtype, sf_mode):
-    source_files = {
-        "flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py": SOURCE_SHA256,
-        "flashinfer/gemm/kernels/epilogue_utils.py": SOURCE_DEPENDENCY_SHA256["epilogue_utils.py"],
-        "flashinfer/gemm/gemm_base.py": SOURCE_DEPENDENCY_SHA256["gemm_base.py"],
-        "flashinfer/gemm/kernels/utils.py": SOURCE_DEPENDENCY_SHA256["kernels/utils.py"],
-    }
-    for relative, expected in source_files.items():
-        source = _SOURCE_ROOT / relative
-        if not source.is_file():
-            raise RuntimeError(f"frozen FlashInfer source is unavailable: {source}")
-        actual = hashlib.sha256(source.read_bytes()).hexdigest()
-        if actual != expected:
-            raise RuntimeError(f"frozen source hash mismatch: {source} sha256={actual}")
+    source = _SOURCE_ROOT / "flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py"
+    if not source.is_file():
+        raise RuntimeError(f"FlashInfer source is unavailable: {source}")
     _install_cutlass_parent()
     loaded = sys.modules.get("flashinfer")
     loaded_file = Path(getattr(loaded, "__file__", "")).resolve() if loaded else None

--- a/tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py
+++ b/tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py
@@ -38,7 +38,6 @@ Upstream sources:
 - flashinfer/gemm/kernels/grouped_gemm_masked_wrapper.py
 """
 
-import hashlib
 import importlib
 import importlib.util
 import sys
@@ -63,15 +62,6 @@ KERNEL_META = {
         {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
     ),
 }
-
-SOURCE_COMMIT = "012cfdb97f217e0d48bc9352c17a74068c9e495b"
-SOURCE_SHA256 = "729ead8b8e3cfc66b0ec57e4b452f571c95f185758444a9ed697b11e60005639"
-SOURCE_DEPENDENCY_SHA256 = {
-    "grouped_gemm_masked_blackwell.py": "3d7cedc70a4504225259ba9f9c6dd6bfa67df18b00f1e416ee2c184909b1ccab",
-    "grouped_gemm_masked_wrapper.py": "6ff61a2c85b1df403578039013e803d649e9c56112925675f3ec908d507bccca",
-}
-CUTLASS_PARENT_COMMIT = "cdcf8d86daa9b417840fd99875a1b1af685d389d"
-CUTLASS_PARENT_SHA256 = "1517d4cde6b7988d5f44eca5fc2de4516b6f582ae60c37a5d1455a09c647453b"
 
 _SOURCE_ROOT = Path("/root-vol/aarch64-ws/kernel-libs/vr200/flashinfer")
 _CUTLASS_ROOT = Path(__file__).resolve().parents[3] / ".reference-deps" / "cutlass-v4.8.0dev"
@@ -2118,17 +2108,9 @@ def _torch_dtype(torch, dtype):
 
 @cache
 def _source_benchmark():
-    source_files = {
-        _SOURCE_ROOT / "flashinfer/gemm/kernels/grouped_gemm_masked_rubin.py": SOURCE_SHA256,
-        **{
-            _SOURCE_ROOT / "flashinfer/gemm/kernels" / name: digest
-            for name, digest in SOURCE_DEPENDENCY_SHA256.items()
-        },
-    }
-    for path, expected in source_files.items():
-        actual = hashlib.sha256(path.read_bytes()).hexdigest()
-        if actual != expected:
-            raise RuntimeError(f"frozen FlashInfer source hash mismatch: {path} sha256={actual}")
+    source = _SOURCE_ROOT / "flashinfer/gemm/kernels/grouped_gemm_masked_rubin.py"
+    if not source.is_file():
+        raise RuntimeError(f"FlashInfer source is unavailable: {source}")
     source_root = str(_SOURCE_ROOT)
     if source_root not in sys.path:
         sys.path.insert(0, source_root)

--- a/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
+++ b/tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py
@@ -10,7 +10,6 @@ Upstream source: csrc/tinygemm2_sm100.cu.
 """
 
 import ctypes
-import hashlib
 from functools import cache, lru_cache
 from pathlib import Path
 from typing import Any
@@ -55,7 +54,6 @@ WT_STAGE_BYTES = 4 * 2048
 ACT_STAGE_BYTES = 4 * 1024
 RED_BYTES = 2048
 BIAS_BYTES = 32
-SOURCE_SHA256 = "ea4d87f058b269e2f15d04f945849d7b26604c5b76eed55a06eb8e08d7bc891d"
 _TMA_G2S_2D = "cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes"
 
 
@@ -513,14 +511,7 @@ def _flashinfer_tinygemm2_spec():
     source = next((path for path in candidates if path.is_file()), None)
     if source is None:
         raise RuntimeError(
-            "FlashInfer TinyGEMM2 frozen source is unavailable; checked "
-            + ", ".join(map(str, candidates))
-        )
-    source_hash = hashlib.sha256(source.read_bytes()).hexdigest()
-    if source_hash != SOURCE_SHA256:
-        raise RuntimeError(
-            "FlashInfer TinyGEMM2 source does not match the frozen oracle: "
-            f"{source} sha256={source_hash}"
+            "FlashInfer TinyGEMM2 source is unavailable; checked " + ", ".join(map(str, candidates))
         )
     return gen_jit_spec(
         "tinygemm2_sm100",

--- a/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
+++ b/tirx_kernels/flashinfer/kda/bf16_fused_m128.py
@@ -2578,7 +2578,6 @@ def run_gpu(
     )
     peer = flashkda_peer.get("reference")
     if peer is not None:
-        result["flashkda_raw_provenance"] = peer.provenance
         result["flashkda_raw_correctness"] = peer.correctness
     return result
 

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py
@@ -8,9 +8,8 @@
 
 Source: ``csrc/kda/flashkda_decode_d128_t1_precomputed_direct_split16.cu`` (and
 its ``_split8`` sibling), symbol ``kernel_flashinfer_recurrent_kda_t1_direct``.
-Both bodies are frozen machine-generated exports ("Generated from a recurrent-KDA
-Loom schedule"); FlashInfer asserts their SHA256 in
-``tests/jit/test_flash_kda_decode_jit.py``.
+Both bodies are machine-generated exports ("Generated from a recurrent-KDA Loom
+schedule").
 
 The two exports differ in exactly three lines -- ``value_splits``,
 ``tile_row_base``'s multiplier, and the ``row_block`` trip count -- so this module

--- a/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
+++ b/tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py
@@ -7,9 +7,8 @@
 """TIRx port of FlashInfer's FlashKDA "cake" T=2 precomputed-gate decode kernel.
 
 Source: ``csrc/kda/flashkda_decode_d128_t2_precomputed_split4.cu``, symbol
-``kernel_flashinfer_recurrent_kda_wy_vtile_short`` -- a frozen machine-generated
-export ("Generated from a recurrent-KDA Loom schedule") whose SHA256 it declares
-in its own header.
+``kernel_flashinfer_recurrent_kda_wy_vtile_short`` -- a machine-generated export
+("Generated from a recurrent-KDA Loom schedule").
 
 This is the WY-transform schedule: 2 warps, a 14720-byte shared-memory arena,
 ``ldmatrix`` + ``mma.sync`` tensor-core products, and a per-token checkpoint

--- a/tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py
+++ b/tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py
@@ -17,7 +17,6 @@ The source specialization serves causal eager Q1 decode with 128 requests,
 64 BF16 query heads, four paged FP8 E4M3 KV heads, D=128, and TopK16.
 """
 
-import hashlib
 import math
 from functools import lru_cache
 from pathlib import Path
@@ -975,18 +974,6 @@ _GUARD_ELEMS = 64
 _OUT_GUARD = 42.5
 _LSE_GUARD = -54321.25
 _SOURCE_ROOT = Path("/root-vol/aarch64-ws/kernel-libs/gb300/flashinfer")
-_SOURCE_COMMIT = "cc6e8794c49bf66172627bdb9742fcb17d18b839"
-_SOURCE_FILES = {
-    "csrc/blackwell_msa/sm103a/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged.cu": (
-        "51a92ebabd161ecf179a84abc13164b9872e778b45864e229e2817d2af50e1da"
-    ),
-    "csrc/blackwell_msa/sm103a/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_binding.cu": (
-        "9200369c7d90c1aa63118d7059719b3f7e6de0163ee0ab0b9f678703ecb34a48"
-    ),
-    "flashinfer/msa_ops/_blackwell_sm100.py": (
-        "a4da56f1151b76827388934fcd9f674218ceb6a3a5fff8f0e1a5b3dd048dc68b"
-    ),
-}
 
 
 def _without_label(config: dict[str, Any]) -> dict[str, Any]:
@@ -1221,15 +1208,6 @@ def _verify_source_checkout() -> None:
         raise RuntimeError(
             f"reference imported from {api_path}, not pinned checkout {_SOURCE_ROOT}"
         )
-    head = (_SOURCE_ROOT / ".git" / "HEAD").read_text().strip()
-    if head.startswith("ref: "):
-        head = (_SOURCE_ROOT / ".git" / head[5:]).read_text().strip()
-    if head != _SOURCE_COMMIT:
-        raise RuntimeError(f"reference checkout is {head}, expected {_SOURCE_COMMIT}")
-    for relative, expected in _SOURCE_FILES.items():
-        actual = hashlib.sha256((_SOURCE_ROOT / relative).read_bytes()).hexdigest()
-        if actual != expected:
-            raise RuntimeError(f"reference hash mismatch for {relative}: {actual} != {expected}")
 
 
 @lru_cache(maxsize=1)

--- a/tirx_kernels/flashinfer/utils/_flashkda_bench.py
+++ b/tirx_kernels/flashinfer/utils/_flashkda_bench.py
@@ -5,17 +5,10 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
-import os
-import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
 from importlib import import_module
-from importlib.metadata import PackageNotFoundError, distribution
-from pathlib import Path
 from typing import Any
-from urllib.parse import unquote, urlparse
 
 import torch
 
@@ -23,92 +16,19 @@ import torch
 @dataclass
 class FlashKDARawReference:
     launch: Callable[[], None]
-    provenance: dict[str, Any]
     correctness: dict[str, float]
 
 
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _git_output(root: Path, *args: str) -> str:
+def _load_flash_kda_peer() -> Any:
     try:
-        return subprocess.check_output(
-            ["git", "-C", str(root), *args], text=True, stderr=subprocess.STDOUT
-        ).strip()
-    except subprocess.CalledProcessError as error:
-        raise RuntimeError(
-            f"failed to verify FlashKDA source provenance at {root}: {error.output.strip()}"
-        ) from error
-
-
-def _source_dir(dist: Any) -> Path | None:
-    override = os.environ.get("FLASHKDA_SOURCE_DIR")
-    if override:
-        return Path(override).expanduser().resolve(strict=True)
-
-    direct_url_text = dist.read_text("direct_url.json")
-    if direct_url_text:
-        url = json.loads(direct_url_text).get("url", "")
-        parsed = urlparse(url)
-        if parsed.scheme == "file":
-            source_dir = Path(unquote(parsed.path))
-            if source_dir.exists():
-                return source_dir.resolve(strict=True)
-    return None
-
-
-def _load_flash_kda_peer() -> tuple[Any, dict[str, Any]]:
-    try:
-        dist = distribution("flash-kda")
-    except PackageNotFoundError as error:
+        return import_module("flash_kda")
+    except ImportError as error:
         raise RuntimeError("MoonshotAI/FlashKDA is not installed") from error
-
-    flash_kda = import_module("flash_kda")
-    extension = import_module("flash_kda_C")
-    package_path = Path(flash_kda.__file__).resolve(strict=True)
-    extension_path = Path(extension.__file__).resolve(strict=True)
-    provenance = {
-        "repository": "https://github.com/MoonshotAI/FlashKDA.git",
-        "package_version": dist.version,
-        "package_path": str(package_path),
-        "package_sha256": _sha256(package_path),
-        "extension_path": str(extension_path),
-        "extension_sha256": _sha256(extension_path),
-    }
-
-    source_dir = _source_dir(dist)
-    if source_dir is not None:
-        source_commit = _git_output(source_dir, "rev-parse", "HEAD")
-        tracked_changes = _git_output(source_dir, "status", "--porcelain", "--untracked-files=no")
-        if tracked_changes:
-            raise RuntimeError(f"FlashKDA checkout has tracked modifications:\n{tracked_changes}")
-
-        source_package_path = source_dir / "flash_kda" / "__init__.py"
-        if _sha256(package_path) != _sha256(source_package_path):
-            raise RuntimeError(
-                "installed flash_kda package does not match its source checkout: "
-                f"package={package_path}, source={source_package_path}"
-            )
-
-        provenance.update({"source_dir": str(source_dir), "source_commit": source_commit})
-        cutlass_dir = source_dir / "cutlass"
-        if cutlass_dir.is_dir():
-            cutlass_commit = _git_output(cutlass_dir, "rev-parse", "HEAD")
-            submodule_record = _git_output(source_dir, "ls-tree", "HEAD", "cutlass").split()
-            if len(submodule_record) < 3 or submodule_record[2] != cutlass_commit:
-                raise RuntimeError("FlashKDA CUTLASS checkout does not match its gitlink")
-            provenance["cutlass_commit"] = cutlass_commit
-    return flash_kda, provenance
 
 
 def prepare_flashkda_raw_reference(case: dict[str, Any]) -> FlashKDARawReference:
     """Prepare and validate the installed raw FlashKDA peer."""
-    flash_kda, provenance = _load_flash_kda_peer()
+    flash_kda = _load_flash_kda_peer()
     cfg = case["config"]
     batch = 1 if cfg.packed else cfg.num_seqs
     seq_len = cfg.total_tokens if cfg.packed else cfg.seq_lens[0]
@@ -155,12 +75,4 @@ def prepare_flashkda_raw_reference(case: dict[str, Any]) -> FlashKDARawReference
         torch.testing.assert_close(peer_final_state, case["final_state"], rtol=1e-2, atol=1e-2)
         correctness["final_state_max_abs"] = state_max_abs
 
-    provenance.update(
-        {
-            "timing_scope": "flash_kda._fwd_raw",
-            "workspace_bytes": int(workspace_bytes),
-            "use_initial_state": cfg.use_initial_state,
-            "store_final_state": cfg.store_final_state,
-        }
-    )
-    return FlashKDARawReference(launch=launch, provenance=provenance, correctness=correctness)
+    return FlashKDARawReference(launch=launch, correctness=correctness)


### PR DESCRIPTION
## Summary

- README: list every registered kernel (adds `fastcu_nvfp4_gemm_gb300`, `flash_attention4_fp4`, `dense_blockscaled_gemm_sm107`, `blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`), add an architecture overview table, and tag single-architecture kernels inline with `**[sm_100a]**` / `**[sm_103a]**` / `**[sm_107a]**`. Also fix the `flashinfer` / `flash_kda` rows of the dependency table and add DeepEP to the third-party list.
- New `tests/lint/check_readme_kernels.py` (in pre-commit) keeps the listing, tags, and table in sync with `KERNEL_META["runtime_cuda_archs"]`.
- Drop per-kernel upstream source SHA256 / git commit gates from `tinygemm2_sm100`, `bmm_fp8_rubin`, `dense_blockscaled_gemm_sm107`, `grouped_gemm_masked_rubin`, `blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`, `blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`, `fastcu_nvfp4_gemm_gb300`, and the FlashKDA bench adapter. Revisions are already pinned by `reference_requirements` and `reference-dependencies.json`; reference lookup, JIT builds, and correctness checks are unchanged.

Rebased onto #155.

## Testing

- pre-commit on the changed files: ruff, license headers, and the new README lint pass.
- `python -m tirx_kernels.bench_suite --check-imports` (102 kernels) and `python -m tirx_kernels.registry --strict` pass.
- Full `tests/python/tirx/` suite against apache/tvm main on 7x B200 (CUDA 13.2): result posted below once the rerun on the rebased branch finishes. The only failure expected is `test_ptx_tcgen05_mma_block_size_form`, a TVM-side PTX 9.4 certification that needs a CUDA 13.4 ptxas (apache/tvm#20270 gates it).
- `flashkda_bf16_fused_m128 --with-references` and the TinyGEMM2 FlashInfer JIT reference path exercised on B200 after the SHA gate removal.

## Note

`flashinfer_fused_add_rmsnorm` is tagged `[sm_100a]` because its `KERNEL_META` only declares `sm_100a`, unlike its sibling norm kernels. If that is an omission, updating `runtime_cuda_archs` will make the lint ask for the README change.
