### PR TITLE
Fix FlexAttention register and TMEM contracts

### DIFF
--- a/tests/test_low_level_ir.py
+++ b/tests/test_low_level_ir.py
@@ -119,6 +119,23 @@ def test_fp8_msa_decode_satisfies_the_default_ir_contract():
     assert check_low_level_ir(kernel).ok
 
 
+@pytest.mark.parametrize("deterministic,num_q_heads", [(False, 1), (True, 1), (False, 2)])
+def test_flex_backward_cooperative_register_roles_are_valid(deterministic, num_q_heads):
+    from tirx_kernels.registry import load_kernel
+
+    module = load_kernel("cudnn_sm100_flex_attention_backward")
+    config = module._config(
+        "register-contract",
+        seqlen_q=128,
+        seqlen_kv=256,
+        num_q_heads=num_q_heads,
+        num_kv_heads=1,
+        deterministic=deterministic,
+    )
+    config.pop("label")
+    assert check_low_level_ir(module.get_kernel(**config)).ok
+
+
 def test_correctness_runner_does_not_rebuild_an_already_checked_kernel():
     class KernelModule:
         @staticmethod

--- a/tests/test_runner_interrupts.py
+++ b/tests/test_runner_interrupts.py
@@ -64,3 +64,20 @@ def test_quiet_critical_section_does_not_redeliver(bench_child_handler):
     # and a later signal still raises immediately.
     with pytest.raises(_Interrupted):
         os.kill(os.getpid(), signal.SIGUSR1)
+
+
+def test_flex_backward_defers_interrupt_during_reference_preparation(
+    bench_child_handler, monkeypatch
+):
+    from tirx_kernels.cudnn.flex_attention import flex_attention_backward_sm100 as flex
+
+    survived = []
+
+    def prepare_data(**config):
+        os.kill(os.getpid(), signal.SIGUSR1)
+        survived.append("reference preparation completed")
+
+    monkeypatch.setattr(flex, "prepare_data", prepare_data)
+    with pytest.raises(_Interrupted):
+        flex.run_gpu({"config": {}})
+    assert survived == ["reference preparation completed"]

--- a/tirx_kernels/cudnn/flex_attention/_flex_attention_backward_sm100/kernel.py
+++ b/tirx_kernels/cudnn/flex_attention/_flex_attention_backward_sm100/kernel.py
@@ -586,8 +586,7 @@ def get_kernel(**config):
         and int(config.get("mask_nfunc", 1)) == 19
     )
     fixed_task_major = p20_all_partial or p16_causal_closed_plan or fixed_gqa_task_major
-    load_regs = 88
-    mma_regs = load_regs
+    producer_regs = 88
     compute_regs = 144 if p20_all_partial else (128 if p26_task_major_2d else 136)
     reduce_regs = 136 if p20_all_partial else (168 if p26_task_major_2d else 152)
 
@@ -1004,21 +1003,20 @@ def get_kernel(**config):
         smem_base = K.local_scalar("uint32")
         K.assign(smem_base, K.cuda.cvta_generic_to_shared(arena.ptr_to([0])))
         sp = K.specialize(chain_dispatch=True)
-        r_empty = sp.role("empty", warps=[15])
-        r_relay = sp.role("relay", warps=[14])
-        r_load = sp.role("load", warps=[13])
-        r_mma = sp.role("mma", warps=[12])
-        r_compute = sp.role("compute", warps=list(range(4, 12)))
-        r_reduce = sp.role("reduce", warps=list(range(4)))
+        r_empty = sp.role("empty", warps=[15], regs=producer_regs)
+        r_relay = sp.role("relay", warps=[14], regs=producer_regs)
+        r_load = sp.role("load", warps=[13], regs=producer_regs)
+        r_mma = sp.role("mma", warps=[12], regs=producer_regs)
+        r_compute = sp.role("compute", warps=list(range(4, 12)), regs=compute_regs)
+        r_reduce = sp.role("reduce", warps=list(range(4)), regs=reduce_regs)
 
         with r_empty:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(24))
+            pass
 
         with r_relay:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(24))
+            pass
 
         with r_load:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(load_regs))
             leader = K.local_scalar("uint32", init=K.cuda.elect_sync())
             q_prod = K.PipelineState(2, phase=0)
             do_prod = K.PipelineState(1, phase=0)
@@ -1141,7 +1139,6 @@ def get_kernel(**config):
                 sum_pipe.empty.wait(do_prod.stage, do_prod.phase ^ 1)
 
         with r_mma:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(mma_regs))
             K.ptx[TMEM_ALLOC](
                 K.cuda.cvta_generic_to_shared(tmem_mailbox.ptr_to([0])), K.uint32(TMEM_COLUMNS)
             )
@@ -1299,7 +1296,6 @@ def get_kernel(**config):
             K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             K.ptx[TMEM_DEALLOC](tcol, K.uint32(TMEM_COLUMNS))
         with r_compute:
-            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(compute_regs))
             K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             tcol = K.local_scalar("uint32")
             K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))
