### PR TITLE
perf(thor): enable FlashInfer top-k kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ keeps them in sync.
 | `sm_100a` | 103 |
 | `sm_103a` | 98 |
 | `sm_107a` | 94 |
-| `sm_110a` | 8 |
+| `sm_110a` | 10 |
 
 ### Native TIRx
 
@@ -153,8 +153,8 @@ Grouped by the FlashInfer Python entry point each port backs.
 - **`flashinfer.fused_moe`:**
   [`blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin`](tirx_kernels/flashinfer/fused_moe/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin.py) ⟨sm_107a⟩
 - **`flashinfer.topk`:**
-  [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py),
-  [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py),
+  [`fast_topk_clusters`](tirx_kernels/flashinfer/topk/fast_topk_clusters.py) ⟨+sm_110a⟩,
+  [`filtered_topk`](tirx_kernels/flashinfer/topk/filtered_topk.py) ⟨+sm_110a⟩,
   [`radix_topk_multi_cta`](tirx_kernels/flashinfer/topk/radix_topk_multi_cta.py),
   [`radix_topk_single_cta`](tirx_kernels/flashinfer/topk/radix_topk_single_cta.py),
   [`stable_sort_topk_by_value`](tirx_kernels/flashinfer/topk/stable_sort_topk_by_value.py)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,8 +61,8 @@ def test_exact_architectures_are_stored_in_source_index():
         ("sm_100a",): 12,
         ("sm_103a",): 7,
         ("sm_107a",): 4,
-        ("sm_100a", "sm_103a", "sm_107a"): 82,
-        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 8,
+        ("sm_100a", "sm_103a", "sm_107a"): 80,
+        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 10,
     }
 
 

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -523,6 +523,22 @@ Grouped workloads show one row per config and one timing column per implementati
 
 ## Jetson AGX Thor (`sm_110a`)
 
+### fast_topk_clusters
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `f32_plain_b16_l4096_k256` | tirx | 10.9391 | flashinfer | 11.1809 | 1.022 | — |
+| `f32_plain_b64_l16384_k256` | tirx | 67.7273 | flashinfer | 192.1225 | 2.837 | — |
+| `f32_plain_b64_l65536_k1024` | tirx | 226.0682 | flashinfer | 304.5217 | 1.347 | — |
+
+### filtered_topk
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `f32_plain_det_r2_l524288_k256_endbit` | tirx | 143.5166 | flashinfer | 162.3314 | 1.131 | — |
+| `f32_plain_r4_l8192_k256` | tirx | 10.4883 | flashinfer | 12.1341 | 1.157 | — |
+| `f32_plain_r64_l8192_k256` | tirx | 39.3581 | flashinfer | 45.6034 | 1.159 | — |
+
 ### flash_attention4
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |

--- a/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
+++ b/tirx_kernels/flashinfer/topk/fast_topk_clusters.py
@@ -52,18 +52,19 @@ and ``num_clusters`` outside ``{1, 2, 4, 8}`` (the launcher degrades it to 1
 before the kernel sees it, ``:607-611``).
 """
 
+import os
 from typing import Any
 
 import tirx_kernels.kern as K
 from tirx_kernels.flashinfer.utils import topk_radix as R
 from tirx_kernels.flashinfer.utils.filtered_topk_ops import st_global_bits
 from tirx_kernels.flashinfer.utils.topk_harness import source_module, torch_dtype
-from tirx_kernels.runner import bench
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, bench, hardware_num_sms
 
 KERNEL_META = {
     "name": "fast_topk_clusters",
     "category": "flashinfer",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flashinfer-python",
@@ -162,6 +163,21 @@ def clusters_for(batch_size: int, seq_len: int) -> int:
     return 1
 
 
+def _tirx_clusters_for(batch_size: int, seq_len: int) -> int:
+    """Use row-level parallelism when it already supplies three Thor waves."""
+    source_clusters = clusters_for(batch_size, seq_len)
+    if (
+        os.environ.get(PREPARE_CUDA_ARCH_ENV, "sm_100a") == "sm_110a"
+        and source_clusters > 1
+        and batch_size >= 3 * hardware_num_sms()
+    ):
+        if seq_len <= 2 * SHORT_ROW_CLUSTER_LIMIT:
+            return 1
+        if source_clusters > 2 and seq_len <= 8 * SHORT_ROW_CLUSTER_LIMIT:
+            return 2
+    return source_clusters
+
+
 # Global memory goes through raw PTX, never TensorLoad/BufferStore: the repo's
 # low-level IR contract rejects the latter outright (db entry
 # `express-low-level-memory-access-through-raw-ptx`).
@@ -250,7 +266,7 @@ def get_kernel(
     is32 = dtype == "float32"
     rounds = 4 if is32 else 2  # NRemainingRounds + 1 (:90)
     lshift_start = 8 * (4 if is32 else 2) - 8  # (:91)
-    nc = clusters_for(batch, seq_len)
+    nc = _tirx_clusters_for(batch, seq_len)
     num_cached = num_cached_for_device(k)
     ovf_stride = seq_len // nc  # binding:47, from the row stride
     plain = mode == "plain"

--- a/tirx_kernels/flashinfer/topk/filtered_topk.py
+++ b/tirx_kernels/flashinfer/topk/filtered_topk.py
@@ -53,7 +53,8 @@ SM100 cluster kernel, which the ``FLASHINFER_TOPK_ALGO=filtered`` pin keeps out 
 the reference path.
 """
 
