### PR TITLE
perf(thor): enable FlashInfer RMSNorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ keeps them in sync.
 | `sm_100a` | 103 |
 | `sm_103a` | 98 |
 | `sm_107a` | 94 |
-| `sm_110a` | 5 |
+| `sm_110a` | 6 |
 
 ### Native TIRx
 
@@ -100,7 +100,7 @@ Grouped by the FlashInfer Python entry point each port backs.
   [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py),
   [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
 - **`flashinfer.norm`:**
-  [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py),
+  [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py) ⟨+sm_110a⟩,
   [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py),
   [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py),
   [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,8 +61,8 @@ def test_exact_architectures_are_stored_in_source_index():
         ("sm_100a",): 12,
         ("sm_103a",): 7,
         ("sm_107a",): 4,
-        ("sm_100a", "sm_103a", "sm_107a"): 85,
-        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 5,
+        ("sm_100a", "sm_103a", "sm_107a"): 84,
+        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 6,
     }
 
 

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -531,6 +531,14 @@ Grouped workloads show one row per config and one timing column per implementati
 | `s4096_h32kv4_causal` | tir | 890.7954 | flashattn_sm100 | 929.1618 | 1.043 | — |
 | `s8192_h32kv32` | tir | 8086.6973 | flashattn_sm100 | 8267.8324 | 1.022 | — |
 
+### flashinfer_rmsnorm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `gemma_bf16_m64_h8192_xc_yc_pdl0` | tirx | 18.3253 | flashinfer_cutedsl | 19.4243 | 1.060 | — |
+| `rms_bf16_m32_h4096_xc_yc_pdl0` | tirx | 6.5895 | flashinfer_cutedsl | 6.8275 | 1.036 | — |
+| `rms_bf16_m32_h4096_xc_yc_pdl1` | tirx | 8.7481 | flashinfer_cutedsl | 8.8077 | 1.007 | — |
+
 ### fp16_bf16_gemm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |

--- a/tirx_kernels/flashinfer/norm/rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm.py
@@ -11,15 +11,16 @@ The source implementation is ``RMSNormKernel`` plus its 2-D host dispatch in
 """
 
 import contextlib
+import os
 from typing import Any
 
 import tirx_kernels.kern as K
-from tirx_kernels.runner import bench
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, bench
 
 KERNEL_META = {
     "name": "flashinfer_rmsnorm",
     "category": "flashinfer",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flashinfer-python",
@@ -46,6 +47,10 @@ _CVT_TO_F32 = {"float16": "cvt.f32.f16", "bfloat16": "cvt.f32.bf16"}
 _CVT_FROM_F32 = {"float16": "cvt.rn.f16.f32", "bfloat16": "cvt.rn.bf16.f32"}
 _CVT_PAIR_FROM_F32 = {"float16": "cvt.rn.f16x2.f32", "bfloat16": "cvt.rn.bf16x2.f32"}
 _CP_ASYNC = "cp.async.ca.shared.global"
+
+
+def _preparing_for_thor() -> bool:
+    return os.environ.get(PREPARE_CUDA_ARCH_ENV, "sm_100a") == "sm_110a"
 
 
 def _ceil_div(lhs: int, rhs: int) -> int:
@@ -119,6 +124,10 @@ def _source_config(H: int) -> dict[str, int | bool]:
         if H % candidate == 0 and _estimate_smem(H, candidate) <= _OPTIN_SMEM_BYTES:
             cluster_n = candidate
             break
+    # Thor supports at most eight CTAs in one cluster. Recompute every derived
+    # launch and storage quantity after shrinking a source-selected cluster.
+    if _preparing_for_thor():
+        cluster_n = min(cluster_n, 8)
     return _derived_config(H, cluster_n)
 
 
@@ -472,6 +481,22 @@ def get_kernel(
     pair_values = packed_pairs * 2
     packed_narrow = not (vec == 1 or (vec == 2 and vec_blocks == 3))
     weight_bias = 0.0 if variant == "rmsnorm" else 1.0
+    is_thor = _preparing_for_thor()
+    thor_zero_weight_bias = is_thor and variant == "rmsnorm"
+    thor_full_rows = is_thor and compact and M % rows == 0
+    thor_full_cols = is_thor and H == cluster_n * cols
+    thor_gemma_bf16_fma = (
+        is_thor and variant == "gemma_rmsnorm" and dtype == "bfloat16" and H in (4096, 8192)
+    )
+    thor_rms_bf16_fma = (
+        is_thor and variant == "rmsnorm" and dtype == "bfloat16" and H in (4096, 8192)
+    )
+    # Multiple accumulators expose enough independent FP32 work to cover Thor's
+    # FMA latency without changing the source launch decomposition.
+    thor_parallel_reduction = is_thor and H in (4096, 8192)
+    thor_bf16_reduction = thor_parallel_reduction and dtype == "bfloat16" and use_async
+    thor_keep_bf16_x = thor_bf16_reduction
+    thor_reduction_partials = 8 if H == 4096 else 4
     copy_bytes = copy_bits // 8
     reduce_base = tile_bytes if use_async else 0
     reduce_count = rows * warps_per_row * cluster_n
@@ -495,7 +520,10 @@ def get_kernel(
     # CTA per SM instead, and the two spellings are mutually exclusive downstream.
     max_registers = None
     if threads == 128:
-        max_registers = 64 if enable_pdl else (96 if H == 8192 else 93)
+        # The exact Thor PDL workload schedules better without the source port's
+        # 64-register launch bound; its grid still fits in one resident wave.
+        if not (is_thor and variant == "rmsnorm" and M == 32 and H == 4096 and enable_pdl):
+            max_registers = 64 if enable_pdl else (96 if H == 8192 else 93)
 
     def entry_registers():
         if max_registers is None:
@@ -504,15 +532,18 @@ def get_kernel(
 
     def kernel_body(x, weight, y, runtime_M, runtime_eps, x_row_stride, y_row_stride):
         # TIRX_TRANSCRIBE_START flashinfer_rmsnorm
+        grid_rows = (
+            K.int32(M // rows)
+            if thor_full_rows
+            else K.cast(K.ceildiv(runtime_M, K.int64(rows)), "int32")
+        )
         if cluster_n > 1:
-            block_x_raw, block_y_raw = K.cta_id(
-                [K.cast(K.ceildiv(runtime_M, K.int64(rows)), "int32"), cluster_n]
-            )
+            block_x_raw, block_y_raw = K.cta_id([grid_rows, cluster_n])
             _, cta_rank_raw = K.cta_id_in_cluster([1, cluster_n], preferred=[1, cluster_n])
             block_y = K.cast(block_y_raw, "int32")
             cta_rank = K.cast(cta_rank_raw, "int32")
         else:
-            block_x_raw = K.cta_id([K.cast(K.ceildiv(runtime_M, K.int64(rows)), "int32")])
+            block_x_raw = K.cta_id([grid_rows])
             block_y = 0
             cta_rank = 0
         tid = K.thread_id()
@@ -530,7 +561,7 @@ def get_kernel(
         # int32 value in a local first gives the cast a single Var to sit on.
         row_i32 = K.local_scalar(K.i32, init=block_x * rows + row_in_cta)
         row_i64 = K.cast(row_i32, "int64")
-        row_valid = row_i64 < runtime_M
+        row_valid = K.bool(True) if thor_full_rows else row_i64 < runtime_M
         warp = tid // 32
         lane = tid % 32
         row_warp = warp // warps_per_row
@@ -549,7 +580,10 @@ def get_kernel(
         w_bits = K.alloc_local([pair_values], K.u16)
         x_f32 = K.alloc_local([pair_values], K.f32)
         w_f32 = K.alloc_local([pair_values], K.f32)
-        x_sq = K.alloc_local([pair_values], K.f32)
+        if thor_parallel_reduction:
+            partial_sums = K.alloc_local([thor_reduction_partials], K.f32)
+        else:
+            x_sq = K.alloc_local([pair_values], K.f32)
         # The odd upper half of the last pair is a don't-care lane the source
         # leaves uninitialized; reading it keeps the packed shape intact.
         undefined_f32 = K.local_scalar(K.f32)
@@ -577,18 +611,34 @@ def get_kernel(
                 x_offset = row_i64 * x_row_stride + K.cast(absolute_col, "int64")
 
             if use_async:
-                with K.If(row_valid), K.Then():
-                    # Ignore-src: an out-of-range column copies nothing and the
-                    # staged bytes read back as zero.
+                if thor_full_rows:
+                    source_bytes = (
+                        K.uint32(copy_bytes)
+                        if thor_full_cols
+                        else K.cast(K.if_then_else(col_valid, copy_bytes, 0), "uint32")
+                    )
                     K.ptx[_CP_ASYNC](
                         shared_raw.ptr_to([(row_in_cta * cols + local_col) * _ELEM_BYTES]),
                         x.ptr_to([x_offset]),
                         copy_bytes,
-                        K.cast(K.if_then_else(col_valid, copy_bytes, 0), "uint32"),
+                        source_bytes,
                     )
+                else:
+                    with K.If(row_valid), K.Then():
+                        # Ignore-src: an out-of-range column copies nothing and the
+                        # staged bytes read back as zero.
+                        K.ptx[_CP_ASYNC](
+                            shared_raw.ptr_to([(row_in_cta * cols + local_col) * _ELEM_BYTES]),
+                            x.ptr_to([x_offset]),
+                            copy_bytes,
+                            K.cast(K.if_then_else(col_valid, copy_bytes, 0), "uint32"),
+                        )
             else:
-                with K.If(K.And(row_valid, col_valid)), K.Then():
+                if thor_full_rows and thor_full_cols:
                     _load_global_bits(x_bits, vb * vec, x, x_offset, vec)
+                else:
+                    with K.If(K.And(row_valid, col_valid)), K.Then():
+                        _load_global_bits(x_bits, vb * vec, x, x_offset, vec)
 
         if use_async:
             K.ptx.cp.async_.commit_group()
@@ -596,8 +646,11 @@ def get_kernel(
         for vb in range(vec_blocks):
             local_col = (thread_in_row + vb * tpr) * vec
             absolute_col = block_y * cols + local_col
-            with K.If(absolute_col < H), K.Then():
+            if thor_full_cols:
                 _load_global_bits(w_bits, vb * vec, weight, absolute_col, vec)
+            else:
+                with K.If(absolute_col < H), K.Then():
+                    _load_global_bits(w_bits, vb * vec, weight, absolute_col, vec)
 
         if use_async:
             K.ptx.cp.async_.wait_group(0)
@@ -607,20 +660,38 @@ def get_kernel(
                     x_bits, vb * vec, shared_raw, (row_in_cta * cols + local_col) * _ELEM_BYTES, vec
                 )
 
-        for value in range(total_values):
-            K.ptx[cvt_to_f32](x_f32[value], x_bits[value])
+        if not thor_bf16_reduction:
+            for value in range(total_values):
+                K.ptx[cvt_to_f32](x_f32[value], x_bits[value])
 
-        for pair in range(packed_pairs):
-            K.ptx.mul.f32x2(
-                packed,
-                K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
-                K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
-            )
-            K.ptx.mov.b64(x_sq[pair * 2], x_sq[pair * 2 + 1], packed)
+        if thor_parallel_reduction:
+            for partial in range(thor_reduction_partials):
+                K.assign(partial_sums[partial], K.float32(0.0))
+            for value in range(total_values):
+                partial = value % thor_reduction_partials
+                if thor_bf16_reduction:
+                    K.ptx.fma.rn.f32.bf16(
+                        partial_sums[partial], x_bits[value], x_bits[value], partial_sums[partial]
+                    )
+                else:
+                    K.ptx.fma.rn.f32(
+                        partial_sums[partial], x_f32[value], x_f32[value], partial_sums[partial]
+                    )
+            local_sum = K.local_scalar(K.f32, init=partial_sums[0])
+            for partial in range(1, thor_reduction_partials):
+                K.ptx.add.f32(local_sum, local_sum, partial_sums[partial])
+        else:
+            for pair in range(packed_pairs):
+                K.ptx.mul.f32x2(
+                    packed,
+                    K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                    K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                )
+                K.ptx.mov.b64(x_sq[pair * 2], x_sq[pair * 2 + 1], packed)
 
-        local_sum = K.local_scalar(K.f32, init=K.float32(0.0))
-        for value in range(total_values):
-            K.ptx.add.f32(local_sum, local_sum, x_sq[value])
+            local_sum = K.local_scalar(K.f32, init=K.float32(0.0))
+            for value in range(total_values):
+                K.ptx.add.f32(local_sum, local_sum, x_sq[value])
 
         _butterfly_sum_f32(local_sum, row_lane_xors)
         warp_sum = local_sum
@@ -697,49 +768,76 @@ def get_kernel(
         rstd = K.local_scalar(K.f32)
         K.ptx.rsqrt.approx.ftz.f32(rstd, shifted)
 
+        # A cluster-1 full Thor tile only reads the staged input after this
+        # point; the earlier block-reduction barrier completed shared writes.
         if cluster_n > 1:
             K.ptx.barrier.cluster.arrive.relaxed()
             K.ptx.barrier.cluster.wait()
-        else:
+        elif not (is_thor and thor_full_rows and thor_full_cols):
             K.ptx.bar.sync(K.uint32(0))
 
         if use_async:
-            for vb in range(vec_blocks):
-                local_col = (thread_in_row + vb * tpr) * vec
-                _load_shared_bits(
-                    x_bits, vb * vec, shared_raw, (row_in_cta * cols + local_col) * _ELEM_BYTES, vec
-                )
+            if not thor_keep_bf16_x:
+                for vb in range(vec_blocks):
+                    local_col = (thread_in_row + vb * tpr) * vec
+                    _load_shared_bits(
+                        x_bits,
+                        vb * vec,
+                        shared_raw,
+                        (row_in_cta * cols + local_col) * _ELEM_BYTES,
+                        vec,
+                    )
+            if not thor_rms_bf16_fma:
+                for value in range(total_values):
+                    K.ptx[cvt_to_f32](x_f32[value], x_bits[value])
+
+        if thor_gemma_bf16_fma or thor_rms_bf16_fma:
+            # Keep BF16 operands in their native registers for the inner FMA,
+            # then apply rstd in FP32. Gemma adds x to form x * (weight + 1).
             for value in range(total_values):
-                K.ptx[cvt_to_f32](x_f32[value], x_bits[value])
-
-        for value in range(total_values):
-            K.ptx[cvt_to_f32](w_f32[value], w_bits[value])
-
-        for pair in range(packed_pairs):
-            high_scale = rstd if pair * 2 + 1 < total_values else undefined_f32
-            K.ptx.mul.f32x2(
-                packed,
-                K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
-                K.cuda.make_float2(rstd, high_scale),
-            )
-            K.ptx.mov.b64(x_f32[pair * 2], x_f32[pair * 2 + 1], packed)
-
-        for pair in range(packed_pairs):
-            high_bias = K.float32(weight_bias) if pair * 2 + 1 < total_values else undefined_f32
-            K.ptx.add.f32x2(
-                packed,
-                K.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
-                K.cuda.make_float2(K.float32(weight_bias), high_bias),
-            )
-            K.ptx.mov.b64(w_f32[pair * 2], w_f32[pair * 2 + 1], packed)
-
-        for pair in range(packed_pairs):
-            K.ptx.mul.f32x2(
-                packed,
-                K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
-                K.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
-            )
-            K.ptx.mov.b64(x_f32[pair * 2], x_f32[pair * 2 + 1], packed)
+                K.ptx.fma.rn.f32.bf16(
+                    x_f32[value],
+                    x_bits[value],
+                    w_bits[value],
+                    x_f32[value] if thor_gemma_bf16_fma else K.float32(0.0),
+                )
+            for pair in range(packed_pairs):
+                high_scale = rstd if pair * 2 + 1 < total_values else undefined_f32
+                K.ptx.mul.f32x2(
+                    packed,
+                    K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                    K.cuda.make_float2(rstd, high_scale),
+                )
+                K.ptx.mov.b64(x_f32[pair * 2], x_f32[pair * 2 + 1], packed)
+        else:
+            for value in range(total_values):
+                K.ptx[cvt_to_f32](w_f32[value], w_bits[value])
+            for pair in range(packed_pairs):
+                high_scale = rstd if pair * 2 + 1 < total_values else undefined_f32
+                K.ptx.mul.f32x2(
+                    packed,
+                    K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                    K.cuda.make_float2(rstd, high_scale),
+                )
+                K.ptx.mov.b64(x_f32[pair * 2], x_f32[pair * 2 + 1], packed)
+            if not thor_zero_weight_bias:
+                for pair in range(packed_pairs):
+                    high_bias = (
+                        K.float32(weight_bias) if pair * 2 + 1 < total_values else undefined_f32
+                    )
+                    K.ptx.add.f32x2(
+                        packed,
+                        K.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
+                        K.cuda.make_float2(K.float32(weight_bias), high_bias),
+                    )
+                    K.ptx.mov.b64(w_f32[pair * 2], w_f32[pair * 2 + 1], packed)
+            for pair in range(packed_pairs):
+                K.ptx.mul.f32x2(
+                    packed,
+                    K.cuda.make_float2(x_f32[pair * 2], x_f32[pair * 2 + 1]),
+                    K.cuda.make_float2(w_f32[pair * 2], w_f32[pair * 2 + 1]),
+                )
+                K.ptx.mov.b64(x_f32[pair * 2], x_f32[pair * 2 + 1], packed)
 
         y_bits = K.alloc_local([pair_values], K.u16)
         y_words = K.alloc_local([packed_pairs], K.u32)
@@ -758,12 +856,15 @@ def get_kernel(
                 y_offset = compact_index(row_i32 * H + absolute_col)
             else:
                 y_offset = row_i64 * y_row_stride + K.cast(absolute_col, "int64")
+            store_predicate = (
+                None if thor_full_rows and thor_full_cols else K.And(row_valid, col_valid)
+            )
             _store_global_fragment(
                 y,
                 y_offset,
                 y_bits,
                 y_words,
-                K.And(row_valid, col_valid),
+                store_predicate,
                 vb * vec,
                 vb * vec // 2,
                 vec,

--- a/tirx_kernels/flashinfer/norm/rmsnorm.py
+++ b/tirx_kernels/flashinfer/norm/rmsnorm.py
@@ -150,24 +150,28 @@ def _butterfly_sum_f32(acc, lane_xors: tuple[int, ...]) -> None:
         K.ptx.add.f32(acc, acc, K.reinterpret("float32", peer))
 
 
-def _load_global_bits(values, value_offset: int, buffer, index, vec: int) -> None:
+def _load_global_bits(
+    values, value_offset: int, buffer, index, vec: int, *, l1_evict_first: bool = False
+) -> None:
     """``values[value_offset : +vec]`` <- *vec* halves at ``buffer[index]``.
 
     One ``ld.global`` of the widest shape the vector width allows; the b32
     forms land two halves per word and are split into the half lanes.
     """
+    if l1_evict_first:
+        load = K.ptx["ld.global.L1::evict_first.L2::128B"]
+    else:
+        load = K.ptx.ld.global_
     if vec == 1:
-        K.ptx.ld.global_.b16(values[value_offset], buffer.ptr_to([index]))
+        load.b16(values[value_offset], buffer.ptr_to([index]))
     elif vec == 2:
-        K.ptx.ld.global_.v2.b16(
-            values[value_offset], values[value_offset + 1], buffer.ptr_to([index])
-        )
+        load.v2.b16(values[value_offset], values[value_offset + 1], buffer.ptr_to([index]))
     else:
         words = K.alloc_local([vec // 2], K.u32)
         if vec == 4:
-            K.ptx.ld.global_.v2.b32(words[0], words[1], buffer.ptr_to([index]))
+            load.v2.b32(words[0], words[1], buffer.ptr_to([index]))
         else:
-            K.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
+            load.v4.b32(words[0], words[1], words[2], words[3], buffer.ptr_to([index]))
         for pair in range(vec // 2):
             K.assign(
                 values[value_offset + pair * 2],
@@ -464,6 +468,17 @@ def get_kernel(
     _validate(variant, dtype, M, H, input_layout, output_layout, eps)
     compact = _uses_compact_specialization(M, H, input_layout, output_layout)
     source = _source_config(H)
+    # A wider CTA plus register-resident input wins for this cold-cache Thor row.
+    if _preparing_for_thor() and variant == "rmsnorm" and dtype == "bfloat16" and H == 8192:
+        source = {
+            **source,
+            "tpr": 256,
+            "threads": 256,
+            "rows": 1,
+            "warps_per_row": 8,
+            "vec_blocks": 4,
+            "smem_bytes": 32,
+        }
     cluster_n = int(source["cluster_n"])
     tpr = int(source["tpr"])
     threads = int(source["threads"])
@@ -496,9 +511,18 @@ def get_kernel(
     thor_parallel_reduction = is_thor and H in (4096, 8192)
     thor_bf16_reduction = thor_parallel_reduction and dtype == "bfloat16" and use_async
     thor_keep_bf16_x = thor_bf16_reduction
-    thor_reduction_partials = 8 if H == 4096 else 4
+    thor_reduction_partials = 8 if H == 4096 or (variant == "rmsnorm" and H == 8192) else 4
+    thor_leader_warp_finalize = (
+        is_thor
+        and variant == "rmsnorm"
+        and dtype == "bfloat16"
+        and H == 8192
+        and cluster_n == 1
+        and tpr == 256
+    )
+    thor_direct_x = thor_leader_warp_finalize
     copy_bytes = copy_bits // 8
-    reduce_base = tile_bytes if use_async else 0
+    reduce_base = 0 if thor_direct_x else (tile_bytes if use_async else 0)
     reduce_count = rows * warps_per_row * cluster_n
     mbar_offset = reduce_base + reduce_count * 4
     expected_bytes = reduce_count * 4
@@ -610,7 +634,13 @@ def get_kernel(
             else:
                 x_offset = row_i64 * x_row_stride + K.cast(absolute_col, "int64")
 
-            if use_async:
+            if thor_direct_x:
+                if thor_full_rows and thor_full_cols:
+                    _load_global_bits(x_bits, vb * vec, x, x_offset, vec, l1_evict_first=True)
+                else:
+                    with K.If(K.And(row_valid, col_valid)), K.Then():
+                        _load_global_bits(x_bits, vb * vec, x, x_offset, vec, l1_evict_first=True)
+            elif use_async:
                 if thor_full_rows:
                     source_bytes = (
                         K.uint32(copy_bytes)
@@ -640,7 +670,7 @@ def get_kernel(
                     with K.If(K.And(row_valid, col_valid)), K.Then():
                         _load_global_bits(x_bits, vb * vec, x, x_offset, vec)
 
-        if use_async:
+        if use_async and not thor_direct_x:
             K.ptx.cp.async_.commit_group()
 
         for vb in range(vec_blocks):
@@ -652,7 +682,7 @@ def get_kernel(
                 with K.If(absolute_col < H), K.Then():
                     _load_global_bits(w_bits, vb * vec, weight, absolute_col, vec)
 
-        if use_async:
+        if use_async and not thor_direct_x:
             K.ptx.cp.async_.wait_group(0)
             for vb in range(vec_blocks):
                 local_col = (thread_in_row + vb * tpr) * vec
@@ -704,14 +734,34 @@ def get_kernel(
                 )
             K.ptx.bar.sync(K.uint32(0))
             final_sum = K.local_scalar(K.f32, init=K.float32(0.0))
-            with K.If(lane < warps_per_row), K.Then():
-                reduce_word = K.local_scalar(K.u32)
-                K.ptx.ld.shared.b32(
-                    reduce_word, shared_raw.ptr_to([reduce_base + (row_warp + lane * rows) * 4])
-                )
-                K.assign(final_sum, K.reinterpret("float32", reduce_word))
-            _butterfly_sum_f32(final_sum, full_lane_xors)
-            sum_sq = final_sum
+            if thor_leader_warp_finalize:
+                with K.If(warp_in_row == 0), K.Then():
+                    with K.If(lane < warps_per_row), K.Then():
+                        reduce_word = K.local_scalar(K.u32)
+                        K.ptx.ld.shared.b32(
+                            reduce_word,
+                            shared_raw.ptr_to([reduce_base + (row_warp + lane * rows) * 4]),
+                        )
+                        K.assign(final_sum, K.reinterpret("float32", reduce_word))
+                    _butterfly_sum_f32(final_sum, full_lane_xors)
+                    with K.If(lane == 0), K.Then():
+                        K.ptx.st.shared.b32(
+                            shared_raw.ptr_to([reduce_base + row_warp * 4]),
+                            K.reinterpret("uint32", final_sum),
+                        )
+                K.ptx.bar.sync(K.uint32(0))
+                final_word = K.local_scalar(K.u32)
+                K.ptx.ld.shared.b32(final_word, shared_raw.ptr_to([reduce_base + row_warp * 4]))
+                sum_sq = K.reinterpret("float32", final_word)
+            else:
+                with K.If(lane < warps_per_row), K.Then():
+                    reduce_word = K.local_scalar(K.u32)
+                    K.ptx.ld.shared.b32(
+                        reduce_word, shared_raw.ptr_to([reduce_base + (row_warp + lane * rows) * 4])
+                    )
+                    K.assign(final_sum, K.reinterpret("float32", reduce_word))
+                _butterfly_sum_f32(final_sum, full_lane_xors)
+                sum_sq = final_sum
         elif cluster_n > 1:
             with K.If(warp == 0), K.Then():
                 with K.If(K.cuda.elect_sync()), K.Then():
@@ -1078,6 +1128,27 @@ def _flashinfer_api(variant: str, device):
     return api, flashinfer_norm
 
 
+def _compile_tirx(config: dict[str, Any]):
+    from tirx_kernels.runner import compile_kernel
+
+    use_thor_h8192_schedule = (
+        _preparing_for_thor()
+        and config["variant"] == "rmsnorm"
+        and config["dtype"] == "bfloat16"
+        and int(config["H"]) == 8192
+    )
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    if use_thor_h8192_schedule:
+        os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = "2"
+    try:
+        return compile_kernel(get_kernel(**config))
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
 def _launch_tirx(executable, data, output, config: dict[str, Any]) -> None:
     M = int(config["M"])
     H = int(config["H"])
@@ -1130,8 +1201,6 @@ def run_test(**config: Any) -> None:
     """Compile, launch, and validate one config."""
     import torch
 
-    from tirx_kernels.runner import compile_kernel
-
     config = dict(config)
     M = int(config["M"])
     H = int(config["H"])
@@ -1144,8 +1213,7 @@ def run_test(**config: Any) -> None:
     output = _prepare_output(M, H, data["y_row_stride"], dtype, initialize_padding=True)
     reference_out = _prepare_output(M, H, data["y_row_stride"], dtype, initialize_padding=True)
 
-    kernel = get_kernel(**config)
-    executable = compile_kernel(kernel)
+    executable = _compile_tirx(config)
     _launch_tirx(executable, data, output, config)
 
     api, flashinfer_norm = _flashinfer_api(variant, data["x"].device)
@@ -1186,9 +1254,9 @@ def run_test(**config: Any) -> None:
 
 def prepare_bench(**config: Any):
     """Compile the selected TIRx specialization before GPU assignment."""
-    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+    from tirx_kernels.runner import prepared_gpu_benchmark
 
-    state = {"config": dict(config), "executable": compile_kernel(get_kernel(**config))}
+    state = {"config": dict(config), "executable": _compile_tirx(dict(config))}
     return prepared_gpu_benchmark(run_gpu, state)
 
 


### PR DESCRIPTION
## Summary

Enable `flashinfer_rmsnorm` on Jetson AGX Thor (`sm_110a`) and add Thor-specific schedules for the BF16 H4096 and RMSNorm H8192 workloads.

The Thor path includes:

- Thor-compatible cluster sizing.
- Native BF16 FMA and parallel reductions for H4096/H8192.
- A dedicated RMSNorm H8192 schedule using a 256-thread CTA.
- Register-resident input data with cold-cache-aware load policy.
- Leader-warp reduction finalization.
- A scoped ptxas scheduling level for RMSNorm BF16 H8192; the environment is restored after compilation.
- Static full-tile predicates for the corresponding fixed configurations.

All tuning is gated by `sm_110a`. Representative `sm_100a` PrimFuncs remain structurally identical to main, and the existing `sm_100a`, `sm_103a`, and `sm_107a` paths retain their original schedules.

The README architecture list, registry counts, and the existing bench-suite baseline document are updated. `baseline.md` records only the three configurations already marked `default: true`.

## Performance

Measured on Jetson AGX Thor using the repository bench-suite flow with the Proton timer:

- 25 ms warmup
- 100 ms repeat
- 100 independent rounds
- Arithmetic mean
- 0 second cooldown
- FlashInfer CuTe-DSL reference

`Source/TIRx` is the FlashInfer latency divided by the TIRx latency. Values above 1 mean TIRx is faster.

| Variant | Dtype | M | H | PDL | TIRx (µs) | FlashInfer (µs) | Source/TIRx | CV TIRx/Source |
|---|---|---:|---:|:---:|---:|---:|---:|---:|
| RMSNorm | BF16 | 32 | 4096 | No | 6.647 | 6.965 | 1.0478× | 4.3% / 4.0% |
| RMSNorm | BF16 | 64 | 8192 | No | 19.341 | 21.136 | 1.0928× | 5.1% / 5.3% |
| RMSNorm | BF16 | 32 | 4096 | Yes | 8.733 | 8.847 | 1.0130× | 5.6% / 4.7% |
| Gemma RMSNorm | BF16 | 32 | 4096 | No | 6.771 | 7.122 | 1.0519× | 5.1% / 3.8% |
| Gemma RMSNorm | BF16 | 64 | 8192 | No | 18.589 | 19.569 | 1.0527× | 4.7% / 3.7% |

All five bench-suite configurations exceed the FlashInfer baseline.

## Validation

- Full registered RMSNorm correctness coverage: 279 configurations.
- Additional RMSNorm BF16 H8192 coverage: 32/32 combinations passed across multiple M values, compact/strided input and output layouts, and PDL enabled/disabled.
- Ten representative `sm_100a` PrimFuncs are structurally identical to main.
- Ruff lint and format checks pass.
- `git diff --check` passes.