@@ -1723,7 +1719,6 @@ def get_kernel(**config):
                                 )
             K.ptx.bar.arrive(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
         with r_reduce:
-            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(reduce_regs))
             K.ptx.bar.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             tcol = K.local_scalar("uint32")
             K.ptx.ld.shared.b32(tcol, tmem_mailbox.ptr_to([0]))

--- a/tirx_kernels/cudnn/flex_attention/_flex_attention_backward_sm100/kernel_2cta.py
+++ b/tirx_kernels/cudnn/flex_attention/_flex_attention_backward_sm100/kernel_2cta.py
@@ -589,24 +589,21 @@ def get_kernel_2cta(**config):
 
         is_mha = qhead_per_kvhead == 1
         if is_mha and not deterministic:
-            compute_regs, producer_regs, mma_regs = 144, 96, 96
-        elif is_mha:
-            compute_regs, producer_regs, mma_regs = 136, 96, 112
+            compute_regs, producer_regs = 144, 96
         else:
-            compute_regs, producer_regs, mma_regs = 136, 112, 112
+            compute_regs, producer_regs = 136, 112
         sp = K.specialize(chain_dispatch=True)
-        r_empty = sp.role("empty", warps=[15])
-        r_relay = sp.role("relay", warps=[14])
-        r_load = sp.role("load", warps=[13])
-        r_mma = sp.role("mma", warps=[12])
-        r_compute = sp.role("compute", warps=list(range(4, 12)))
-        r_reduce = sp.role("reduce", warps=list(range(4)))
+        r_empty = sp.role("empty", warps=[15], regs=producer_regs)
+        r_relay = sp.role("relay", warps=[14], regs=producer_regs)
+        r_load = sp.role("load", warps=[13], regs=producer_regs)
+        r_mma = sp.role("mma", warps=[12], regs=producer_regs)
+        r_compute = sp.role("compute", warps=list(range(4, 12)), regs=compute_regs)
+        r_reduce = sp.role("reduce", warps=list(range(4)), regs=128)
 
         with r_empty:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(24))
+            pass
 
         with r_relay:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(producer_regs))
             relay_phase = K.local_scalar("int32", init=K.int32(0))
             edge = K.local_scalar("int32", init=K.int32(0))
             with K.While(edge < count):
@@ -617,7 +614,6 @@ def get_kernel_2cta(**config):
                 K.assign(edge, edge + K.int32(1))
 
         with r_load:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(producer_regs))
             elected = K.local_scalar("uint32", init=K.cuda.elect_sync())
             with K.If(elected != K.uint32(0)), K.Then():
                 for tensor_map in (q_map, qt_map, k_map, kt_map, v_map, do_map, dot_map):
@@ -987,7 +983,6 @@ def get_kernel_2cta(**config):
                         )
 
         with r_mma:
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(K.uint32(mma_regs))
             K.ptx.tcgen05.alloc.cta_group__2.sync.aligned.shared__cta.b32(
                 K.address_of(tmem_mailbox), K.uint32(TMEM_COLUMNS)
             )
@@ -1215,7 +1210,6 @@ def get_kernel_2cta(**config):
             K.ptx["tcgen05.dealloc.cta_group::2.sync.aligned.b32"](tcol, K.uint32(TMEM_COLUMNS))
 
         with r_compute:
-            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(compute_regs))
             K.ptx.barrier.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             tcol = K.local_scalar("uint32")
             K.ptx.ld.shared.u32(tcol, tmem_mailbox.ptr_to([0]))
