### PR TITLE
fix(msa): fix Q1 row-state races and reverse-prefill score reuse

### DIFF
--- a/.agents/skills/tirx-codegen-diagnostics/references/db/reuse-register-resident-tmem-values-instead-of-reloading.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/reuse-register-resident-tmem-values-instead-of-reloading.md
@@ -1,6 +1,6 @@
 # Reuse register-resident TMEM values instead of reloading
 
-**Symptoms:** `tmem_wait`, `long_scoreboard`, `exposed_load_latency`, `dispatch_specific_deficit`
+**Symptoms:** `tmem_wait`, `long_scoreboard`, `exposed_load_latency`, `dispatch_specific_deficit`, `data_dependent_correctness_failure`
 
 ## Symptom
 
@@ -10,12 +10,19 @@ synchronization window, and the specialization that exercises the path trails
 the reference at matched protocol. The source often carries the same redundant
 read, so instruction parity hides it.
 
+A numerical variant reloads cells after they were repurposed, although the
+consumer needs the earlier snapshot rather than their current value.
+
 ## What to change
 
 When no TMEM store to those cells intervenes between the first read and the
 reuse site -- same acquire, same release -- forward the live registers and
 delete the second load chain. The gate judges time, not fidelity to a
 redundancy the source happens to carry.