-from contextlib import nullcontext
+import os
+from contextlib import contextmanager, nullcontext
 from typing import Any
 
 import tirx_kernels.kern as K
@@ -94,7 +95,7 @@ from tirx_kernels.flashinfer.utils.topk_radix import (
     st_global_u16,
     st_global_u32,
 )
-from tirx_kernels.runner import bench
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, bench
 
 # Patterns whose whole purpose is to overflow the candidate arena; prepare_data
 # asserts on the host that they still do.
@@ -106,7 +107,7 @@ _OVERFLOW_LENGTH = 131072
 KERNEL_META = {
     "name": "filtered_topk",
     "category": "flashinfer",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flashinfer-python",
@@ -272,6 +273,40 @@ def _validate(
 # ---------------------------------------------------------------------------
 # Target entries.
 # ---------------------------------------------------------------------------
+def _select_ptxas_reg_level(
+    num_rows: int, length: int, k: int, deterministic: bool, tie_break: int
+) -> str:
+    if (num_rows, length, k, deterministic, tie_break) == (4, 8192, 256, False, TIE_NONE):
+        return "6"
+    if (num_rows, length, k, deterministic, tie_break) == (2, 524288, 256, True, TIE_NONE):
+        return "5"
+    return "10"
+
+
+@contextmanager
+def _thor_ptxas_reg_level(config: dict[str, Any]):
+    """Scope Thor's measured compiler setting to this module's compilation."""
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV, "sm_100a") != "sm_110a":
+        yield
+        return
+    name = "TVM_CUDA_PTXAS_REG_LEVEL"
+    previous = os.environ.get(name)
+    os.environ[name] = _select_ptxas_reg_level(
+        config["num_rows"],
+        config["length"],
+        config["k"],
+        config["deterministic"],
+        config["tie_break"],
+    )
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = previous
+
+
 def get_kernel(
     dtype: str = "float32",
     mode: str = "basic",
@@ -996,10 +1031,11 @@ def run_test(**config):
     assert_reference_is_top_k(cfg, data, ref_out)
     assert_reference_tie_break(cfg, data, ref_out)
 
-    kernel = get_kernel(**cfg)
-    finalize = get_finalize_kernel(**cfg)
-    ex = compile_kernel(kernel)
-    ex_finalize = compile_kernel(finalize) if finalize is not None else None
+    with _thor_ptxas_reg_level(cfg):
+        kernel = get_kernel(**cfg)
+        finalize = get_finalize_kernel(**cfg)
+        ex = compile_kernel(kernel)
+        ex_finalize = compile_kernel(finalize) if finalize is not None else None
 
     tirx_out = alloc_outputs(cfg)
     _launch_tirx(ex, ex_finalize, build_tirx_args(cfg, data, tirx_out))
@@ -1159,13 +1195,14 @@ def prepare_bench(**kwargs: Any):
     from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
 
     cfg = _normalize_config(kwargs)
-    finalize = get_finalize_kernel(**cfg)
-    state = {
-        "config": cfg,
-        "executable": compile_kernel(get_kernel(**cfg)),
-        # None where `finalize_plan` says the dispatcher issues no second launch.
-        "finalize": compile_kernel(finalize) if finalize is not None else None,
-    }
+    with _thor_ptxas_reg_level(cfg):
+        finalize = get_finalize_kernel(**cfg)
+        state = {
+            "config": cfg,
+            "executable": compile_kernel(get_kernel(**cfg)),
+            # None where `finalize_plan` says the dispatcher issues no second launch.
+            "finalize": compile_kernel(finalize) if finalize is not None else None,
+        }
     return prepared_gpu_benchmark(run_gpu, state)
 
 


### PR DESCRIPTION
## Summary

Enable `fast_topk_clusters` and `filtered_topk` on Jetson AGX Thor (`sm_110a`).

- Select smaller TIRx cluster counts for Thor fast Top-K workloads where row-level parallelism already supplies at least three device waves.
- Use the measured Thor ptxas register-usage levels for the affected filtered Top-K specializations. The setting is scoped to this module's compilation and restores the caller environment afterward, so it does not change other architectures or later kernel builds.
- Update the architecture registry, README support list, and the existing Thor section in `tirx_kernels/bench_suite/baseline.md`.

## Validation

- `fast_topk_clusters`: correctness **34/34**, paired performance **34/34** with strict `Source/TIRx > 1.000`.
- `filtered_topk`: correctness **107/107** (101 performance configs plus 6 correctness-only guards), paired performance **101/101** with strict `Source/TIRx > 1.000`.
- `pytest -q tests/test_registry.py`: **22 passed**.
- Ruff and `git diff --check`: passed.

Performance was measured on one Jetson AGX Thor (`sm_110a`, 20 SM) with TVM `15b607d6` and the FlashInfer source implementation. Each value is the arithmetic mean of 100 independent Proton rounds using the repository timer defaults: 25 ms warmup, 100 ms repeat, and 0 s cooldown. `Source/TIRx` above 1 means TIRx is faster. There were no interference retries.

The narrowest row from each complete matrix was also rerun independently for 100 rounds:

| Kernel | Config | TIRx (µs) | Source (µs) | Source/TIRx |
|---|---|---:|---:|---:|
| `fast_topk_clusters` | `f32_pt_b16_l16384_k256_rowvar` | 140.9356 | 141.7577 | 1.0058× |
| `filtered_topk` | `bf16_pt_det_r4_l8192_k256` | 21.9707 | 22.0149 | 1.0020× |

## Complete performance matrix

### `fast_topk_clusters` (34/34 pass)

| Config | TIRx (µs) | FlashInfer (µs) | Source/TIRx |
|---|---:|---:|---:|
| `bf16_plain_b16_l16384_k256` | 129.2067 | 144.1197 | 1.1154× |
| `bf16_plain_b64_l16384_k1024_tie_heavy` | 69.0565 | 162.8887 | 2.3588× |
| `bf16_plain_b64_l65536_k1024` | 154.1168 | 215.6730 | 1.3994× |
| `bf16_pt_b16_l16384_k256` | 142.5038 | 154.6859 | 1.0855× |
| `bf16_rag_b16_l16384_k256` | 127.4562 | 140.4092 | 1.1016× |
| `bf16_rag_b300_l16384_k256` | 149.3046 | 162.0246 | 1.0852× |
| `f16_plain_b16_l16384_k256` | 128.4623 | 143.0894 | 1.1139× |
| `f16_plain_b16_l4096_k256` | 7.2960 | 8.2474 | 1.1304× |
| `f16_plain_b64_l16384_k1024_tie_heavy` | 48.2831 | 135.6298 | 2.8091× |
| `f16_plain_b64_l65536_k2048_i64` | 183.6534 | 239.7914 | 1.3057× |
| `f16_pt_b16_l16384_k256` | 141.8332 | 154.1911 | 1.0871× |
| `f16_rag_b16_l16384_k256` | 127.5915 | 140.2119 | 1.0989× |
| `f32_plain_b16_l16384_k2048_all_equal` | 239.5227 | 249.4499 | 1.0414× |
| `f32_plain_b16_l16384_k256` | 200.4295 | 209.3179 | 1.0443× |
| `f32_plain_b16_l16384_k256_all_equal` | 236.3723 | 242.0827 | 1.0242× |
| `f32_plain_b16_l16384_k256_i64` | 198.6449 | 208.2939 | 1.0486× |
| `f32_plain_b16_l16384_k256_neg` | 200.6375 | 210.0545 | 1.0469× |
| `f32_plain_b16_l16384_k256_tie_heavy` | 217.7353 | 223.6853 | 1.0273× |
| `f32_plain_b16_l4096_k256` | 10.5646 | 11.0924 | 1.0500× |
| `f32_plain_b200_l16384_k256` | 131.8730 | 266.9421 | 2.0242× |
| `f32_plain_b200_l65536_k1024` | 479.2157 | 509.4651 | 1.0631× |
| `f32_plain_b300_l16384_k256` | 201.5765 | 220.0671 | 1.0917× |
| `f32_plain_b64_l16384_k1024` | 74.3941 | 201.7398 | 2.7118× |
| `f32_plain_b64_l16384_k2048` | 82.3898 | 207.3584 | 2.5168× |
| `f32_plain_b64_l16384_k256` | 65.5426 | 192.1237 | 2.9313× |
| `f32_plain_b64_l65536_k1024` | 224.0130 | 304.7789 | 1.3605× |
| `f32_plain_b8_l4096_k4096` | 4.5838 | 4.7431 | 1.0347× |
| `f32_pt_b16_l16384_k256` | 210.3934 | 219.0162 | 1.0410× |
| `f32_pt_b16_l16384_k256_rowvar` | 140.8323 | 141.0465 | 1.0015× |
| `f32_pt_b200_l16384_k256` | 151.4191 | 272.1660 | 1.7974× |
| `f32_pt_b8_l4096_k4096` | 4.4944 | 4.7018 | 1.0461× |
| `f32_rag_b16_l16384_k256` | 200.4315 | 204.6672 | 1.0211× |
| `f32_rag_b16_l16384_k256_rowvar` | 129.1763 | 130.7187 | 1.0119× |
| `f32_rag_b8_l4096_k4096` | 2.8667 | 3.1653 | 1.1041× |

### `filtered_topk` (101/101 pass)

| Config | TIRx (µs) | FlashInfer (µs) | Source/TIRx |
|---|---:|---:|---:|
| `bf16_plain_det_r4_l8192_k256` | 15.2758 | 16.2429 | 1.0633× |
| `bf16_plain_det_tlarge_r4_l8192_k256` | 14.0373 | 15.5811 | 1.1100× |
| `bf16_plain_det_tsmall_r4_l8192_k256` | 14.6181 | 16.2801 | 1.1137× |
| `bf16_plain_r4_l8188_k256_vec` | 9.1673 | 10.3042 | 1.1240× |
| `bf16_plain_r4_l8189_k256_vec` | 11.1433 | 11.7936 | 1.0584× |
| `bf16_plain_r4_l8190_k256_vec` | 10.0762 | 10.7336 | 1.0652× |
| `bf16_plain_r4_l8192_k256` | 8.6016 | 9.8791 | 1.1485× |
| `bf16_plain_tlarge_r4_l8192_k256` | 10.1769 | 11.4574 | 1.1258× |
| `bf16_plain_tsmall_r4_l8192_k256` | 10.7431 | 12.0789 | 1.1243× |
| `bf16_pt_det_r4_l8192_k256` | 20.7637 | 21.0844 | 1.0154× |
| `bf16_pt_det_tlarge_r4_l8192_k256` | 20.2661 | 20.8863 | 1.0306× |
| `bf16_pt_det_tsmall_r4_l8192_k256` | 21.2164 | 21.6884 | 1.0222× |
| `bf16_pt_r4_l8192_k256` | 10.5269 | 11.4042 | 1.0833× |
| `bf16_pt_tlarge_r4_l8192_k256` | 17.9450 | 18.3926 | 1.0249× |
| `bf16_pt_tsmall_r4_l8192_k256` | 19.0395 | 19.3717 | 1.0174× |
| `bf16_rag_det_r4_l8192_k256` | 16.0175 | 16.4091 | 1.0245× |
| `bf16_rag_det_tlarge_r4_l8192_k256` | 15.1844 | 15.7753 | 1.0389× |
| `bf16_rag_det_tsmall_r4_l8192_k256` | 16.3081 | 16.7968 | 1.0300× |
| `bf16_rag_r4_l8192_k256` | 9.3430 | 10.0234 | 1.0728× |
| `bf16_rag_tlarge_r4_l8192_k256` | 12.8978 | 13.3595 | 1.0358× |
| `bf16_rag_tsmall_r4_l8192_k256` | 14.1447 | 14.4367 | 1.0206× |
| `f16_plain_det_r2_l131072_k256_quantized` | 125.2981 | 139.8318 | 1.1160× |
| `f16_plain_det_r2_l131072_k256_tie_heavy` | 124.7396 | 139.5579 | 1.1188× |
| `f16_plain_det_r4_l8192_k256` | 11.4702 | 12.8729 | 1.1223× |
| `f16_plain_det_tlarge_r4_l8192_k256` | 11.4104 | 12.8508 | 1.1262× |
| `f16_plain_det_tsmall_r4_l8192_k256` | 11.4590 | 12.8113 | 1.1180× |
| `f16_plain_r2_l131072_k256_quantized` | 96.7061 | 111.1334 | 1.1492× |
| `f16_plain_r2_l131072_k256_tie_heavy` | 96.6936 | 110.3125 | 1.1408× |
| `f16_plain_r4_l8188_k256_vec` | 8.0578 | 9.0600 | 1.1244× |
| `f16_plain_r4_l8189_k256_vec` | 10.0775 | 10.5999 | 1.0518× |
| `f16_plain_r4_l8190_k256_vec` | 8.9042 | 9.4649 | 1.0630× |
| `f16_plain_r4_l8192_k256` | 7.5141 | 8.5149 | 1.1332× |
| `f16_plain_tlarge_r4_l8192_k256` | 7.5866 | 8.6933 | 1.1459× |
| `f16_plain_tlarge_r4_l8192_k256_pivot_tie` | 9.6343 | 11.0813 | 1.1502× |
| `f16_plain_tsmall_r4_l8192_k256` | 7.6026 | 8.7231 | 1.1474× |
| `f16_plain_tsmall_r4_l8192_k256_pivot_tie` | 9.6205 | 10.9825 | 1.1416× |
| `f16_pt_det_r4_l8192_k256` | 17.3493 | 18.3535 | 1.0579× |
| `f16_pt_det_tlarge_r4_l8192_k256` | 17.4734 | 18.3879 | 1.0523× |
| `f16_pt_det_tsmall_r4_l8192_k256` | 17.4044 | 18.4344 | 1.0592× |
| `f16_pt_r4_l8192_k256` | 9.3479 | 10.1660 | 1.0875× |
| `f16_pt_tlarge_r4_l8192_k256` | 15.0811 | 15.8649 | 1.0520× |
| `f16_pt_tsmall_r4_l8192_k256` | 15.0160 | 15.8831 | 1.0577× |
| `f16_rag_det_r4_l8192_k256` | 12.2601 | 13.2792 | 1.0831× |
| `f16_rag_det_tlarge_r4_l8192_k256` | 12.6923 | 13.5479 | 1.0674× |
| `f16_rag_det_tsmall_r4_l8192_k256` | 12.6606 | 13.5707 | 1.0719× |
| `f16_rag_r4_l8192_k256` | 8.2366 | 8.9354 | 1.0848× |
| `f16_rag_tlarge_r4_l8192_k256` | 10.0288 | 10.7545 | 1.0724× |
| `f16_rag_tsmall_r4_l8192_k256` | 10.1897 | 10.9618 | 1.0758× |
| `f32_plain_det_r2_l131072_k256_quantized` | 222.5761 | 245.0446 | 1.1009× |
| `f32_plain_det_r2_l131072_k256_tie_heavy` | 221.7087 | 244.5931 | 1.1032× |
| `f32_plain_det_r2_l200_k128_endbit` | 9.0696 | 9.6962 | 1.0691× |
| `f32_plain_det_r2_l4096_k256_endbit` | 13.5151 | 14.5052 | 1.0733× |
| `f32_plain_det_r2_l524288_k256_endbit` | 140.6472 | 153.7985 | 1.0935× |
| `f32_plain_det_r2_l65536_k256_endbit` | 32.0842 | 34.1741 | 1.0651× |
| `f32_plain_det_r4_l8192_k1` | 8.1317 | 9.2656 | 1.1394× |
| `f32_plain_det_r4_l8192_k1024` | 17.9596 | 20.0335 | 1.1155× |
| `f32_plain_det_r4_l8192_k128` | 13.7862 | 15.2938 | 1.1094× |
| `f32_plain_det_r4_l8192_k2048` | 21.5053 | 23.7162 | 1.1028× |
| `f32_plain_det_r4_l8192_k256` | 14.2890 | 16.1901 | 1.1331× |
| `f32_plain_det_r4_l8192_k512` | 15.8327 | 17.8683 | 1.1286× |
| `f32_plain_det_r4_l8192_k576` | 16.6050 | 18.2487 | 1.0990× |
| `f32_plain_det_tlarge_r4_l8192_k256` | 14.3042 | 16.2755 | 1.1378× |
| `f32_plain_det_tsmall_r4_l8192_k256` | 14.6715 | 16.5531 | 1.1282× |
| `f32_plain_r16_l8192_k256` | 14.2093 | 15.7970 | 1.1117× |
| `f32_plain_r1_l8192_k256` | 8.4351 | 10.2733 | 1.2179× |
| `f32_plain_r256_l8192_k256` | 119.4301 | 138.7941 | 1.1621× |
| `f32_plain_r2_l131072_k256_quantized` | 196.8857 | 212.7908 | 1.0808× |
| `f32_plain_r2_l131072_k256_tie_heavy` | 196.8223 | 212.4064 | 1.0792× |
| `f32_plain_r4_l8189_k256_vec` | 12.8137 | 13.5444 | 1.0570× |
| `f32_plain_r4_l8190_k256_vec` | 11.6337 | 12.2866 | 1.0561× |
| `f32_plain_r4_l8192_k1` | 7.8405 | 9.0441 | 1.1535× |
| `f32_plain_r4_l8192_k1024` | 11.6892 | 13.1483 | 1.1248× |
| `f32_plain_r4_l8192_k128` | 10.1869 | 11.7143 | 1.1499× |
| `f32_plain_r4_l8192_k2048` | 11.8751 | 13.4818 | 1.1353× |
| `f32_plain_r4_l8192_k256` | 10.1212 | 11.8115 | 1.1670× |
| `f32_plain_r4_l8192_k256_dsa` | 12.3425 | 13.0978 | 1.0612× |
| `f32_plain_r4_l8192_k512` | 11.0126 | 12.4724 | 1.1326× |
| `f32_plain_r4_l8192_k576` | 11.1876 | 12.6265 | 1.1286× |
| `f32_plain_r64_l8192_k256` | 38.5356 | 44.6670 | 1.1591× |
| `f32_plain_tlarge_r4_l8192_k256` | 10.4728 | 12.1243 | 1.1577× |
| `f32_plain_tlarge_r4_l8192_k256_pivot_tie` | 14.9384 | 16.8586 | 1.1285× |
| `f32_plain_tsmall_r4_l8192_k256` | 10.3361 | 12.0621 | 1.1670× |
| `f32_plain_tsmall_r4_l8192_k256_pivot_tie` | 14.9477 | 16.8197 | 1.1252× |
| `f32_pt_det_r4_l8192_k256` | 21.1035 | 21.8977 | 1.0376× |
| `f32_pt_det_tlarge_r4_l8192_k256` | 21.1541 | 21.8851 | 1.0346× |
| `f32_pt_det_tsmall_r4_l8192_k256` | 21.3269 | 22.1080 | 1.0366× |
| `f32_pt_r4_l8192_k256` | 12.9564 | 13.6597 | 1.0543× |
| `f32_pt_r4_l8192_k256_dsa` | 14.0972 | 14.7323 | 1.0451× |
| `f32_pt_tlarge_r4_l8192_k256` | 19.0489 | 19.6891 | 1.0336× |
| `f32_pt_tsmall_r4_l8192_k256` | 18.9826 | 19.6452 | 1.0349× |
| `f32_pt_tsmall_r4_l8192_k256_r2b` | 19.2757 | 19.7925 | 1.0268× |
| `f32_pt_tsmall_r4_l8192_k256_rs` | 20.3797 | 20.8728 | 1.0242× |
| `f32_pt_tsmall_r4_l8192_k256_rs_pts` | 20.4633 | 21.0232 | 1.0274× |
| `f32_rag_det_r4_l8192_k256` | 16.1848 | 16.9513 | 1.0474× |
| `f32_rag_det_tlarge_r4_l8192_k256` | 16.1890 | 16.9368 | 1.0462× |
| `f32_rag_det_tsmall_r4_l8192_k256` | 16.2851 | 17.0186 | 1.0450× |
| `f32_rag_r4_l8192_k256` | 11.9112 | 12.4758 | 1.0474× |
| `f32_rag_r4_l8192_k256_dsa` | 13.1174 | 13.6543 | 1.0409× |
| `f32_rag_r4_l8192_k256_rs` | 13.3476 | 13.8019 | 1.0340× |
| `f32_rag_tlarge_r4_l8192_k256` | 14.1377 | 14.6886 | 1.0390× |
| `f32_rag_tsmall_r4_l8192_k256` | 13.8123 | 14.3902 | 1.0418× |
