### PR TITLE
docs(kernel): regroup README kernels by upstream port with architecture notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,316 +6,203 @@ High-performance GPU kernels authored in
 
 ## Kernels
 
-Each architecture section lists every public registry kernel supported on
-that target. A kernel appears in every section declared by its
-`KERNEL_META["runtime_cuda_archs"]`. Each linked name is accepted by
-`--kernel`; the link opens its implementation. Run
-`python -m tirx_kernels.registry --format json` for the authoritative
-metadata. `tests/lint/check_readme_kernels.py` keeps these lists in sync.
+Kernels are grouped by the upstream library and entry point they port. Unless
+annotated, a kernel runs on `sm_100a`, `sm_103a` and `sm_107a`, and its
+performance was measured and tuned on `sm_100a`; every listed architecture is
+gated by the registry correctness tests. Annotations mark the exceptions:
+⟨sm_103a⟩ runs only on that architecture and was tuned there, and ⟨+sm_110a⟩
+runs on that architecture in addition to the default three. Annotations follow
+`KERNEL_META["runtime_cuda_archs"]` and `tests/lint/check_readme_kernels.py`
+keeps them in sync.
 
-### `sm_110a` (Thor)
+| Architecture | Kernels |
+|---|---:|
+| `sm_100a` | 101 |
+| `sm_103a` | 96 |
+| `sm_107a` | 94 |
+| `sm_110a` | 1 |
 
-- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
+### Native TIRx
 
