### PR TITLE
[CUDA][Thor] Enable FlashInfer LayerNorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ keeps them in sync.
 | `sm_100a` | 103 |
 | `sm_103a` | 98 |
 | `sm_107a` | 94 |
-| `sm_110a` | 7 |
+| `sm_110a` | 8 |
 
 ### Native TIRx
 
@@ -104,7 +104,7 @@ Grouped by the FlashInfer Python entry point each port backs.
   [`flashinfer_rmsnorm_quant`](tirx_kernels/flashinfer/norm/rmsnorm_quant.py),
   [`flashinfer_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/rmsnorm_fp4quant.py),
   [`flashinfer_add_rmsnorm_fp4quant`](tirx_kernels/flashinfer/norm/add_rmsnorm_fp4quant.py),
-  [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py),
+  [`flashinfer_layernorm`](tirx_kernels/flashinfer/norm/layernorm.py) ⟨+sm_110a⟩,
   [`flashinfer_fused_add_rmsnorm`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm.py) ⟨sm_100a⟩,
   [`flashinfer_fused_add_rmsnorm_quant`](tirx_kernels/flashinfer/norm/fused_add_rmsnorm_quant.py),
   [`flashinfer_fused_dit_layernorm`](tirx_kernels/flashinfer/norm/fused_dit_layernorm.py),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,8 +61,8 @@ def test_exact_architectures_are_stored_in_source_index():
         ("sm_100a",): 12,
         ("sm_103a",): 7,
         ("sm_107a",): 4,
-        ("sm_100a", "sm_103a", "sm_107a"): 83,
-        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 7,
+        ("sm_100a", "sm_103a", "sm_107a"): 82,
+        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 8,
     }
 
 

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -531,6 +531,14 @@ Grouped workloads show one row per config and one timing column per implementati
 | `s4096_h32kv4_causal` | tir | 890.7954 | flashattn_sm100 | 929.1618 | 1.043 | — |
 | `s8192_h32kv32` | tir | 8086.6973 | flashattn_sm100 | 8267.8324 | 1.022 | — |
 
+### flashinfer_layernorm
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `bf16_m1_h128_xc_yc_pdl0_eps1e6` | tirx | 2.9773 | flashinfer_cutedsl | 3.1874 | 1.071 | — |
+| `bf16_m128_h1024_xc_yc_pdl0_eps1e6` | tirx | 6.2452 | flashinfer_cutedsl | 7.2593 | 1.162 | — |
+| `bf16_m128_h16384_xc_yc_pdl0_eps1e6` | tirx | 64.8166 | flashinfer_cutedsl | 75.6959 | 1.168 | — |
+
 ### flashinfer_qk_rmsnorm
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |

--- a/tirx_kernels/flashinfer/norm/layernorm.py
+++ b/tirx_kernels/flashinfer/norm/layernorm.py
@@ -11,15 +11,16 @@ The source implementation is ``LayerNormKernel`` in
 ``flashinfer/norm/utils.py``.
 """
 
+import os
 from typing import Any
 
 import tirx_kernels.kern as K
-from tirx_kernels.runner import bench
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, bench
 
 KERNEL_META = {
     "name": "flashinfer_layernorm",
     "category": "flashinfer",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flashinfer-python",
@@ -36,6 +37,10 @@ _DEFAULT_EPS = 1e-6
 _LAYOUTS = ("compact", "strided")
 _GUARD_ELEMENTS = 64
 _GUARD_VALUE = 123.0
+
+
+def _preparing_for_thor() -> bool:
+    return os.environ.get(PREPARE_CUDA_ARCH_ENV, "sm_100a") == "sm_110a"
 
 
 def _ceil_div(lhs: int, rhs: int) -> int:
@@ -169,6 +174,46 @@ def _load_x(buffer, index, values, value_offset, VEC: int):
             )
 
 
+def _load_affine_f32x8(gamma, beta, index, gamma_frag, beta_frag, value_offset):
+    gamma_words = K.alloc_local([4], K.u64)
+    beta_words = K.alloc_local([4], K.u64)
+    K.ptx.ld.global_.v4.b64(
+        gamma_words[0], gamma_words[1], gamma_words[2], gamma_words[3], gamma.ptr_to([index])
+    )
+    K.ptx.ld.global_.v4.b64(
+        beta_words[0], beta_words[1], beta_words[2], beta_words[3], beta.ptr_to([index])
+    )
+    for pair in range(4):
+        K.ptx.mov.b64(
+            gamma_frag[value_offset + pair * 2],
+            gamma_frag[value_offset + pair * 2 + 1],
+            gamma_words[pair],
+        )
+        K.ptx.mov.b64(
+            beta_frag[value_offset + pair * 2],
+            beta_frag[value_offset + pair * 2 + 1],
+            beta_words[pair],
+        )
+
+
+def _load_affine_f32x4(gamma, beta, index, gamma_frag, beta_frag, value_offset):
+    gamma_words = K.alloc_local([2], K.u64)
+    beta_words = K.alloc_local([2], K.u64)
+    K.ptx.ld.global_.v2.b64(gamma_words[0], gamma_words[1], gamma.ptr_to([index]))
+    K.ptx.ld.global_.v2.b64(beta_words[0], beta_words[1], beta.ptr_to([index]))
+    for pair in range(2):
+        K.ptx.mov.b64(
+            gamma_frag[value_offset + pair * 2],
+            gamma_frag[value_offset + pair * 2 + 1],
+            gamma_words[pair],
+        )
+        K.ptx.mov.b64(
+            beta_frag[value_offset + pair * 2],
+            beta_frag[value_offset + pair * 2 + 1],
+            beta_words[pair],
+        )
+
+
 def _store_y(buffer, index, bits, words, value_offset, word_offset, VEC: int):
     if VEC == 1:
         K.ptx.st.global_.b16(buffer.ptr_to([index]), bits[value_offset])
@@ -284,6 +329,8 @@ def get_kernel(
     mixed_local_sum = bool(source["mixed_local_sum"])
     packed_pairs = _ceil_div(total_values, 2)
     pair_values = packed_pairs * 2
+    thor_vector_affine = _preparing_for_thor() and vec in (4, 8)
+    full_affine_tile = int(source["cols"]) == H
 
     x_stride_hint = int(kwargs.get("x_row_stride", H if input_layout == "compact" else 2 * H))
     y_stride_hint = int(kwargs.get("y_row_stride", H if output_layout == "compact" else 2 * H))
@@ -427,13 +474,33 @@ def get_kernel(
         for value in range(total_values):
             K.assign(gamma_frag[value], K.float32(0.0))
             K.assign(beta_frag[value], K.float32(0.0))
-        for vb in range(vec_blocks):
-            for e in range(vec):
-                value = vb * vec + e
-                col = tid * vec + vb * threads * vec + e
-                with K.If(col < H), K.Then():
-                    K.ptx.ld.global_.b32(gamma_frag[value], gamma.ptr_to([col]))
-                    K.ptx.ld.global_.b32(beta_frag[value], beta.ptr_to([col]))
+        if thor_vector_affine:
+            for vb in range(vec_blocks):
+                value_offset = vb * vec
+                col = tid * vec + vb * threads * vec
+                if full_affine_tile:
+                    if vec == 8:
+                        _load_affine_f32x8(gamma, beta, col, gamma_frag, beta_frag, value_offset)
+                    else:
+                        _load_affine_f32x4(gamma, beta, col, gamma_frag, beta_frag, value_offset)
+                else:
+                    with K.If(col < H), K.Then():
+                        if vec == 8:
+                            _load_affine_f32x8(
+                                gamma, beta, col, gamma_frag, beta_frag, value_offset
+                            )
+                        else:
+                            _load_affine_f32x4(
+                                gamma, beta, col, gamma_frag, beta_frag, value_offset
+                            )
+        else:
+            for vb in range(vec_blocks):
+                for e in range(vec):
+                    value = vb * vec + e
+                    col = tid * vec + vb * threads * vec + e
+                    with K.If(col < H), K.Then():
+                        K.ptx.ld.global_.b32(gamma_frag[value], gamma.ptr_to([col]))
+                        K.ptx.ld.global_.b32(beta_frag[value], beta.ptr_to([col]))
 
         y_f32 = K.alloc_local([pair_values], K.f32)
         if total_values == 1:


### PR DESCRIPTION
## Summary

Enable `flashinfer_layernorm` on Jetson AGX Thor (`sm_110a`).

The Thor-specific path:

- Uses 128-bit loads for four-element FP32 gamma/beta vectors.
- Uses 256-bit loads for eight-element FP32 gamma/beta vectors.
- Removes per-element predicates for complete affine tiles while retaining bounds checks for partial tiles.
- Preserves the existing scalar-load path for other vector widths.
- Leaves the generated TIR for `sm_100a`, `sm_103a`, and `sm_107a` unchanged.

The PR also registers the kernel for `sm_110a` and records the three official bench-suite default configurations in the existing baseline report.

## Performance

Measured on Jetson AGX Thor (`sm_110a`, 20 SM) against the unmodified FlashInfer CuTeDSL baseline.

Proton timer with 25 ms warmup, 100 ms repeat, 100 independent rounds, serial preparation, and zero interference retries. Times are arithmetic means across the 100 rounds. `Source/TIRx` is FlashInfer latency divided by TIRx latency.

| Default | Config | TIRx (µs) | FlashInfer (µs) | Source/TIRx |
|---|---|---:|---:|---:|
| ✓ | `bf16_m1_h128_xc_yc_pdl0_eps1e6` | 2.9773 | 3.1874 | 1.071× |
|  | `bf16_m1_h129_xc_yc_pdl0_eps1e6` | 3.4585 | 3.8048 | 1.100× |
|  | `bf16_m1_h1024_xc_yc_pdl0_eps1e6` | 3.5356 | 3.7603 | 1.064× |
|  | `bf16_m1_h16384_xc_yc_pdl0_eps1e6` | 5.6015 | 10.1185 | 1.806× |
|  | `bf16_m2_h128_xc_yc_pdl0_eps1e6` | 2.6366 | 2.6231 | 0.995× |
|  | `bf16_m2_h129_xc_yc_pdl0_eps1e6` | 3.0956 | 3.0439 | 0.983× |
|  | `bf16_m2_h1024_xc_yc_pdl0_eps1e6` | 3.1922 | 3.7334 | 1.170× |
|  | `bf16_m2_h16384_xc_yc_pdl0_eps1e6` | 6.2293 | 10.4568 | 1.679× |
|  | `bf16_m3_h128_xc_yc_pdl0_eps1e6` | 2.9304 | 2.9735 | 1.015× |
|  | `bf16_m3_h129_xc_yc_pdl0_eps1e6` | 3.1311 | 3.1493 | 1.006× |
|  | `bf16_m3_h1024_xc_yc_pdl0_eps1e6` | 3.5140 | 3.6793 | 1.047× |
|  | `bf16_m3_h16384_xc_yc_pdl0_eps1e6` | 6.8167 | 10.8941 | 1.598× |
|  | `bf16_m128_h128_xc_yc_pdl0_eps1e6` | 3.1552 | 3.1905 | 1.011× |
|  | `bf16_m128_h129_xc_yc_pdl0_eps1e6` | 5.5442 | 5.4867 | 0.990× |
| ✓ | `bf16_m128_h1024_xc_yc_pdl0_eps1e6` | 6.2452 | 7.2593 | 1.162× |
| ✓ | `bf16_m128_h16384_xc_yc_pdl0_eps1e6` | 64.8166 | 75.6959 | 1.168× |

All three official bench-suite default configurations exceed `Source/TIRx > 1`. Across the complete 16-configuration diagnostic matrix, TIRx is faster on 13 configurations.

## Validation

- Passed all 23 LayerNorm correctness configurations, including compact and strided layouts, tail dimensions, PDL, and large-index coverage.
- Confirmed that all 23 `sm_100a` configurations generate TIR identical to the base revision.
- Confirmed unchanged generated TIR for representative `sm_103a` and `sm_107a` configurations.
- Passed 44 registry and bench-suite tests.
- Passed Ruff, formatting, README registry lint, and `git diff --check`.