### PR TITLE
fix(kernels): correct FP4 MMA descriptors and FP8/Rubin synchronization

### DIFF
--- a/.agents/skills/tirx-codegen-diagnostics/references/db/keep-setmaxnreg-on-the-complete-warpgroup-scope.md
+++ b/.agents/skills/tirx-codegen-diagnostics/references/db/keep-setmaxnreg-on-the-complete-warpgroup-scope.md
@@ -54,6 +54,14 @@ This governs where the register instruction sits, not whether the roles are
 worth splitting. Splitting the functional roles is a separate change with its
 own evidence.
 
+Scope validity does not prove the compiler honors the hint. On CUDA 13.2/B200,
+a three-warpgroup probe with only a one-operand launch bound compiled to eight
+registers, warning C7508 and no USETMAXREG. Giving the same body an explicit
+minimum-blocks-per-SM bound of one produced 168 registers and USETMAXREG.
+Do not add an occupancy constraint merely to satisfy a source-level register
+model: it activates a resource contract the original compiled kernel did not
+have, and the same requests can then genuinely overdraw the CTA register pool.
+
 ## Verification
 
 Verify in the realized TIR that there is one producer `setmaxnreg` and that

--- a/tests/test_rubin_fp4_descriptor.py
+++ b/tests/test_rubin_fp4_descriptor.py
@@ -1,0 +1,15 @@
+"""FP4 instruction descriptors must encode SM107 v1 even for dense MMA."""
+
+from tirx_kernels.registry import load_kernel
+
+
+def test_rubin_dense_fp4_descriptors_encode_k128_and_v1():
+    dense = load_kernel("dense_blockscaled_gemm_sm107", strict=True)
+    grouped = load_kernel("grouped_gemm_masked_rubin", strict=True)
+    fused = load_kernel(
+        "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin", strict=True
+    )
+    assert fused._instruction_descriptor() == 0x08201488
+    for n, sf, expected in [(128, "float8_e4m3fn", 0x08201488), (64, "float8_e8m0fnu", 0x08901488)]:
+        assert dense._instruction_descriptor(128, n, sf) == expected
+        assert grouped._instruction_descriptor(128, n, "float4_e2m1fn", sf) == expected

--- a/tirx_kernels/flashattention/flash_attention4_fp4.py
+++ b/tirx_kernels/flashattention/flash_attention4_fp4.py
@@ -246,12 +246,14 @@ MMA_F16 = "tcgen05.mma.cta_group::1.kind::f16"
 MMA_F8F6F4 = "tcgen05.mma.cta_group::1.kind::f8f6f4"
 NEG_INF = float("-inf")
 L2_SIZE = 50 * 1024 * 1024  # tile_scheduler.py:428
-# instruction descriptors, taken verbatim from the export (`mov.b32 idesc, ...`)
-IDESC_QK_NVFP4 = 0x08201680
+# Packed NVFP4 uses E2M1=1 for both operands, not the unpacked MXF8F6F4
+# encoding E2M1=5. SM103 also requires sparsity-version bit 12 to be zero
+# (PTX ISA 9.4, instruction descriptor Table 53 and its Target ISA Note).
+IDESC_NVFP4 = 0x08200480
+# Other instruction descriptors, taken from the export (`mov.b32 idesc, ...`).
 IDESC_BLOCK32_BASE = 0x08A00000  # | k << 29 | k << 4 (a_sf_id / b_sf_id = k)
 IDESC_PV_BF16 = {128: 0x08210490, 64: 0x08110490}
 IDESC_PV_FP8 = {128: 0x08210010, 64: 0x08110010}
-IDESC_PV_NVFP4 = 0x08201680
 # cuTensorMapEncodeTiled enums
 _TMA_SWIZZLE = {0: 0, 32: 1, 64: 2, 128: 3}
 _TMA_L2_PROMOTION_128B = 2