@@ -1706,7 +1700,6 @@ def get_kernel_2cta(**config):
             K.ptx.bar.arrive(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
 
         with r_reduce:
-            K.ptx.setmaxnreg.inc.sync.aligned.u32(K.uint32(128))
             K.ptx.barrier.sync(K.uint32(BAR_TMEM[0]), K.uint32(BAR_TMEM[1]))
             tcol = K.local_scalar("uint32")
             K.ptx.ld.shared.u32(tcol, tmem_mailbox.ptr_to([0]))

--- a/tirx_kernels/cudnn/flex_attention/flex_attention_backward_sm100.py
+++ b/tirx_kernels/cudnn/flex_attention/flex_attention_backward_sm100.py
@@ -441,11 +441,12 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     """Validate once, then time only matching source/TIRx direct main kernels."""
     import torch
 
-    from tirx_kernels.runner import bench, external_references_enabled
+    from tirx_kernels.runner import bench, defer_gpu_interrupts, external_references_enabled
 
     config = {**prepared["config"], **kwargs}
     kernel_config = {key: value for key, value in config.items() if key != "label"}
-    data = prepare_data(**kernel_config)
+    with defer_gpu_interrupts():
+        data = prepare_data(**kernel_config)
 
     validation_launch = _data.target_launch(prepared["executable"], data)
     # Mask planning, preprocessing, and the source forward run through

--- a/tirx_kernels/cudnn/flex_attention/forward_hd256_sm100.py
+++ b/tirx_kernels/cudnn/flex_attention/forward_hd256_sm100.py
@@ -710,12 +710,6 @@ def _make_kernel(**config):
         K.ptx.fence.mbarrier_init.release.cluster()
         if cta_group == 2:
             K.ptx.barrier.cluster.arrive.relaxed()
-        # The source scheduler warp returns its registers before the pipeline
-        # init wait.  Delaying this transition can deadlock WG0's 240-register
-        # acquisition in the two-CTA launch.
-        with K.If(warp == 10), K.Then():
-            K.ptx.setmaxnreg.dec.sync.aligned.u32(72)
-        if cta_group == 2:
             K.ptx.barrier.cluster.wait()
         else:
             K.cuda.cta_sync()
@@ -1139,7 +1133,7 @@ def _make_kernel(**config):
             K.ptx.bar.sync(K.uint32(1), K.uint32(288))
             tmem_base = K.local_scalar("uint32")
             K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
-            row_hi = K.shift_left(K.cast(tid128, "uint32"), K.uint32(16))
+            row_hi = K.shift_left(K.cast((warp % 4) * 32, "uint32"), K.uint32(16))
             score_stage = K.local_scalar("int32", init=0)
             score_phase = K.local_scalar("int32", init=0)
             p_stage = K.local_scalar("int32", init=0)
@@ -1304,7 +1298,7 @@ def _make_kernel(**config):
             K.ptx.bar.sync(K.uint32(1), K.uint32(288))
             tmem_base = K.local_scalar("uint32")
             K.ptx.ld.shared.u32(tmem_base, tmem_mailbox.ptr_to([0]))
-            row_hi = K.shift_left(K.cast(tid128, "uint32"), K.uint32(16))
+            row_hi = K.shift_left(K.cast((warp % 4) * 32, "uint32"), K.uint32(16))
             stats_stage = K.local_scalar("int32", init=0)
             stats_phase = K.local_scalar("int32", init=0)
             o_phase = K.local_scalar("int32", init=0)
@@ -2169,7 +2163,7 @@ def _compile_tirx(config):
     previous = os.environ.get(name)
     os.environ[name] = str(_ptxas_register_usage_level(config))
     try:
-        return compile_kernel(get_kernel(**config), arch="sm_103a")
+        return compile_kernel(get_kernel(**config))
     finally:
         if previous is None:
             os.environ.pop(name, None)


### PR DESCRIPTION
## Motivation

Canonical numerical, Synccheck, and Racecheck coverage exposed source-level register-allocation and TMEM-address violations in FlexAttention. Fix these in the kernels instead of weakening checker semantics to match compiler-dependent handling of invalid instructions.

Benchmark validation also exposed an interference signal escaping through native CuTe/MLIR reference compilation and aborting the benchmark child.

## Changes

- Fix backward warpgroup register allocation in both one- and two-CTA paths.
  - Give all four producer-warpgroup warps the same register cap.
  - Express caps through the existing `K.specialize` role API.
  - Preserve compute/reduce caps and the 64K register-pool budget.

- Fix HD256 forward register and TMEM contracts.
  - Remove the extra warp-10-only `setmaxnreg.dec` before the initialization rendezvous; retain the existing role-level transitions.
  - Use a warp-uniform TMEM base address in the softmax and correction roles. Lane selection comes from the instruction layout, not a different base address per lane.

- Respect the selected compilation architecture.
  - Remove the forced `sm_103a` target so the runner can compile this SM100/SM103 kernel for the actual device.

- Protect backward reference preparation from asynchronous interruption.
  - Reuse `defer_gpu_interrupts()` around reference preparation.
  - Deliver pending interruption after preparation exits, without changing GPU timing or interference-retry policy.

- Add three focused IR cases and one signal-injection regression test; reuse existing GPU correctness and benchmark configurations.

No algorithm or tiling changes, new data structures, or checker exceptions.

## Validation

- Kernel IR/API/interrupt tests: **46 passed**.
- The new interruption regression fails before the guard and passes after it.
- B200 / CUDA 13.2: **9 forward and 8 representative backward GPU correctness cases passed**.
- FlexAttention numerical/Synccheck/Racecheck coverage: **9 passed** with TVM `7e06fc6c14` and FFI `9d784c4`.
- Full agent suite with this kernel commit: **3321 passed**, with no marker exclusions:
  `pytest -q -n 16 --dist=worksteal`

## Performance

Official bench-suite paired A/B uses the same physical GPU per pair, 15 rounds, 1-second cooldown, and the unchanged strict 1% gate.

- Backward: the initial 9-row run passed 8 rows.
- Forward: both CTA2 rows passed initially. CTA1 initially failed (+1.34%); another repeat encountered thermal throttling (+13.14%). A subsequent clean repeat passed: **23.335 → 23.243 ms (-0.39%)**, with a peak temperature of 42°C and no thermal slowdown or interference.

These are separate campaigns; original failures are retained, not replaced by selectively combined samples.

Performance comparisons use frozen TVM `b5d13cd` and CUDA 13.2. Backward compares against `ff180eff`; forward uses diagnostic baseline `9f891564`, differing from that parent only by removing the forced SM103 target to permit B200 execution. Rebasing onto `e3a5b15` leaves the measured GPU kernel source unchanged.

SM103 hardware performance was not measured.