-### `sm_100a` (B200)
+- **GEMM:**
+  [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py) ⟨+sm_110a⟩,
+  [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
+- **Normalization:**
+  [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
+- **Distributed:**
+  [`allgather_gemm`](tirx_kernels/basic/allgather_gemm.py) ⟨sm_100a⟩,
+  [`gemm_reduce_scatter`](tirx_kernels/basic/gemm_reduce_scatter.py) ⟨sm_100a⟩
 
-- [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py)
-- [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
-- [`allgather_gemm`](tirx_kernels/basic/allgather_gemm.py)
-- [`blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py)
-- [`blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100.py)
-- [`cake_vsa_blk128_compact_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py)
-- [`cake_vsa_longseq_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py)
-- [`cake_vsa_ultrasparse_bsr_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py)
-- [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py)
-- [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
-- [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py)
-- [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py)
-- [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
-- [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
-- [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py)
-- [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
-- [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
-- [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py)
-- [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py)
-- [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
-- [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py)
-- [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py)
-- [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py)
-- [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
-- [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
-- [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
-- [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
-- [`deepep_combine`](tirx_kernels/deepep/combine.py)
-- [`deepep_dispatch`](tirx_kernels/deepep/dispatch.py)
-- [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py)
-- [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py)
-- [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py)
-- [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py)
-- [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py)
-- [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
-- [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py)
-- [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py)
-- [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py)
-- [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
-- [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py)
-- [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py)
-- [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
-- [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
-- [`flash_mla_sparse_fwd`](tirx_kernels/flashmla/flash_mla_sparse_fwd.py)
-- [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py)
-- [`flashinfer_fused_add_rmsnorm`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py)
-- [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py)
-- [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py)
-- [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py)
-- [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
-- [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py)
-- [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py)
-- [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py)
-- [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py)
-- [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py)
-- [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py)
-- [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py)
-- [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py)
-- [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py)
-- [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
-- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
-- [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
-- [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py)
-- [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py)
-- [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py)
-- [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
-- [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py)
-- [`gemm_reduce_scatter`](tirx_kernels/basic/gemm_reduce_scatter.py)
-- [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
-- [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py)
-- [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py)
-- [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py)
-- [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
-- [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py)
-- [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
-- [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
-- [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py)
-- [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py)
-- [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py)
-- [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py)
-- [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py)
-- [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py)
-- [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
-- [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
-- [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py)
-- [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py)
-- [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py)
-- [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py)
-- [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py)
-- [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
-- [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
-- [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
-- [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py)
-- [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
-- [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py)
-- [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
-- [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py)
+### Agent-evolved TIRx
 
-### `sm_103a` (GB300)
+Curated kernels selected from measured agent-evolution runs. Their canonical
+modules retain the supported workload and stable provenance; run logs and
+intermediate candidates remain outside this package. See the
+[measured speedups](tirx_kernels/agent_evolved/README.md) for the benchmark
+contract and results.
 
-- [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py)
-- [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
-- [`blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py)
-- [`blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103.py)
-- [`blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py)
-- [`cake_vsa_longseq_sm103`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py)
-- [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py)
-- [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
-- [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py)
-- [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py)
-- [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
-- [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
-- [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py)
-- [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
-- [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
-- [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py)
-- [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py)
-- [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
-- [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py)
-- [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py)
-- [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py)
-- [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
-- [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
-- [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
-- [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
-- [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py)
-- [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py)
-- [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py)
-- [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py)
-- [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py)
-- [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
-- [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py)
-- [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py)
-- [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py)
-- [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
-- [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py)
-- [`fastcu_nvfp4_gemm_gb300`](tirx_kernels/fastcu/nvfp4_gemm_gb300.py)
-- [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py)
-- [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
-- [`flash_attention4_fp4`](tirx_kernels/flashattention/flash_attention4_fp4.py)
-- [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
-- [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py)
-- [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py)
-- [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py)
-- [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py)
-- [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
-- [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py)
-- [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py)
-- [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py)
-- [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py)
-- [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py)
-- [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py)
-- [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py)
-- [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py)
-- [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py)
-- [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
-- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
-- [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
-- [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py)
-- [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py)
-- [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py)
-- [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
-- [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py)
-- [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
-- [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py)
-- [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py)
-- [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py)
-- [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
-- [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py)
-- [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
-- [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
-- [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py)
-- [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py)
-- [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py)
-- [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py)
-- [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py)
-- [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py)
-- [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
-- [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
-- [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py)
-- [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py)
-- [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py)
-- [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py)
-- [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py)
-- [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
-- [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
-- [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
-- [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py)
-- [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
-- [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py)
-- [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
-- [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py)
+- **KDA forward:**
+  [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
 
-### `sm_107a` (Rubin)
+### cuDNN Frontend ports
 
-- [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py)
-- [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
-- [`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`](tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py)
-- [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py)
-- [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py)
-- [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
-- [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py)
-- [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py)
-- [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py)
-- [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py)
-- [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py)
-- [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py)
-- [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py)
-- [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py)
-- [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py)
-- [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py)
-- [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
-- [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py)
-- [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py)
-- [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py)
-- [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
-- [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py)
-- [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py)
-- [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
-- [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py)
-- [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py)
-- [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py)
-- [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py)
-- [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py)
-- [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
-- [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py)
-- [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py)
-- [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py)
-- [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
-- [`dense_blockscaled_gemm_sm107`](tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py)
-- [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py)
-- [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py)
-- [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py)
-- [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
-- [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py)
-- [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py)
-- [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py)
-- [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py)
-- [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
-- [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py)
-- [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py)
-- [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py)
-- [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py)
-- [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py)
-- [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py)
-- [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py)
-- [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py)
-- [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py)
-- [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
-- [`fp16_bf16_gemm`](tirx_kernels/basic/fp16_bf16_gemm.py)
-- [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
-- [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py)
-- [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py)
-- [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py)
-- [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
-- [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py)
-- [`grouped_gemm_masked_rubin`](tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py)
-- [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
-- [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py)
-- [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py)
-- [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py)
-- [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
-- [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py)
-- [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
-- [`nvfp4_gemm`](tirx_kernels/basic/nvfp4_gemm.py)
-- [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py)
-- [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py)
-- [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py)
-- [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py)
-- [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py)
-- [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py)
-- [`rmsnorm`](tirx_kernels/basic/rmsnorm.py)
-- [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
-- [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py)
-- [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py)
-- [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py)
-- [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py)
-- [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py)
-- [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
-- [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
-- [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
-- [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py)
-- [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
-- [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py)
-- [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
-- [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py)
+- **Persistent GEMM:**
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_amax`](tirx_kernels/cudnn/amax/dense_blockscaled_gemm_persistent_amax.py),
+  [`cudnn_sm100_dense_gemm_persistent_swiglu`](tirx_kernels/cudnn/swiglu/dense_gemm_persistent_swiglu.py),
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_swiglu_interleaved_quant`](tirx_kernels/cudnn/swiglu/dense_blockscaled_gemm_persistent_swiglu_interleaved_quant.py),
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_srelu_quant`](tirx_kernels/cudnn/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py),
+  [`cudnn_sm100_dense_blockscaled_gemm_persistent_dsrelu_quant`](tirx_kernels/cudnn/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py),
+  [`cudnn_sm100_gemm_proj_rope_mxfp8_bf16in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py),
+  [`cudnn_sm100_gemm_proj_rope_mxfp8_mxfp8in`](tirx_kernels/cudnn/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py)
+- **Grouped GEMM:**
+  [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py),
+  [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
+- **Linear attention:**
+  [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
+  [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py),
+  [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
+  [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
+  [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py),
+  [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),
+  [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
+- **CSA compression:**
+  [`cudnn_sm100_csa_compressor_fwd`](tirx_kernels/cudnn/csa/compressor_fwd_sm100.py)
+- **Sparse attention:**
+  [`cudnn_sm100_dsa_sparse_attention_backward`](tirx_kernels/cudnn/dsa/sparse_attention_backward.py),
+  [`cudnn_sm100_bsa_forward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk128.py),
+  [`cudnn_sm100_bsa_forward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_sm100_blk64.py),
+  [`cudnn_sm100_bsa_forward_combine_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_forward_combine_sm100_blk64.py),
+  [`cudnn_sm100_bsa_backward_blk128`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk128.py),
+  [`cudnn_sm100_bsa_backward_blk64`](tirx_kernels/cudnn/bsa/block_sparse_attention_backward_sm100_blk64.py)
+
+### FlashAttention ports
+
+- **Forward:**
+  [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py),
+  [`flash_attention4_fp4`](tirx_kernels/flashattention/flash_attention4_fp4.py) ⟨sm_103a⟩
+- **Backward:**
+  [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
+
+### FlashInfer ports
+
+Grouped by the FlashInfer Python entry point each port backs.
+
+- **`flashinfer.activation`:**
+  [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py),
+  [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
+- **`flashinfer.quantization`:**
+  [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py),
+  [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py),
+  [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py),
+  [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
+- **`flashinfer.norm`:**
+  [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py),
+  [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py),
+  [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py),
+  [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py),
+  [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py),
+  [`flashinfer_fused_add_rmsnorm`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py) ⟨sm_100a⟩,
+  [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py),
+  [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py),
+  [`flashinfer_qk_rmsnorm`](tirx_kernels/flashinfer/norm/qk_rmsnorm.py)
+- **`flashinfer.mamba`:**
+  [`selective_state_update_stp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_simple.py),
+  [`selective_state_update_stp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_vertical.py),
+  [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py),
+  [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py),
+  [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py),
+  [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
+- **`flashinfer.kda`:**
+  [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py),
+  [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py),
+  [`recurrent_kda_decode_grouped`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_grouped.py),
+  [`flashkda_decode_t1_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t1_precomputed.py),
+  [`flashkda_decode_t2_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t2_precomputed.py),
+  [`flashkda_decode_t3_lower_bound`](tirx_kernels/flashinfer/kda/flashkda_decode_t3_lower_bound.py),
+  [`flashkda_decode_t4_precomputed`](tirx_kernels/flashinfer/kda/flashkda_decode_t4_precomputed.py),
+  [`flashkda_decode_t5_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t5_gram.py),
+  [`flashkda_decode_t6_gram`](tirx_kernels/flashinfer/kda/flashkda_decode_t6_gram.py)
+- **`flashinfer.gdn_decode`:**
+  [`gdn_decode_bf16_ilp4`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_ilp4.py),
+  [`gdn_decode_bf16_wide_vec_t1`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_t1.py),
+  [`gdn_decode_bf16_wide_vec_mtp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_bf16_wide_vec_mtp.py),
+  [`gdn_decode_fp32_mtp_warp`](tirx_kernels/flashinfer/gdn_decode/gdn_decode_fp32_mtp_warp.py)
+- **`flashinfer.gdn_prefill`:**
+  [`gdn_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_prefill_sm100.py),
+  [`gdn_cp_prefill_sm100`](tirx_kernels/flashinfer/gdn_prefill/gdn_cp_prefill_sm100.py)
+- **`flashinfer.cake_vsa`:**
+  [`cake_vsa_blk128_compact_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_blk128_compact_sm100.py) ⟨sm_100a⟩,
+  [`cake_vsa_ultrasparse_bsr_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_ultrasparse_bsr_sm100.py) ⟨sm_100a⟩,
+  [`cake_vsa_longseq_sm100`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm100.py) ⟨sm_100a⟩,
+  [`cake_vsa_longseq_sm103`](tirx_kernels/flashinfer/cake_vsa/cake_vsa_longseq_sm103.py) ⟨sm_103a⟩
+- **`flashinfer.msa_ops`:**
+  [`blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103.py) ⟨sm_103a⟩,
+  [`blackwell_msa_decode_uniform_fp8_qkv_paged_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py) ⟨sm_100a⟩,
+  [`blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_long_prefill_paged_bf16_gqa16_direct_group_sm100.py) ⟨sm_100a⟩,
+  [`blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_prefill_m64_bf16_gqa16_flat_sm103.py) ⟨sm_103a⟩,
+  [`blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103`](tirx_kernels/flashinfer/msa_ops/blackwell_msa_reverse_prefill_bf16_paged_topk4_qload4_sm103.py) ⟨sm_103a⟩
+- **`flashinfer.gemm`:**
+  [`tinygemm2_sm100`](tirx_kernels/flashinfer/gemm/tinygemm2_sm100.py),
+  [`bmm_fp8_rubin`](tirx_kernels/flashinfer/gemm/bmm_fp8_rubin.py) ⟨sm_107a⟩,
+  [`dense_blockscaled_gemm_sm107`](tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py) ⟨sm_107a⟩,
+  [`grouped_gemm_masked_rubin`](tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py) ⟨sm_107a⟩
+- **`flashinfer.fused_moe`:**
+  [`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`](tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py) ⟨sm_107a⟩
+- **`flashinfer.topk`:**
+  [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py),
+  [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py),
+  [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py),
+  [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py),
+  [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)
+
+### FlashMLA ports
+
+- **Sparse prefill:**
+  [`sparse_flashmla_prefill_head64_phase1`](tirx_kernels/flashmla/sparse_prefill_head64_phase1.py),
+  [`sparse_flashmla_prefill_head128_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_phase1.py),
+  [`sparse_flashmla_prefill_head128_small_topk_phase1`](tirx_kernels/flashmla/sparse_prefill_head128_small_topk_phase1.py)
+- **Sparse decode:**
+  [`sparse_flashmla_decode_head64`](tirx_kernels/flashmla/sparse_decode_head64.py)
+- **Sparse forward:**
+  [`flash_mla_sparse_fwd`](tirx_kernels/flashmla/flash_mla_sparse_fwd.py) ⟨sm_100a⟩
+
+### DeepGEMM ports
+
+- **Dense and grouped GEMM:**
+  [`deepgemm_sm100_fp8_gemm_1d1d`](tirx_kernels/deepgemm/fp8_gemm_1d1d.py),
+  [`deepgemm_sm100_m_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_contiguous.py),
+  [`deepgemm_sm100_m_grouped_fp8_gemm_masked`](tirx_kernels/deepgemm/m_grouped_fp8_gemm_masked.py),
+  [`deepgemm_sm100_k_grouped_fp8_gemm_contiguous`](tirx_kernels/deepgemm/k_grouped_fp8_gemm_contiguous.py),
+  [`deepgemm_sm100_fp8_bmm`](tirx_kernels/deepgemm/fp8_bmm.py),
+  [`deepgemm_sm100_tf32_hc_prenorm_gemm`](tirx_kernels/deepgemm/tf32_hc_prenorm_gemm.py)
+- **MQA logits:**
+  [`deepgemm_sm100_fp4_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp4.py),
+  [`deepgemm_sm100_fp8_mqa_logits`](tirx_kernels/deepgemm/mqa_logits_fp8.py),
+  [`deepgemm_sm100_fp4_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp4.py),
+  [`deepgemm_sm100_fp8_paged_mqa_logits`](tirx_kernels/deepgemm/paged_mqa_logits_fp8.py)
+- **MoE:**
+  [`sm100_fp8_fp4_mega_moe`](tirx_kernels/deepgemm/sm100_fp8_fp4_mega_moe.py)
+
+### DeepEP ports
+
+- **Elastic communication:**
+  [`deepep_dispatch`](tirx_kernels/deepep/dispatch.py) ⟨sm_100a⟩,
+  [`deepep_combine`](tirx_kernels/deepep/combine.py) ⟨sm_100a⟩
+
+### fast.cu ports
+
+- **NVFP4 GEMM:**
+  [`fastcu_nvfp4_gemm_gb300`](tirx_kernels/fastcu/nvfp4_gemm_gb300.py) ⟨sm_103a⟩
+
+### MSA ports
+
+- **Sparse-attention preparation:**
+  [`msa_sparse_prepare_flat_schedule_sm100`](tirx_kernels/msa/sparse_prepare_flat_schedule.py),
+  [`msa_sparse_prepare_fwd_split_atomic_sm100`](tirx_kernels/msa/sparse_prepare_fwd_split_atomic.py)
+- **Sparse-attention forward:**
+  [`msa_sparse_atten_fwd_sm100`](tirx_kernels/msa/sparse_atten_fwd.py),
+  [`msa_sparse_atten_fwd_nvfp4_kv_sm100`](tirx_kernels/msa/sparse_atten_fwd_nvfp4_kv.py),
+  [`msa_sparse_atten_fwd_combine_sm100`](tirx_kernels/msa/sparse_atten_fwd_combine.py)
 
 ## Performance
 

--- a/tests/lint/check_readme_kernels.py
+++ b/tests/lint/check_readme_kernels.py
@@ -2,26 +2,33 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright TIRx authors
 
-"""Check that each README architecture list matches the kernel registry.
+"""Check that the README kernel section matches the kernel registry.
 
-Every supported CUDA architecture has its own section. Each section must list
-exactly the public kernels whose ``KERNEL_META["runtime_cuda_archs"]`` contains
-that architecture, and every link must open the registered module.
+The ``## Kernels`` section groups kernels by upstream library and entry point.
+Every registered kernel must be linked exactly once, optionally followed by one
+annotation in angle brackets. Without an annotation a kernel runs on the default
+architectures (``sm_100a``, ``sm_103a``, ``sm_107a``). The architecture tokens of
+an annotation are derived from ``KERNEL_META["runtime_cuda_archs"]``: the full
+list when it is not a superset of the default set, or ``+sm_xxx`` for each
+architecture beyond it.
+
+The summary table at the top of the section must give, per architecture, how
+many kernels run on it.
 """
 
 from __future__ import annotations
 
 import re
 import sys
-from collections import Counter
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 README = REPO_ROOT / "README.md"
-ARCHITECTURES = ("sm_110a", "sm_100a", "sm_103a", "sm_107a")
+ARCH_ORDER = ("sm_100a", "sm_103a", "sm_107a", "sm_110a")
+DEFAULT_ARCHS = ("sm_100a", "sm_103a", "sm_107a")
 
-_ARCH_HEADING = re.compile(r"^### `(sm_[0-9]+[af]?)` \([^)]+\)$", re.MULTILINE)
-_LINK = re.compile(r"^- \[`([^`]+)`\]\((tirx_kernels/[^)]+\.py)\)$", re.MULTILINE)
+_LINK = re.compile(r"\[`([^`]+)`\]\((tirx_kernels/[^)]+\.py)\)(?: ⟨([^⟩]*)⟩)?")
+_SUMMARY_ROW = re.compile(r"^\| `(sm_[0-9]+[af]?)` \| (\d+) \|$", re.MULTILINE)
 
 
 def _registry() -> dict[str, tuple[str, tuple[str, ...]]]:
@@ -37,53 +44,56 @@ def _registry() -> dict[str, tuple[str, tuple[str, ...]]]:
     }
 
 
+def _ordered(archs: tuple[str, ...]) -> list[str]:
+    ordered = [arch for arch in ARCH_ORDER if arch in archs]
+    return ordered + sorted(arch for arch in archs if arch not in ARCH_ORDER)
+
+
+def _expected_annotation(archs: tuple[str, ...]) -> str:
+    extra = [arch for arch in _ordered(archs) if arch not in DEFAULT_ARCHS]
+    if set(archs) - set(extra) == set(DEFAULT_ARCHS):
+        return " ".join(f"+{arch}" for arch in extra)
+    return " ".join(_ordered(archs))
+
+
 def main() -> int:
     kernels = _registry()
     text = README.read_text()
+    start = text.index("## Kernels")
+    end = text.index("\n## ", start + 1)
+    section = text[start:end]
     errors: list[str] = []
 
-    _, kernel_marker, remainder = text.partition("## Kernels\n")
-    kernel_text, performance_marker, _ = remainder.partition("\n## Performance")
-    if not kernel_marker or not performance_marker:
-        errors.append("README.md must contain Kernels and Performance sections")
-        headings = []
-    else:
-        headings = list(_ARCH_HEADING.finditer(kernel_text))
+    rows: dict[str, tuple[str, str]] = {}
+    for name, path, annotation in _LINK.findall(section):
+        if name in rows:
+            errors.append(f"{name}: listed more than once")
+        rows[name] = (path, annotation.strip())
 
-    listed_archs = tuple(match.group(1) for match in headings)
-    if listed_archs != ARCHITECTURES:
-        errors.append(f"architecture sections must be {ARCHITECTURES}, found {listed_archs}")
+    for name, (path, archs) in sorted(kernels.items()):
+        if name not in rows:
+            errors.append(f"{name}: not listed in README.md")
+            continue
+        readme_path, annotation = rows[name]
+        if readme_path != path:
+            errors.append(f"{name}: README links {readme_path}, module is {path}")
+        expected = _expected_annotation(archs)
+        if annotation != expected:
+            errors.append(f"{name}: annotation is {annotation!r}, expected {expected!r}")
+    for name in sorted(set(rows) - set(kernels)):
+        errors.append(f"{name}: listed in README.md but not registered")
 
-    registry_archs = {arch for _, archs in kernels.values() for arch in archs}
-    for arch in sorted(registry_archs - set(ARCHITECTURES)):
-        errors.append(f"registry architecture {arch} has no README section")
-
-    parsed_link_count = 0
-    for index, heading in enumerate(headings):
-        arch = heading.group(1)
-        body_end = headings[index + 1].start() if index + 1 < len(headings) else len(kernel_text)
-        body = kernel_text[heading.end() : body_end]
-        links = _LINK.findall(body)
-        parsed_link_count += len(links)
-
-        counts = Counter(name for name, _ in links)
-        for name, count in sorted(counts.items()):
-            if count > 1:
-                errors.append(f"{arch}: {name} is linked {count} times")
-
-        found = dict(links)
-        expected = {name: path for name, (path, archs) in kernels.items() if arch in archs}
-        for name in sorted(set(expected) - set(found)):
-            errors.append(f"{arch}: {name} is not linked")
-        for name in sorted(set(found) - set(expected)):
-            errors.append(f"{arch}: {name} is linked but not supported")
-        for name in sorted(set(expected) & set(found)):
-            if found[name] != expected[name]:
-                errors.append(f"{arch}: {name} links {found[name]}, module is {expected[name]}")
-
-    all_kernel_links = re.findall(r"\[`[^`]+`\]\(tirx_kernels/[^)]+\.py\)", kernel_text)
-    if len(all_kernel_links) != parsed_link_count:
-        errors.append("kernel links must be plain bullets inside architecture sections")
+    summary = {arch: int(runs) for arch, runs in _SUMMARY_ROW.findall(section)}
+    for arch in ARCH_ORDER:
+        runs = sum(arch in archs for _, archs in kernels.values())
+        if runs == 0 and arch not in summary:
+            continue
+        if arch not in summary:
+            errors.append(f"summary table: missing row for {arch}")
+        elif summary[arch] != runs:
+            errors.append(f"summary table: {arch} should read {runs}, found {summary[arch]}")
+    for arch in set(summary) - set(ARCH_ORDER):
+        errors.append(f"summary table: unexpected row for {arch}")
 
     for error in errors:
         print(error, file=sys.stderr)


### PR DESCRIPTION
## Summary

#153 replaced the README's grouped-by-upstream kernel listing with four flat per-architecture lists, repeating the 89 common kernels three or four times and losing the "which upstream entry point does this port" structure.

- **README `## Kernels`** is grouped by upstream library and entry point again, one link per kernel, in the compact bullet style of #154. The default is stated once: runs on `sm_100a`, `sm_103a` and `sm_107a`, performance measured and tuned on `sm_100a`. Only exceptions carry an annotation: `⟨sm_103a⟩` for a port that runs only on that architecture (and was tuned there), `⟨+sm_110a⟩` for a kernel that additionally supports another architecture. 100 of 111 kernels carry no annotation. A summary table gives the kernel count per architecture.
- `tests/lint/check_readme_kernels.py` derives the expected annotation for every kernel from `KERNEL_META["runtime_cuda_archs"]` and checks it, the link path, uniqueness, and the summary table. No new metadata is introduced.

## Testing

- pre-commit (ruff, license headers, README lint) passes; the lint was negative-tested by deleting two annotations, which it reported.
- `python -m tirx_kernels.registry --strict` passes.
