### PR TITLE
fix(kern): handle unstaged MMA descriptors in loop lint

### DIFF
--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -46,6 +46,27 @@ def _calls_named(func, name):
     return calls
 
 
+def test_mma_desc_loop_invariance_handles_unstaged_and_staged_tiles():
+    import warnings
+
+    for mode in ("unstaged", "constant", "varying"):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+
+            @K.kernel(warps=1, arch="sm_100a", grid=False)
+            def probe(out: K.gptr("uint64")):
+                shape = (16, 128) if mode == "unstaged" else (2, 16, 128)
+                tile = K.smem_pool().alloc(shape, K.bf16, swizzle=K.SW128B)
+                with K.serial(2) as i:
+                    view = tile if mode == "unstaged" else tile[i if mode == "varying" else 0]
+                    desc = view.mma_desc()
+                    K.ptx.st.global_.b64(out.ptr_to([i]), desc.value)
+
+        invariant = [w for w in caught if "encode is invariant" in str(w.message)]
+        assert len(invariant) == (0 if mode == "varying" else 1)
+        assert _calls_named(probe.func, "tirx.cuda.tcgen05_encode_matrix_descriptor")
+
+
 def test_local_scalar_init_matches_declare_then_assign():
     def two_statement(out):
         x = K.local_scalar("float32")

--- a/tirx_kernels/kern/smem.py
+++ b/tirx_kernels/kern/smem.py
@@ -168,7 +168,7 @@ def _lint_invariant_encode(stage):
         return
     if builder is None or not any(isinstance(f, ForFrame) for f in builder.frames):
         return
-    if not isinstance(stage, int) and undefined_vars(stage):
+    if stage is not None and not isinstance(stage, int) and undefined_vars(stage):
         return
     warnings.warn(
         "mma_desc: encode is invariant w.r.t. the enclosing loop; hoist it. "


### PR DESCRIPTION
## Summary

- Fix a compilation-time SIGSEGV when an unstaged 2-D tile calls `mma_desc()` inside a runtime loop.
- Treat `stage=None` as loop-invariant without passing it to native `undefined_vars`, while preserving the invariant-encode warning.
- Add one regression test covering unstaged, constant-stage, and varying-stage tiles.

## Validation

- The reproducer exits with code 139 before the fix; afterward, it compiles for SM100 and retains the expected warning.
- Kern API, low-level IR, and CUDA compile-contract tests: **39 passed**.
- Ruff check/format and `git diff --check` passed.
- Tested with TVM `5e49b343` and CUDA 13.2.