@@ -801,7 +803,7 @@ def make_kernel(spec: Spec, batch_size, seq_len_q, seq_len_kv, num_qo_heads, num
                                     K.uint32(TMEM_S[stage]),
                                     desc_at(desc_q, a_base + 2 * kt),
                                     desc_at(desc_k, b_base + 2 * kt),
-                                    K.uint32(IDESC_QK_NVFP4),
+                                    K.uint32(IDESC_NVFP4),
                                     K.uint32(TMEM_SFQ[stage] + 4 * kt),
                                     K.uint32(TMEM_SFK[stage] + 4 * kt),
                                     kt != 0,
@@ -853,7 +855,7 @@ def make_kernel(spec: Spec, batch_size, seq_len_q, seq_len_kv, num_qo_heads, num
                                 K.uint32(TMEM_O[stage]),
                                 a_tmem,
                                 b_desc,
-                                K.uint32(IDESC_PV_NVFP4),
+                                K.uint32(IDESC_NVFP4),
                                 K.uint32(TMEM_SFP[stage] + 4 * kt),
                                 K.uint32(TMEM_SFV[stage] + 4 * kt),
                                 enable,

--- a/tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py
+++ b/tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py
@@ -185,7 +185,8 @@ def _descriptor_with_address(base, shared_address):
 
 
 def _instruction_descriptor():
-    value = (1 << 3) | (1 << 7) | (1 << 10)
+    # PTX FP4 descriptor: K128 and SM107 sparsity-version v1 (also for dense MMA).
+    value = (1 << 3) | (1 << 7) | (1 << 10) | (1 << 12)
     value |= ((128 >> 3) & 0x3F) << 17
     value |= (0 & 3) << 23
     value |= ((128 >> 4) & 0x1F) << 24
@@ -567,6 +568,9 @@ def _make_kernel(num_experts, seq_len, N, K_dim, routing, num_sms, use_pdl):
                 count = K.local_scalar("int32", init=0)
                 with K.While(count < k_tiles):
                     _wait(a_pipe.empty.ptr_to([producer.stage]), producer.phase)
+                    # The prior MMA reads A through the async proxy; cp.async
+                    # reuses it through the generic proxy after this handoff.
+                    K.ptx.fence.proxy.async_.shared__cta()
                     if materialize_gather_a:
                         count_uniform = K.uniform(count)
                         k_offset = K.local_scalar("uint64")
@@ -786,6 +790,8 @@ def _make_kernel(num_experts, seq_len, N, K_dim, routing, num_sms, use_pdl):
                 accumulate = K.local_scalar("uint32", init=K.uint32(0))
                 with K.While(count < k_tiles):
                     _wait(a_pipe.full.ptr_to([a_consumer.stage]), a_consumer.phase)
+                    # cp.async (not bulk) writes through the generic proxy.
+                    K.ptx.fence.proxy.async_.shared__cta()
                     _wait(b_pipe.full.ptr_to([b_consumer.stage]), b_consumer.phase)
                     _wait(sfa_t_pipe.full.ptr_to([sfa_t_consumer.stage]), sfa_t_consumer.phase)
                     for chunk in range(4):

--- a/tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py
+++ b/tirx_kernels/flashinfer/gemm/dense_blockscaled_gemm_sm107.py
@@ -156,7 +156,8 @@ def _descriptor_with_address(base, shared_address):
 
 def _instruction_descriptor(inst_m, inst_n, sf_dtype):
     sf_format = {"float8_e4m3fn": 0, "float8_e8m0fnu": 1}[sf_dtype]
-    value = (1 << 3) | (1 << 7) | (1 << 10)
+    # PTX FP4 descriptor: K128 and SM107 sparsity-version v1 (also for dense MMA).
+    value = (1 << 3) | (1 << 7) | (1 << 10) | (1 << 12)
     value |= ((inst_n >> 3) & 0x3F) << 17
     value |= (sf_format & 1) << 23
     value |= ((inst_m >> 4) & 0x1F) << 24

--- a/tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py
+++ b/tirx_kernels/flashinfer/gemm/grouped_gemm_masked_rubin.py
@@ -297,7 +297,8 @@ def _descriptor_with_address(base, shared_address):
 def _instruction_descriptor(inst_m, inst_n, ab_dtype, sf_dtype):
     sf_format = {"float8_e4m3fn": 0, "float8_e8m0fnu": 1, "float8_e5m3fnu": 2}[sf_dtype]
     if ab_dtype == "float4_e2m1fn":
-        value = (1 << 3) | (1 << 7) | (1 << 10)
+        # PTX FP4 descriptor: K128 and SM107 sparsity-version v1 (also for dense MMA).
+        value = (1 << 3) | (1 << 7) | (1 << 10) | (1 << 12)
     else:
         value = 1 << 31
         if ab_dtype == "float8_e5m2":

--- a/tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py
+++ b/tirx_kernels/flashinfer/msa_ops/blackwell_msa_decode_uniform_fp8_qkv_paged_sm100.py
@@ -291,7 +291,8 @@ _MBARRIER_INIT = (
     (_MBAR_CORR_SIG + 8, 32),
     (_MBAR_P_STORE_TURN, 32),
     (_MBAR_P_STORE_TURN + 8, 32),
-    (_MBAR_O_FULL, 1),
+    # Epilogue needs final PV completion and row state from both score warps.
+    (_MBAR_O_FULL, 1 + 2 * 32),
     (_MBAR_DECODE_DONE, 32),
 )
 
@@ -645,7 +646,7 @@ def _build_kernel():
                     _bar(smem, _SMEM_ROW_MAX) + K.cast(state_row, "uint32") * _u32(4), row_max
                 )
                 K.ptx.fence.proxy.async_.shared__cta()
-                _mbar_arrive(_bar(smem, _MBAR_CORR_SIG) + K.cast(stage, "uint32") * _u32(8))
+                _mbar_arrive(_bar(smem, _MBAR_O_FULL))
                 K.assign(work, work + grid_x)
 
         # ---- elected Q / K / V producer: warp 2 ---------------------------
@@ -930,11 +931,6 @@ def _build_kernel():
 
                 _mbar_wait(_bar(smem, _MBAR_O_FULL), o_phase)
                 _flip(o_phase)
-                K.ptx["tcgen05.fence::after_thread_sync"]()
-                _mbar_wait(_bar(smem, _MBAR_CORR_SIG), corr0_phase)
-                _flip(corr0_phase)
-                _mbar_wait(_bar(smem, _MBAR_CORR_SIG + 8), corr1_phase)
-                _flip(corr1_phase)
                 K.ptx["tcgen05.fence::after_thread_sync"]()
 
                 sum0 = K.local_scalar("float32")


### PR DESCRIPTION
## Summary

Fix kernel-side correctness issues found during TIRx-kernel-agent dependency validation:

- FP8 MSA: join final PV completion and both score-warps’ row-state publication through the existing `O_FULL` barrier. Remove redundant epilogue waits without introducing new barrier state.
- FA4: correct the packed NVFP4 operand encoding and SM103 descriptor bits, using one shared descriptor constant for QK and PV.
- Rubin: set the required FP4 descriptor version bit in three kernels and add the missing proxy fences around fused gather/SwiGLU A-buffer handoffs.
- Add one compact descriptor regression test and clarify register-hint diagnostics.

Scope: 7 files, +44 / -15 lines. No algorithm redesign or changes to REVIEW expectations.

## Validation

- 25 targeted kernel API and descriptor tests passed.
- 17 targeted integration tests passed with the companion kernel-agent fixes, covering NumSim, Synccheck, Racecheck, registry consistency, and A-stage reuse.