+
+If the consumer needs the earlier snapshot across a TMEM overwrite, retain the
+existing, unmodified register fragment and delete the reload of the overwritten
+cells. This is distinct from substituting stale registers for a current value.
 
 ```python
 # before: the snapshot path re-reads the cells the repack just read.
@@ -49,10 +56,20 @@ same warpgroup -- folding negations, de-duplicating a replicated register
 array, about 620K dynamic operations together -- measured neutral: that work
 sat in stall shadow.
 
+Preserving tail-score registers across an overlapping probability store fixed
+a sparse-prefill LSE error: maximum absolute error fell from 0.02354 to
+4.77e-7 against an independent oracle, also matched by three SM100 launches.
+Producer x64 TMEM-load sites fell from four to three, retaining 128 registers
+and zero spills on SM100 and SM103. Three paired 15-round SM100 workloads had
+after/before time ratios of 0.984-1.002; this is not an SM103 performance result.
+
 ## Boundary
 
-Valid only inside one synchronization window: any intervening TMEM store to the
-same cells, or a barrier that admits one, makes the registers stale.
+For current-value forwarding, an intervening TMEM store to the same cells, or a
+barrier that admits one, makes the registers stale. An earlier-snapshot consumer
+may cross that store only if the registers retain the required snapshot.
+Neither form establishes asynchronous memory ordering; required lifetime waits
+remain a separate obligation.
 Forwarding must not stretch the fragment's live range into a later region
 either -- keeping a wide fragment alive across an independent load batch pushed
 a warpgroup roughly sixty registers past its budget and spilled, regressing the
@@ -65,3 +82,5 @@ Confirm the `tcgen05.ld` site count drops in generated code for the affected
 specialization and that registers do not spill, then measure the affected and
 guard shapes; an instruction drop alone is not evidence, since shadowed-work
 removals measure neutral.
+For snapshots, also check numerical results with an overwrite between the
+original read and the consumer.

--- a/tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py
+++ b/tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py
@@ -339,6 +339,7 @@ def _build_kernel():
 
         with r_softmax:
             phase_s = [K.local_scalar("int32", init=_i32(0)) for _ in range(2)]
+            phase_o = K.local_scalar("int32", init=_i32(0))
             work_s = K.local_scalar("int32", init=first_work)
             with K.While(work_s < total_work):
                 instance = K.uniform(K.if_then_else(warp >= 4, _i32(1), _i32(0)))
@@ -364,13 +365,14 @@ def _build_kernel():
                     K.assign(corr_base, bar(_SMEM_CORR[1]))
                     K.assign(p_base, bar(_SMEM_P[1]))
 
-                for h in range(16):
+                # Each head's row state is owned by its corresponding lane.
+                with K.If(lane < 16), K.Then():
                     K.ptx.st.shared.b32(
-                        bar(_SMEM_ROW_MAX) + K.cast(row_base + h, "uint32") * _u32(4),
+                        bar(_SMEM_ROW_MAX) + K.cast(row_base + lane, "uint32") * _u32(4),
                         _f32(_NEG_INF),
                     )
                     K.ptx.st.shared.b32(
-                        bar(_SMEM_ROW_SUM) + K.cast(row_base + h, "uint32") * _u32(4), _f32(0.0)
+                        bar(_SMEM_ROW_SUM) + K.cast(row_base + lane, "uint32") * _u32(4), _f32(0.0)
                     )
 
                 pair = K.local_scalar("int32", init=_i32(0))
@@ -421,25 +423,30 @@ def _build_kernel():
                             _load_shared_f32(exch_base + K.cast(48 + lane, "uint32") * _u32(4)),
                         )
                         K.assign(tile_max_lane, _max_f32(max01, max23))
-                    tile_max = K.alloc_local((16,), "float32")
-                    for h in range(16):
-                        K.assign(tile_max[h], _shfl_idx_f32(tile_max_lane, h))
-
-                    acc_scale = K.alloc_local((16,), "float32")
-                    for h in range(16):
-                        state_addr = bar(_SMEM_ROW_MAX) + K.cast(row_base + h, "uint32") * _u32(4)
+                    new_max_lane = K.local_scalar("float32", init=_f32(_NEG_INF))
+                    acc_scale_lane = K.local_scalar("float32", init=_f32(1.0))
+                    with K.If(lane < 16), K.Then():
+                        state_addr = bar(_SMEM_ROW_MAX) + K.cast(row_base + lane, "uint32") * _u32(
+                            4
+                        )
                         old_max = _load_shared_f32(state_addr)
-                        new_max = _max_f32(old_max, tile_max[h])
-                        K.ptx.st.shared.b32(state_addr, new_max)
+                        K.assign(new_max_lane, _max_f32(old_max, tile_max_lane))
+                        K.ptx.st.shared.b32(state_addr, new_max_lane)
                         delta = K.local_scalar("float32")
-                        K.ptx.sub.rn.f32(delta, old_max, new_max)
+                        K.ptx.sub.rn.f32(delta, old_max, new_max_lane)
                         K.ptx.mul.rn.f32(delta, softmax_scale_log2, delta)
                         exp_delta = K.local_scalar("float32")
                         K.ptx.ex2.approx.ftz.f32(exp_delta, delta)
                         K.assign(
-                            acc_scale[h],
+                            acc_scale_lane,
                             K.if_then_else(old_max > _f32(_NEG_INF), exp_delta, _f32(1.0)),
                         )
+
+                    tile_max = K.alloc_local((16,), "float32")
+                    acc_scale = K.alloc_local((16,), "float32")
+                    for h in range(16):
+                        K.assign(tile_max[h], _shfl_idx_f32(new_max_lane, h))
+                        K.assign(acc_scale[h], _shfl_idx_f32(acc_scale_lane, h))
 
                     _tmem_store_x16(my_stats, acc_scale)
                     K.ptx.tcgen05.wait__st.sync.aligned()
@@ -456,9 +463,7 @@ def _build_kernel():
                             K.assign(score[h], _f32(_NEG_INF))
                     exp_values = K.alloc_local((16,), "float32")
                     for h in range(16):
-                        new_max = _load_shared_f32(
-                            bar(_SMEM_ROW_MAX) + K.cast(row_base + h, "uint32") * _u32(4)
-                        )
+                        new_max = tile_max[h]
                         safe_max = K.if_then_else(new_max == _f32(_NEG_INF), _f32(0.0), new_max)
                         max_scaled = K.local_scalar("float32")
                         K.ptx["mul.f32"](max_scaled, safe_max, softmax_scale_log2)
@@ -477,11 +482,12 @@ def _build_kernel():
                         for delta in (16, 8, 4, 2, 1):
                             shuffled = _shfl_xor_f32(exp_values[h], delta)
                             K.ptx.add.rn.f32(exp_values[h], exp_values[h], shuffled)
-                        sum_addr = bar(_SMEM_ROW_SUM) + K.cast(row_base + h, "uint32") * _u32(4)
-                        old_sum = _load_shared_f32(sum_addr)
-                        new_sum = K.local_scalar("float32")
-                        K.ptx.fma.rn.f32(new_sum, old_sum, acc_scale[h], exp_values[h])
-                        K.ptx.st.shared.b32(sum_addr, new_sum)
+                        with K.If(lane == h), K.Then():
+                            sum_addr = bar(_SMEM_ROW_SUM) + K.cast(row_base + h, "uint32") * _u32(4)
+                            old_sum = _load_shared_f32(sum_addr)
+                            new_sum = K.local_scalar("float32")
+                            K.ptx.fma.rn.f32(new_sum, old_sum, acc_scale[h], exp_values[h])
+                            K.ptx.st.shared.b32(sum_addr, new_sum)
                     K.ptx.fence.proxy.async_()
                     with K.If(instance == _i32(0)):
                         with K.Then():
@@ -537,6 +543,9 @@ def _build_kernel():
                         K.ptx.barrier.sync(8, 128)
                     with K.Else():
                         K.ptx.barrier.sync(9, 128)
+                # Final PV completion acknowledges consumption of the last correction signal.
+                _mbar_wait(bar(_MBAR_O_FULL), phase_o)
+                _flip(phase_o)
                 with K.If(instance == _i32(0)):
                     with K.Then():
                         _mbar_arrive(bar(_MBAR_CORR_SIG))

--- a/tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py
+++ b/tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py
@@ -655,7 +655,7 @@ def _build_producer_kernel():
                     probability_addr, *(packed_probability[index] for index in range(32))
                 )
 
-                _tmem_load_x64(score1, score_addr + _u32(64))
+                # Keep the original tail scores: the P store has reused their TMEM columns.
                 with K.If(K.And(valid_cols > _i32(0), tail_valid < _i32(64))), K.Then():
                     _mask_64(score1, tail_valid)
                 for pair in range(32):


### PR DESCRIPTION
## Summary

- Fix Q1 decode's shared row-state races by assigning each head to one lane and broadcasting through existing warp shuffles.
- Wait for final PV completion before publishing Q1's final correction signal, preventing premature barrier-generation reuse.
- Preserve reverse-prefill tail scores in registers instead of reloading TMEM columns already overwritten by the probability store.
- Update the existing TMEM reuse field note. No new mechanisms, data structures, or pytest cases.

## Validation

Base: tirx-kernels `05bf6744`, TVM `5e49b343`, CUDA 13.2.

- Both canonical cases have zero NumSim numerical mismatches against independent oracles.
- Both kernels pass three bitwise-repeatable GPU launches on B200 / SM100 against the same oracles.
- Targeted Synccheck/Racecheck reruns report no ERROR or INCOMPLETE.
- SM100 and SM103 compilation passed; register and spill counts are unchanged.
- Targeted registry, low-level IR, and benchmark tests: 42 passed. Ruff check/format passed.

REVIEW-only paths remain untouched: Q1 retains 4096 uninitialized-read advisories and 10 TMEM-lifetime REVIEWs; reverse-prefill retains one TMEM-lifetime REVIEW. This is not an all-clean or exhaustive-schedule claim.

## Performance

Standard bench-suite paired A/B on B200 / SM100, three default configurations per kernel, 15 rounds per configuration, same physical GPU per pair.

| Kernel / configuration | Before (us) | After (us) | Latency change |
| --- | ---: | ---: | ---: |
| Q1 / seed53 | 267.38 | 259.31 | +3.02% |
| Q1 / ragged boundaries | 262.22 | 263.35 | -0.43% |
| Q1 / scattered pages | 257.30 | 258.27 | -0.38% |
| Reverse / identity, no stats | 75.52 | 75.67 | -0.20% |
| Reverse / identity, both LSEs | 75.75 | 74.72 | +1.36% |
| Reverse / permuted, LSE | 75.75 | 74.51 | +1.65% |

6/6 passed the strict `after/before < 1.01` gate.

Both local A/B sides received identical SM100 architecture-gate adjustments; those adjustments are not included in this PR. Workloads and the benchmark harness were unchanged. These measurements do not certify SM103 performance.