### PR TITLE
perf(cuda): tune fp16 bf16 gemm for Thor

### DIFF
--- a/tirx_kernels/basic/fp16_bf16_gemm.py
+++ b/tirx_kernels/basic/fp16_bf16_gemm.py
@@ -3,13 +3,14 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 import torch
 
 import tirx_kernels.kern as K
 import tvm
-from tirx_kernels.runner import bench
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, bench
 
 
 def prepare_data(dtype, M, N, K):
@@ -110,7 +111,40 @@ _DEFAULT_CONFIG = {
 }
 
 
+# Thor has fewer SMs and a different cache hierarchy than the datacenter parts.
+# Keep its tile ordering and pipeline choices separate so tuning it does not
+# change the established SM100/SM103/SM107 code paths.
+_THOR_GEMM_CONFIGS = {
+    4096: {
+        "cta_n": 256,
+        "cta_k": 64,
+        "l2_group_size": 4,
+        "overlap_epilogue": True,
+        "pipe_depth": 4,
+        "wb_pipe_depth": 8,
+    },
+    8192: {
+        "cta_n": 256,
+        "cta_k": 64,
+        "l2_group_size": 4,
+        "overlap_epilogue": True,
+        "pipe_depth": 4,
+        "wb_pipe_depth": 8,
+    },
+    16384: {
+        "cta_n": 256,
+        "cta_k": 64,
+        "l2_group_size": 2,
+        "overlap_epilogue": True,
+        "pipe_depth": 4,
+        "wb_pipe_depth": 8,
+    },
+}
+
+
 def _cfg_for(N):
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        return _THOR_GEMM_CONFIGS.get(N, GEMM_CONFIGS.get(N, _DEFAULT_CONFIG))
     return GEMM_CONFIGS.get(N, _DEFAULT_CONFIG)
 
 

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -527,9 +527,9 @@ Grouped workloads show one row per config and one timing column per implementati
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
 |---|---|---:|---|---:|---:|---|
-| `bf16_4096x4096x4096` | tir | 1889.1804 | torch-cublas | 1768.7883 | 0.936 | — |
-| `fp16_1024x1024x1024` | tir | 108.0997 | torch-cublas | 111.0238 | 1.027 | — |
-| `fp16_16384x16384x16384` | tir | 348158.6372 | torch-cublas | 334817.1432 | 0.962 | — |
+| `bf16_4096x4096x4096` | tir | 1172.8616 | torch-cublas | 1337.8177 | 1.141 | — |
+| `fp16_1024x1024x1024` | tir | 96.8199 | torch-cublas | 98.3945 | 1.016 | — |
+| `fp16_16384x16384x16384` | tir | 193286.4660 | torch-cublas | 211708.9267 | 1.095 | — |
 
 ### msa_sparse_prepare_flat_schedule_sm100
 


### PR DESCRIPTION
## Thor performance

Measured on Jetson AGX Thor (`sm_110a`, 20 SM) using the repository-default
Proton protocol: 25 ms warmup, 100 ms repeat, 15 rounds, and arithmetic-mean
aggregation. `Source/TIRx` is cuBLAS latency divided by TIRx latency, so values
above 1 mean TIRx is faster.

| Dtype | Shape | TIRx (µs) | cuBLAS (µs) | Source/TIRx |
| --- | ---: | ---: | ---: | ---: |
| FP16 | 1024×1024×1024 | 108.983 | 112.618 | 1.033× |
| FP16 | 2048×2048×2048 | 246.375 | 255.967 | 1.039× |
| FP16 | 4096×4096×4096 | 1,195.935 | 1,315.121 | 1.100× |
| FP16 | 8192×8192×8192 | 11,254.432 | 14,714.200 | 1.307× |
| FP16 | 16384×16384×16384 | 213,231.398 | 269,764.583 | 1.265× |
| BF16 | 1024×1024×1024 | 67.395 | 66.560 | 0.988× |
| BF16 | 2048×2048×2048 | 240.677 | 236.529 | 0.983× |
| BF16 | 4096×4096×4096 | 1,124.945 | 1,693.179 | 1.505× |
| BF16 | 8192×8192×8192 | 14,074.978 | 14,885.591 | 1.058× |
| BF16 | 16384×16384×16384 | 153,439.511 | 167,684.432 | 1.093× |

The geometric-mean `Source/TIRx` ratio across all ten configurations is
**1.127×**. The Thor-specific schedule is selected only for the tuned 4096,
8192, and 16384 shapes; the existing 1024 and 2048 configurations remain
unchanged.

| Shape | CTA M | CTA N | CTA K | L2 group | Overlap epilogue | Pipeline depth | Writeback depth |
| ---: | ---: | ---: | ---: | ---: | :---: | ---: | ---: |
| 1024 | 256 | 64 | 128 | 4 | Yes | 5 | 2 |
| 2048 | 256 | 256 | 64 | 8 | Yes | 5 | 4 |
| 4096 | 256 | 256 | 64 | 4 | Yes | 4 | 8 |
| 8192 | 256 | 256 | 64 | 4 | Yes | 4 | 8 |
| 16384 | 256 | 256 | 64 | 2 | Yes | 4 | 8 |