### PR TITLE
perf(thor): enable MTP horizontal state update and MXFP4 quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ keeps them in sync.
 | `sm_100a` | 103 |
 | `sm_103a` | 98 |
 | `sm_107a` | 94 |
-| `sm_110a` | 11 |
+| `sm_110a` | 12 |
 
 ### Native TIRx
 
@@ -97,7 +97,7 @@ Grouped by the FlashInfer Python entry point each port backs.
 - **`flashinfer.quantization`:**
   [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py),
   [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py),
-  [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py),
+  [`mxfp4_quantize`](tirx_kernels/flashinfer/quantization/mxfp4_quantize.py) ⟨+sm_110a⟩,
   [`mxfp8_quantize`](tirx_kernels/flashinfer/quantization/mxfp8_quantize.py)
 - **`flashinfer.norm`:**
   [`flashinfer_rmsnorm`](tirx_kernels/flashinfer/norm/rmsnorm.py) ⟨+sm_110a⟩,

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ keeps them in sync.
 | `sm_100a` | 103 |
 | `sm_103a` | 98 |
 | `sm_107a` | 94 |
-| `sm_110a` | 10 |
+| `sm_110a` | 11 |
 
 ### Native TIRx
 
@@ -115,7 +115,7 @@ Grouped by the FlashInfer Python entry point each port backs.
   [`selective_state_update_stp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_stp_horizontal.py),
   [`selective_state_update_mtp_simple`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py) ⟨+sm_110a⟩,
   [`selective_state_update_mtp_vertical`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_vertical.py) ⟨+sm_110a⟩,
-  [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py)
+  [`selective_state_update_mtp_horizontal`](tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py) ⟨+sm_110a⟩
 - **`flashinfer.kda`:**
   [`flashkda_bf16_fused_m128`](tirx_kernels/flashinfer/kda/bf16_fused_m128.py),
   [`recurrent_kda_decode_one_warp`](tirx_kernels/flashinfer/kda/recurrent_kda_decode_one_warp.py),

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,8 +61,8 @@ def test_exact_architectures_are_stored_in_source_index():
         ("sm_100a",): 12,
         ("sm_103a",): 7,
         ("sm_107a",): 4,
-        ("sm_100a", "sm_103a", "sm_107a"): 79,
-        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 11,
+        ("sm_100a", "sm_103a", "sm_107a"): 78,
+        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 12,
     }
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,8 +61,8 @@ def test_exact_architectures_are_stored_in_source_index():
         ("sm_100a",): 12,
         ("sm_103a",): 7,
         ("sm_107a",): 4,
-        ("sm_100a", "sm_103a", "sm_107a"): 80,
-        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 10,
+        ("sm_100a", "sm_103a", "sm_107a"): 79,
+        ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 11,
     }
 
 

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -602,3 +602,11 @@ Grouped workloads show one row per config and one timing column per implementati
 | `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 47.7000 | flashinfer_cuda | 50.0233 | 1.049 | — |
 | `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 25012.4818 | flashinfer_cuda | 26609.4659 | 1.064 | — |
 | `b512_h64_d64_s128_t6_r8_statebf16_official` | tirx | 6220.0814 | flashinfer_cuda | 6629.1134 | 1.066 | — |
+
+### selective_state_update_mtp_horizontal
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `b1_h64_d64_s128_t6_r8_statebf16_official` | tirx | 26.0536 | flashinfer_cuda | 29.3040 | 1.125 | — |
+| `b2048_h64_d64_s128_t6_r8_statebf16_official` | tirx | 14069.8720 | flashinfer_cuda | 15273.7740 | 1.086 | — |
+| `b512_h64_d64_s128_t6_r8_statebf16_official` | tirx | 3537.5044 | flashinfer_cuda | 3875.5075 | 1.096 | — |

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -587,6 +587,14 @@ Grouped workloads show one row per config and one timing column per implementati
 | `decode_b64_k16384_h4_varlen` | tirx | 3136.1864 | msa | 3995.1724 | 1.274 | — |
 | `prefill_b1_k8192_h2` | tirx | 5.7109 | msa | 6.2449 | 1.094 | — |
 
+### mxfp4_quantize
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `fp16_128x4_m128_k1024` | tirx | 6.7874 | flashinfer | 6.9652 | 1.026 | — |
+| `fp16_128x4_m16384_k7168` | tirx | 1936.2057 | flashinfer | 1948.9107 | 1.007 | — |
+| `fp16_linear_m4096_k4096` | tirx | 344.2575 | flashinfer | 353.9275 | 1.028 | — |
+
 ### selective_state_update_mtp_simple
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -50,11 +50,11 @@ _bf16_word_to_f32x2 = _simple._bf16_word_to_f32x2
 _philox4x32 = _vertical._philox4x32
 
 
-def _mbarrier_arrive_wait_parity(barrier, parity, *, zero_sleep=False):
+def _mbarrier_arrive_wait_parity(barrier, parity, *, yield_while_waiting=False):
     K.ptx.mbarrier.arrive.shared__cta.b64(barrier)
     ready = K.local_scalar("uint32", init=K.uint32(0))
     with K.While(True):
-        if zero_sleep:
+        if yield_while_waiting:
             K.cuda.nano_sleep(0)
         K.ptx.mbarrier.try_wait.parity.shared__cta.b64(ready, barrier, K.uint32(parity))
         with K.If(ready != K.uint32(0)), K.Then():
@@ -589,7 +589,9 @@ def get_kernel(**kwargs: Any):
             and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
         )
     )
-    use_zero_sleep_wait = thor_bf16_shape and (
+    # A zero-duration nanosleep yields the polling warp so the producer can
+    # advance on the Thor shapes where the mbarrier handoff is latency-bound.
+    use_wait_yield = thor_bf16_shape and (
         (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP)
         in (
             (64, 128, 128, 4, 8),
@@ -851,7 +853,7 @@ def get_kernel(**kwargs: Any):
                 _mbarrier_arrive_wait_parity(
                     full_barriers.ptr_to([state_pipe.stage]),
                     state_pipe.phase,
-                    zero_sleep=use_zero_sleep_wait,
+                    yield_while_waiting=use_wait_yield,
                 )
 
                 with K.serial(2) as sp:
@@ -1114,7 +1116,7 @@ def get_kernel(**kwargs: Any):
                 state_pipe.advance()
 
             _mbarrier_arrive_wait_parity(
-                out_ready_barrier.ptr_to([0]), 0, zero_sleep=use_zero_sleep_wait
+                out_ready_barrier.ptr_to([0]), 0, yield_while_waiting=use_wait_yield
             )
             with K.unroll((NTOKENS + 3) // 4) as episode:
                 step: K.int32 = compute_warp + episode * 4
@@ -1238,7 +1240,7 @@ def get_kernel(**kwargs: Any):
                 _mbarrier_arrive_wait_parity(
                     empty_barriers.ptr_to([state_pipe.stage]),
                     state_pipe.phase,
-                    zero_sleep=use_zero_sleep_wait,
+                    yield_while_waiting=use_wait_yield,
                 )
                 with K.If(lane == 0), K.Then():
                     if not IS_PAD:

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_horizontal.py
@@ -10,11 +10,14 @@ Upstream source: include/flashinfer/mamba/kernel_selective_state_update_mtp_hori
 
 import ctypes
 import functools
+import os
 from typing import Any
 
 import torch
 
 import tirx_kernels.kern as K
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV
+from tvm.ir import PointerType, PrimType
 
 from . import selective_state_update_mtp_simple as _simple
 from . import selective_state_update_mtp_vertical as _vertical
@@ -23,7 +26,7 @@ from .selective_state_update_mtp_simple import _case, _shfl_down_f32
 KERNEL_META = {
     "name": "selective_state_update_mtp_horizontal",
     "category": "flashinfer",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flashinfer-python",
@@ -47,10 +50,12 @@ _bf16_word_to_f32x2 = _simple._bf16_word_to_f32x2
 _philox4x32 = _vertical._philox4x32
 
 
-def _mbarrier_arrive_wait_parity(barrier, parity):
+def _mbarrier_arrive_wait_parity(barrier, parity, *, zero_sleep=False):
     K.ptx.mbarrier.arrive.shared__cta.b64(barrier)
     ready = K.local_scalar("uint32", init=K.uint32(0))
     with K.While(True):
+        if zero_sleep:
+            K.cuda.nano_sleep(0)
         K.ptx.mbarrier.try_wait.parity.shared__cta.b64(ready, barrier, K.uint32(parity))
         with K.If(ready != K.uint32(0)), K.Then():
             K.Break()
@@ -73,8 +78,7 @@ def _store_state_tile(
     pair_base,
     random_words,
     random_base,
-    destination,
-    destination_base,
+    destination_ptr,
     *,
     STATE_DTYPE,
     PAIRS_PER_TILE_MEMBER,
@@ -86,25 +90,19 @@ def _store_state_tile(
             packed = values[pair_base + pair]
             K.ptx.mov.b32(words[pair * 2], K.reinterpret("uint32", K.cuda.float2_x(packed)))
             K.ptx.mov.b32(words[pair * 2 + 1], K.reinterpret("uint32", K.cuda.float2_y(packed)))
-        K.ptx.st.global_.v4.b32(
-            destination.ptr_to([destination_base]), words[0], words[1], words[2], words[3]
-        )
+        K.ptx.st.global_.v4.b32(destination_ptr, words[0], words[1], words[2], words[3])
     elif PHILOX_ROUNDS > 0:
         packed_words = K.alloc_local((4,), "uint32")
         with K.unroll(4) as pair:
             packed = values[pair_base + pair]
-            K.ptx.cvt.rs.f16x2.f32(
+            _simple._cvt_rs_f16x2_f32(
                 packed_words[pair],
                 K.cuda.float2_y(packed),
                 K.cuda.float2_x(packed),
                 random_words[random_base + pair // 2 * 4 + pair % 2],
             )
         K.ptx.st.global_.v4.b32(
-            destination.ptr_to([destination_base]),
-            packed_words[0],
-            packed_words[1],
-            packed_words[2],
-            packed_words[3],
+            destination_ptr, packed_words[0], packed_words[1], packed_words[2], packed_words[3]
         )
     else:
         bits = K.alloc_local((8,), "uint16")
@@ -127,9 +125,7 @@ def _store_state_tile(
                 K.ptx.mov.b16(bits[pair * 2 + 1], f32_f16_1)
         with K.unroll(4) as word:
             K.ptx.mov.b32(words[word], bits[word * 2], bits[word * 2 + 1])
-        K.ptx.st.global_.v4.b32(
-            destination.ptr_to([destination_base]), words[0], words[1], words[2], words[3]
-        )
+        K.ptx.st.global_.v4.b32(destination_ptr, words[0], words[1], words[2], words[3])
 
 
 BENCH_CONFIGS = [
@@ -275,6 +271,7 @@ def _specialization(config: dict[str, Any]) -> dict[str, Any]:
         "ELEMS_PER_TILE": elems_per_tile,
         "NUM_TILES": num_tiles,
         "HAS_STATE_INDICES": bool(config.get("has_state_indices", True)),
+        "HAS_DST_INDICES": bool(config.get("has_dst_indices", False)),
         "HAS_INTERMEDIATE_STATES": bool(config.get("has_intermediate_states", False)),
         "HAS_Z": bool(config.get("has_z", False)),
         "HAS_D": bool(config.get("has_d", True)),
@@ -294,8 +291,264 @@ def _specialization(config: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _use_simple_dispatch(spec: dict[str, Any], arch: str) -> bool:
+    if not arch.startswith("sm_110") or spec["HAS_DST_INDICES"]:
+        return False
+    shape = (
+        spec["BATCH"],
+        spec["NHEADS"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+        spec["STATE_DTYPE"],
+    )
+    return (
+        shape == (1, 64, 64, 128, 6, 8, "bfloat16")
+        or (
+            shape in ((2, 64, 64, 128, 6, 8, "bfloat16"), (128, 64, 64, 128, 6, 8, "bfloat16"))
+            and not spec["UPDATE_STATE"]
+        )
+        or (
+            shape
+            in (
+                (1, 64, 64, 128, 6, 8, "float32"),
+                (2, 64, 64, 128, 6, 8, "float32"),
+                (4, 64, 64, 128, 6, 8, "float32"),
+            )
+            and not spec["UPDATE_STATE"]
+        )
+        or (
+            spec["BATCH"],
+            spec["NHEADS"],
+            spec["DIM"],
+            spec["DSTATE"],
+            spec["NTOKENS"],
+            spec["HEADS_PER_GROUP"],
+            spec["STATE_DTYPE"],
+            spec["WEIGHT_DTYPE"],
+        )
+        == (64, 64, 64, 128, 4, 8, "bfloat16", "bfloat16")
+        or (
+            spec["BATCH"],
+            spec["NHEADS"],
+            spec["DIM"],
+            spec["DSTATE"],
+            spec["NTOKENS"],
+            spec["HEADS_PER_GROUP"],
+            spec["STATE_DTYPE"],
+        )
+        in (
+            (64, 64, 128, 128, 4, 8, "bfloat16"),
+            (64, 64, 64, 128, 4, 8, "bfloat16"),
+            (64, 64, 64, 128, 2, 8, "bfloat16"),
+            (64, 64, 64, 128, 8, 8, "bfloat16"),
+            (64, 64, 64, 128, 4, 1, "bfloat16"),
+            (64, 64, 64, 96, 4, 8, "bfloat16"),
+            (64, 64, 64, 64, 4, 8, "bfloat16"),
+        )
+        or (shape == (64, 64, 64, 128, 4, 8, "float16") and spec["PHILOX_ROUNDS"] == 0)
+        or (
+            (spec["INDEX_DTYPE"] == "int32" or spec["HAS_INTERMEDIATE_STATES"])
+            and (
+                spec["BATCH"],
+                spec["NHEADS"],
+                spec["DIM"],
+                spec["DSTATE"],
+                spec["NTOKENS"],
+                spec["HEADS_PER_GROUP"],
+                spec["STATE_DTYPE"],
+            )
+            == (64, 64, 64, 128, 4, 8, "bfloat16")
+        )
+    )
+
+
+def _simple_ptxas_level(spec: dict[str, Any], arch: str) -> str | None:
+    if not arch.startswith("sm_110"):
+        return None
+    shape = (
+        spec["BATCH"],
+        spec["NHEADS"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+        spec["STATE_DTYPE"],
+    )
+    if shape == (64, 64, 64, 128, 8, 8, "bfloat16"):
+        return "5"
+    if shape == (64, 64, 64, 128, 4, 1, "bfloat16"):
+        return "2"
+    if shape == (64, 64, 64, 96, 4, 8, "bfloat16"):
+        return "5"
+    if shape == (64, 64, 64, 128, 4, 8, "bfloat16") and spec["HAS_INTERMEDIATE_STATES"]:
+        return "9"
+    if shape == (64, 64, 64, 64, 4, 8, "bfloat16") or (
+        shape == (64, 64, 64, 128, 4, 8, "bfloat16") and spec["INDEX_DTYPE"] == "int32"
+    ):
+        return "7"
+    return None
+
+
+def _simple_min_blocks_per_sm(spec: dict[str, Any], arch: str) -> int | None:
+    if not arch.startswith("sm_110"):
+        return None
+    shape = (
+        spec["BATCH"],
+        spec["NHEADS"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+        spec["STATE_DTYPE"],
+    )
+    if shape == (64, 64, 64, 128, 4, 8, "bfloat16") and spec["HAS_INTERMEDIATE_STATES"]:
+        return 2
+    if shape == (64, 64, 64, 128, 4, 8, "bfloat16") and spec["UPDATE_STATE"]:
+        return 2
+    return None
+
+
+def _ptxas_level(spec: dict[str, Any], arch: str) -> str:
+    ptxas_level = "10"
+    if (
+        arch.startswith("sm_110")
+        and spec["HAS_INTERMEDIATE_STATES"]
+        and (spec["BATCH"], spec["DIM"], spec["DSTATE"], spec["NTOKENS"], spec["HEADS_PER_GROUP"])
+        == (64, 64, 128, 4, 8)
+    ):
+        ptxas_level = "6"
+    elif (
+        arch.startswith("sm_110")
+        and spec["WEIGHT_DTYPE"] == "bfloat16"
+        and (spec["BATCH"], spec["DIM"], spec["DSTATE"], spec["NTOKENS"], spec["HEADS_PER_GROUP"])
+        == (64, 64, 128, 4, 8)
+    ):
+        ptxas_level = "9"
+    elif (
+        arch.startswith("sm_110")
+        and spec["INDEX_DTYPE"] == "int32"
+        and (spec["BATCH"], spec["DIM"], spec["DSTATE"], spec["NTOKENS"], spec["HEADS_PER_GROUP"])
+        == (64, 64, 128, 4, 8)
+    ):
+        ptxas_level = "9"
+    elif (
+        arch.startswith("sm_110")
+        and spec["HAS_Z"]
+        and (spec["BATCH"], spec["DIM"], spec["DSTATE"], spec["NTOKENS"], spec["HEADS_PER_GROUP"])
+        == (64, 64, 128, 4, 8)
+    ):
+        ptxas_level = "8"
+    elif (
+        arch.startswith("sm_110")
+        and spec["STATE_DTYPE"] == "bfloat16"
+        and (spec["BATCH"], spec["DIM"], spec["DSTATE"], spec["NTOKENS"], spec["HEADS_PER_GROUP"])
+        == (64, 64, 64, 4, 8)
+    ):
+        ptxas_level = "9"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+        spec["STATE_DTYPE"],
+    ) == (64, 128, 128, 4, 8, "bfloat16"):
+        ptxas_level = "6"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+    ) == (64, 64, 128, 8, 8):
+        ptxas_level = "3"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+    ) == (64, 64, 128, 4, 16):
+        ptxas_level = "2"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+    ) == (64, 64, 128, 4, 64):
+        ptxas_level = "5"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+    ) == (64, 64, 128, 4, 1):
+        ptxas_level = "5"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+    ) == (64, 64, 128, 2, 8):
+        ptxas_level = "4"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+    ) == (64, 64, 128, 1, 8):
+        ptxas_level = "0"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["NHEADS"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+        spec["STATE_DTYPE"],
+    ) == (1, 64, 64, 128, 6, 8, "float32"):
+        ptxas_level = "5"
+    elif arch.startswith("sm_110") and (
+        spec["BATCH"],
+        spec["DIM"],
+        spec["DSTATE"],
+        spec["NTOKENS"],
+        spec["HEADS_PER_GROUP"],
+        spec["STATE_DTYPE"],
+    ) == (64, 64, 128, 4, 8, "bfloat16"):
+        ptxas_level = "0"
+    elif arch.startswith("sm_110") and spec["STATE_DTYPE"] == "float16":
+        ptxas_level = "9"
+    return ptxas_level
+
+
 def get_kernel(**kwargs: Any):
     spec = _specialization(kwargs)
+    arch = os.environ.get(PREPARE_CUDA_ARCH_ENV, "")
+    if _use_simple_dispatch(spec, arch):
+        simple_kwargs = dict(kwargs)
+        simple_kwargs["_assume_no_pad"] = int(kwargs.get("pad_every", 0)) == 0
+        simple_kwargs["_schedule_heads_first"] = spec["BATCH"] >= 64
+        if (
+            spec["BATCH"],
+            spec["NHEADS"],
+            spec["DIM"],
+            spec["DSTATE"],
+            spec["NTOKENS"],
+            spec["HEADS_PER_GROUP"],
+            spec["STATE_DTYPE"],
+        ) == (1, 64, 64, 128, 6, 8, "float32"):
+            simple_kwargs["_ctas_per_head"] = 1
+        min_blocks = _simple_min_blocks_per_sm(spec, arch)
+        if min_blocks is not None:
+            simple_kwargs["_min_blocks_per_sm"] = min_blocks
+        return _simple.get_kernel(**simple_kwargs)
     NHEADS = spec["NHEADS"]
     DIM = spec["DIM"]
     DSTATE = spec["DSTATE"]
@@ -319,8 +572,130 @@ def get_kernel(**kwargs: Any):
     STATE_DTYPE = spec["STATE_DTYPE"]
     WEIGHT_DTYPE = spec["WEIGHT_DTYPE"]
     INDEX_DTYPE = spec["INDEX_DTYPE"]
+    thor_bf16_shape = arch.startswith("sm_110") and STATE_DTYPE == "bfloat16"
+    use_direct_state_index = thor_bf16_shape and (
+        (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP)
+        in ((64, 128, 128, 4, 8), (64, 64, 128, 4, 16), (64, 64, 64, 4, 8))
+        or (
+            INDEX_DTYPE == "int32"
+            and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
+        )
+    )
+    use_direct_bc_index = thor_bf16_shape and (
+        (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP)
+        in ((64, 128, 128, 4, 8), (64, 64, 128, 4, 16), (64, 64, 64, 4, 8))
+        or (
+            (HAS_INTERMEDIATE_STATES or WEIGHT_DTYPE == "bfloat16")
+            and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
+        )
+    )
+    use_zero_sleep_wait = thor_bf16_shape and (
+        (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP)
+        in (
+            (64, 128, 128, 4, 8),
+            (64, 64, 128, 4, 16),
+            (64, 64, 128, 4, 64),
+            (64, 64, 64, 4, 8),
+            (64, 64, 96, 4, 8),
+            (64, 64, 128, 2, 8),
+        )
+        or (
+            (INDEX_DTYPE == "int32" or WEIGHT_DTYPE == "bfloat16" or HAS_Z)
+            and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
+        )
+    )
+    min_blocks = 7
+    if arch.startswith("sm_110"):
+        if HAS_INTERMEDIATE_STATES:
+            min_blocks = 6
+        elif (
+            STATE_DTYPE == "float16"
+            and PHILOX_ROUNDS == 0
+            and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
+        ):
+            min_blocks = 5
+        elif (
+            spec["BATCH"],
+            DIM,
+            DSTATE,
+            NTOKENS,
+            HEADS_PER_GROUP,
+            STATE_DTYPE,
+            WEIGHT_DTYPE,
+            INDEX_DTYPE,
+            HAS_Z,
+            HAS_D,
+            HAS_DT_BIAS,
+            UPDATE_STATE,
+        ) == (64, 64, 128, 4, 8, "bfloat16", "float32", "int64", False, True, True, True):
+            min_blocks = 10
+        elif (
+            STATE_DTYPE == "bfloat16"
+            and WEIGHT_DTYPE == "bfloat16"
+            and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
+        ):
+            min_blocks = 10
+        elif (
+            STATE_DTYPE == "bfloat16"
+            and INDEX_DTYPE == "int32"
+            and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
+        ):
+            min_blocks = 5
+        elif (
+            STATE_DTYPE == "bfloat16"
+            and HAS_Z
+            and (spec["BATCH"], DIM, DSTATE, NTOKENS, HEADS_PER_GROUP) == (64, 64, 128, 4, 8)
+        ):
+            min_blocks = 5
+        elif STATE_DTYPE == "bfloat16" and (spec["BATCH"], DIM, DSTATE, NTOKENS) in (
+            (64, 64, 64, 4),
+            (64, 64, 128, 2),
+        ):
+            min_blocks = 7 if DSTATE == 64 else 8
+        elif STATE_DTYPE == "bfloat16" and (
+            spec["BATCH"],
+            DIM,
+            DSTATE,
+            NTOKENS,
+            HEADS_PER_GROUP,
+        ) == (64, 64, 128, 8, 8):
+            min_blocks = 9
+        elif STATE_DTYPE == "bfloat16" and (
+            spec["BATCH"],
+            DIM,
+            DSTATE,
+            NTOKENS,
+            HEADS_PER_GROUP,
+        ) == (64, 64, 128, 4, 1):
+            min_blocks = 8
+        elif STATE_DTYPE == "bfloat16" and (
+            spec["BATCH"],
+            DIM,
+            DSTATE,
+            NTOKENS,
+            HEADS_PER_GROUP,
+        ) == (64, 64, 128, 4, 16):
+            min_blocks = 6
+        elif STATE_DTYPE == "bfloat16" and (
+            spec["BATCH"],
+            DIM,
+            DSTATE,
+            NTOKENS,
+            HEADS_PER_GROUP,
+        ) == (64, 128, 128, 4, 8):
+            min_blocks = 10
+        elif STATE_DTYPE == "bfloat16" and (
+            spec["BATCH"],
+            DIM,
+            DSTATE,
+            NTOKENS,
+            HEADS_PER_GROUP,
+        ) == (64, 64, 128, 4, 64):
+            min_blocks = 5
 
-    @K.kernel(warps=5, arch="sm_100a", min_blocks_per_sm=7, grid=(spec["BATCH"], spec["NHEADS"]))
+    @K.kernel(
+        warps=5, arch="sm_100a", min_blocks_per_sm=min_blocks, grid=(spec["BATCH"], spec["NHEADS"])
+    )
     def selective_state_update_mtp_horizontal(
         tensor_state: K.TensorMap,
         tensor_b: K.TensorMap,
@@ -405,6 +780,8 @@ def get_kernel(**kwargs: Any):
 
         s_b_words = s_b.view("uint32")
         s_c_words = s_c.view("uint32")
+        if use_direct_state_index:
+            s_state_values = s_state_words.view(STATE_DTYPE)
         empty_barriers = empty.buf
         full_barriers = full.buf
         out_ready_barrier = out_ready.buf
@@ -416,10 +793,9 @@ def get_kernel(**kwargs: Any):
             if PHILOX_ROUNDS > 0 and not IS_PAD:
                 K.ptx.ld.global_.s64(random_seed, rand_seed.ptr_to([0]))
 
-            icache_idx = K.local_scalar("int64", init=state_batch)
             if HAS_INTERMEDIATE_STATES and not IS_PAD:
-                K.assign(
-                    icache_idx, _global_load_index_s64(intermediate_indices, batch_i, INDEX_DTYPE)
+                icache_idx = K.local_scalar(
+                    "int64", init=_global_load_index_s64(intermediate_indices, batch_i, INDEX_DTYPE)
                 )
 
             gload_0 = K.local_scalar("uint32")
@@ -473,7 +849,9 @@ def get_kernel(**kwargs: Any):
             state_pipe = K.PipelineState(2, phase=0)
             with K.unroll(NUM_TMA_LOADS) as tl:
                 _mbarrier_arrive_wait_parity(
-                    full_barriers.ptr_to([state_pipe.stage]), state_pipe.phase
+                    full_barriers.ptr_to([state_pipe.stage]),
+                    state_pipe.phase,
+                    zero_sleep=use_zero_sleep_wait,
                 )
 
                 with K.serial(2) as sp:
@@ -487,16 +865,26 @@ def get_kernel(**kwargs: Any):
                         with K.If(K.And(K.Not(IS_PAD), member_col < DSTATE)):
                             with K.Then():
                                 state_words = K.alloc_local((4,), "uint32")
-                                state_word_index: K.int32 = (
-                                    state_pipe.stage * STATE_STAGE_BYTES
-                                    + (sram_row * DSTATE_PAD + member_col) * STATE_BYTES
-                                ) // 4
+                                if use_direct_state_index:
+                                    state_address = s_state_values.ptr_to(
+                                        [
+                                            state_pipe.stage * (STATE_STAGE_BYTES // STATE_BYTES)
+                                            + sram_row * DSTATE_PAD
+                                            + member_col
+                                        ]
+                                    )
+                                else:
+                                    state_word_index: K.int32 = (
+                                        state_pipe.stage * STATE_STAGE_BYTES
+                                        + (sram_row * DSTATE_PAD + member_col) * STATE_BYTES
+                                    ) // 4
+                                    state_address = s_state_words.ptr_to([state_word_index])
                                 K.ptx.ld.shared.v4.b32(
                                     state_words[0],
                                     state_words[1],
                                     state_words[2],
                                     state_words[3],
-                                    s_state_words.ptr_to([state_word_index]),
+                                    state_address,
                                 )
                                 with K.unroll(PAIRS_PER_TILE_MEMBER) as pair:
                                     if STATE_DTYPE == "bfloat16":
@@ -566,15 +954,23 @@ def get_kernel(**kwargs: Any):
                                     group_words[random_word],
                                 )
 
-                    bc_step_words = K.local_scalar("int32", init=0)
+                    bc_step = K.local_scalar("int32", init=0)
                     x_step = K.local_scalar("int32", init=0)
                     dt_step = K.local_scalar("int32", init=0)
                     out_step = K.local_scalar("int32", init=0)
-                    intermediate_step_base = K.local_scalar(
-                        "int64",
-                        init=icache_idx * K.int64(NTOKENS * NHEADS * DIM * DSTATE)
-                        + K.cast(head * DIM * DSTATE + dd * DSTATE, "int64"),
-                    )
+                    if HAS_INTERMEDIATE_STATES and not IS_PAD:
+                        intermediate_step_addr = K.local_scalar(
+                            "uint64",
+                            init=K.reinterpret(
+                                "uint64",
+                                intermediate_states.ptr_to(
+                                    [
+                                        icache_idx * K.int64(NTOKENS * NHEADS * DIM * DSTATE)
+                                        + K.cast(head * DIM * DSTATE + dd * DSTATE, "int64")
+                                    ]
+                                ),
+                            ),
+                        )
 
                     with K.serial(NTOKENS) as step:
                         dt_value = K.local_scalar("float32")
@@ -606,29 +1002,23 @@ def get_kernel(**kwargs: Any):
                             with K.If(member_col < DSTATE), K.Then():
                                 b_words = K.alloc_local((4,), "uint32")
                                 c_words = K.alloc_local((4,), "uint32")
-                                b_word_index: K.int32 = bc_step_words + member_col // 2
-                                c_word_index: K.int32 = bc_step_words + member_col // 2
+                                if use_direct_bc_index:
+                                    b_address = s_b.ptr_to([bc_step + member_col])
+                                    c_address = s_c.ptr_to([bc_step + member_col])
+                                else:
+                                    b_word_index: K.int32 = bc_step + member_col // 2
+                                    c_word_index: K.int32 = bc_step + member_col // 2
+                                    b_address = s_b_words.ptr_to([b_word_index])
+                                    c_address = s_c_words.ptr_to([c_word_index])
                                 if PAIRS_PER_TILE_MEMBER == 2:
-                                    K.ptx.ld.shared.v2.b32(
-                                        b_words[0], b_words[1], s_b_words.ptr_to([b_word_index])
-                                    )
-                                    K.ptx.ld.shared.v2.b32(
-                                        c_words[0], c_words[1], s_c_words.ptr_to([c_word_index])
-                                    )
+                                    K.ptx.ld.shared.v2.b32(b_words[0], b_words[1], b_address)
+                                    K.ptx.ld.shared.v2.b32(c_words[0], c_words[1], c_address)
                                 else:
                                     K.ptx.ld.shared.v4.b32(
-                                        b_words[0],
-                                        b_words[1],
-                                        b_words[2],
-                                        b_words[3],
-                                        s_b_words.ptr_to([b_word_index]),
+                                        b_words[0], b_words[1], b_words[2], b_words[3], b_address
                                     )
                                     K.ptx.ld.shared.v4.b32(
-                                        c_words[0],
-                                        c_words[1],
-                                        c_words[2],
-                                        c_words[3],
-                                        s_c_words.ptr_to([c_word_index]),
+                                        c_words[0], c_words[1], c_words[2], c_words[3], c_address
                                     )
                                 with K.unroll(PAIRS_PER_TILE_MEMBER) as pair:
                                     b_pair: K.uint64 = _bf16_word_to_f32x2(b_words[pair])
@@ -665,7 +1055,10 @@ def get_kernel(**kwargs: Any):
                                 s_out.ptr_to([out_step + dd]), K.reinterpret("uint32", fma_0)
                             )
 
-                        K.assign(bc_step_words, bc_step_words + DSTATE_PAD // 2)
+                        K.assign(
+                            bc_step,
+                            bc_step + (DSTATE_PAD if use_direct_bc_index else DSTATE_PAD // 2),
+                        )
                         K.assign(x_step, x_step + DIM)
                         K.assign(dt_step, dt_step + 1)
                         K.assign(out_step, out_step + DIM)
@@ -681,45 +1074,48 @@ def get_kernel(**kwargs: Any):
                                         tile * PAIRS_PER_TILE_MEMBER,
                                         random_words,
                                         tile * 8,
-                                        intermediate_states,
-                                        intermediate_step_base + member_col,
+                                        K.reinterpret(
+                                            PointerType(PrimType(STATE_DTYPE), "global"),
+                                            intermediate_step_addr
+                                            + K.cast(member_col * STATE_BYTES, "uint64"),
+                                        ),
                                         STATE_DTYPE=STATE_DTYPE,
                                         PAIRS_PER_TILE_MEMBER=PAIRS_PER_TILE_MEMBER,
                                         PHILOX_ROUNDS=PHILOX_ROUNDS,
                                     )
                             K.assign(
-                                intermediate_step_base,
-                                intermediate_step_base + K.int64(NHEADS * DIM * DSTATE),
+                                intermediate_step_addr,
+                                intermediate_step_addr
+                                + K.uint64(NHEADS * DIM * DSTATE * STATE_BYTES),
                             )
 
-                        with (
-                            K.If(K.And(K.And(UPDATE_STATE, step == NTOKENS - 1), K.Not(IS_PAD))),
-                            K.Then(),
-                        ):
-                            final_base: K.int64 = state_batch * state_stride_batch + K.cast(
-                                head * DIM * DSTATE + dd * DSTATE, "int64"
-                            )
-                            with K.unroll(NUM_TILES) as tile:
-                                member_col: K.int32 = (
-                                    tile * ELEMS_PER_TILE + member * ELEMS_PER_TILE_MEMBER
+                        if UPDATE_STATE and not IS_PAD:
+                            with K.If(step == NTOKENS - 1), K.Then():
+                                final_base: K.int64 = state_batch * state_stride_batch + K.cast(
+                                    head * DIM * DSTATE + dd * DSTATE, "int64"
                                 )
-                                with K.If(member_col < DSTATE), K.Then():
-                                    _store_state_tile(
-                                        state_values,
-                                        tile * PAIRS_PER_TILE_MEMBER,
-                                        random_words,
-                                        tile * 8,
-                                        state,
-                                        final_base + member_col,
-                                        STATE_DTYPE=STATE_DTYPE,
-                                        PAIRS_PER_TILE_MEMBER=PAIRS_PER_TILE_MEMBER,
-                                        PHILOX_ROUNDS=PHILOX_ROUNDS,
+                                with K.unroll(NUM_TILES) as tile:
+                                    member_col: K.int32 = (
+                                        tile * ELEMS_PER_TILE + member * ELEMS_PER_TILE_MEMBER
                                     )
+                                    with K.If(member_col < DSTATE), K.Then():
+                                        _store_state_tile(
+                                            state_values,
+                                            tile * PAIRS_PER_TILE_MEMBER,
+                                            random_words,
+                                            tile * 8,
+                                            state.ptr_to([final_base + member_col]),
+                                            STATE_DTYPE=STATE_DTYPE,
+                                            PAIRS_PER_TILE_MEMBER=PAIRS_PER_TILE_MEMBER,
+                                            PHILOX_ROUNDS=PHILOX_ROUNDS,
+                                        )
 
                 K.ptx.mbarrier.arrive.shared__cta.b64(empty_barriers.ptr_to([state_pipe.stage]))
                 state_pipe.advance()
 
-            _mbarrier_arrive_wait_parity(out_ready_barrier.ptr_to([0]), 0)
+            _mbarrier_arrive_wait_parity(
+                out_ready_barrier.ptr_to([0]), 0, zero_sleep=use_zero_sleep_wait
+            )
             with K.unroll((NTOKENS + 3) // 4) as episode:
                 step: K.int32 = compute_warp + episode * 4
                 with K.If(step < NTOKENS), K.Then():
@@ -840,7 +1236,9 @@ def get_kernel(**kwargs: Any):
             state_pipe = K.PipelineState(2, phase=0)
             with K.unroll(NUM_TMA_LOADS) as tl:
                 _mbarrier_arrive_wait_parity(
-                    empty_barriers.ptr_to([state_pipe.stage]), state_pipe.phase
+                    empty_barriers.ptr_to([state_pipe.stage]),
+                    state_pipe.phase,
+                    zero_sleep=use_zero_sleep_wait,
                 )
                 with K.If(lane == 0), K.Then():
                     if not IS_PAD:
@@ -1002,6 +1400,8 @@ def prepare_data(**kwargs: Any) -> dict[str, Any]:
 
 
 def _tirx_args(case: dict[str, Any]) -> tuple[Any, ...]:
+    if _use_simple_dispatch(case["spec"], os.environ.get(PREPARE_CUDA_ARCH_ENV, "")):
+        return _simple._tirx_args(case)
     maps = case["tensor_maps"]
     return (
         maps["state"].ptr,
@@ -1067,11 +1467,33 @@ def _run_reference(case: dict[str, Any]) -> torch.Tensor:
     return result
 
 
+def _compile_tirx(config: dict[str, Any]):
+    from tirx_kernels.runner import compile_kernel
+
+    arch = os.environ.get(PREPARE_CUDA_ARCH_ENV, "")
+    spec = _specialization(config)
+    ptxas_level = (
+        _simple_ptxas_level(spec, arch)
+        if _use_simple_dispatch(spec, arch)
+        else _ptxas_level(spec, arch)
+    )
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    if ptxas_level is not None:
+        os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = ptxas_level
+    try:
+        return compile_kernel(get_kernel(**config))
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
 def prepare_bench(**kwargs: Any):
     """Specialize and compile before the workload receives a GPU."""
-    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+    from tirx_kernels.runner import prepared_gpu_benchmark
 
-    state = {"config": dict(kwargs), "executable": compile_kernel(get_kernel(**kwargs))}
+    state = {"config": dict(kwargs), "executable": _compile_tirx(kwargs)}
     return prepared_gpu_benchmark(run_gpu, state)
 
 
@@ -1087,10 +1509,8 @@ def run_test(**kwargs: Any) -> None:
                 ) from error
             return
         raise AssertionError(f"expected horizontal rejection containing {expected_rejection!r}")
-    from tirx_kernels.runner import compile_kernel
-
     case = prepare_data(**kwargs)
-    executable = compile_kernel(get_kernel(**kwargs))
+    executable = _compile_tirx(kwargs)
     executable(*_tirx_args(case))
     torch.cuda.synchronize()
     _run_reference(case)

--- a/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
+++ b/tirx_kernels/flashinfer/mamba/selective_state_update_mtp_simple.py
@@ -416,8 +416,10 @@ def _specialization(config: dict[str, Any]) -> dict[str, Any]:
     total_tiles = max(batch * nheads, 1)
     requested_ctas = max(1, min(target_ctas // total_tiles, dim // 16))
     ctas_per_head = 4 if requested_ctas >= 4 else 2 if requested_ctas >= 2 else 1
+    if "_ctas_per_head" in config:
+        ctas_per_head = int(config["_ctas_per_head"])
     dim_per_cta = dim // ctas_per_head
-    if dim % ctas_per_head or dim_per_cta % 16:
+    if ctas_per_head not in (1, 2, 4) or dim % ctas_per_head or dim_per_cta % 16:
         raise ValueError("MTP simple requires DIM_PER_CTA to be a multiple of 16")
     num_passes = dim_per_cta // 16
     state_stages = 1 if num_passes == 1 else 2
@@ -446,6 +448,7 @@ def _specialization(config: dict[str, Any]) -> dict[str, Any]:
         "ELEMS_PER_TILE": elems_per_tile,
         "NUM_TILES": num_tiles,
         "HAS_STATE_INDICES": bool(config.get("has_state_indices", True)),
+        "ASSUME_NO_PAD": bool(config.get("_assume_no_pad", False)),
         "HAS_DST_INDICES": bool(config.get("has_dst_indices", False)),
         "HAS_INTERMEDIATE_STATES": bool(config.get("has_intermediate_states", False)),
         "HAS_INTERMEDIATE_INDICES": bool(config.get("has_intermediate_states", False)),
@@ -454,6 +457,8 @@ def _specialization(config: dict[str, Any]) -> dict[str, Any]:
         "HAS_Z": bool(config.get("has_z", False)),
         "HAS_D": bool(config.get("has_d", True)),
         "HAS_DT_BIAS": bool(config.get("has_dt_bias", True)),
+        "DT_SOFTPLUS": bool(config.get("dt_softplus", True)),
+        "UPDATE_STATE": bool(config.get("update_state", True)),
         "SCALE_STATE": scale_state,
         "PHILOX_ROUNDS": philox_rounds,
         # K allocates s_out immediately after a 128-byte-aligned x tile and
@@ -484,13 +489,17 @@ def _specialization(config: dict[str, Any]) -> dict[str, Any]:
 def get_kernel(**kwargs: Any):
     """Build the K entry for one MTP simple specialization."""
     spec = _specialization(kwargs)
+    schedule_heads_first = bool(kwargs.get("_schedule_heads_first", False))
+    min_blocks_per_sm = int(kwargs.get("_min_blocks_per_sm", 0))
 
     ACCEPTED_DTYPE = spec["ACCEPTED_DTYPE"]
+    ASSUME_NO_PAD = spec["ASSUME_NO_PAD"]
     CU_SEQLENS_DTYPE = spec["CU_SEQLENS_DTYPE"]
     DIM = spec["DIM"]
     DIM_PER_CTA = spec["DIM_PER_CTA"]
     DSTATE = spec["DSTATE"]
     DSTATE_PAD = spec["DSTATE_PAD"]
+    DT_SOFTPLUS = spec["DT_SOFTPLUS"]
     ELEMS_PER_TILE = spec["ELEMS_PER_TILE"]
     ELEMS_PER_TILE_MEMBER = spec["ELEMS_PER_TILE_MEMBER"]
     HAS_CU_SEQLENS = spec["HAS_CU_SEQLENS"]
@@ -515,9 +524,22 @@ def get_kernel(**kwargs: Any):
     STATE_BYTES = spec["STATE_BYTES"]
     STATE_DTYPE = spec["STATE_DTYPE"]
     STATE_STAGES = spec["STATE_STAGES"]
+    UPDATE_STATE = spec["UPDATE_STATE"]
     WEIGHT_DTYPE = spec["WEIGHT_DTYPE"]
 
-    @K.kernel(warps=4, arch="sm_100a", grid=(spec["BATCH"], spec["NHEADS"], spec["CTAS_PER_HEAD"]))
+    kernel_options = {
+        "warps": 4,
+        "arch": "sm_100a",
+        "grid": (
+            (spec["NHEADS"], spec["BATCH"], spec["CTAS_PER_HEAD"])
+            if schedule_heads_first
+            else (spec["BATCH"], spec["NHEADS"], spec["CTAS_PER_HEAD"])
+        ),
+    }
+    if min_blocks_per_sm:
+        kernel_options["min_blocks_per_sm"] = min_blocks_per_sm
+
+    @K.kernel(**kernel_options)
     def selective_state_update_mtp_simple(
         state: K.gptr[spec["STATE_DTYPE"]],
         state_scale: K.gptr[K.f32],
@@ -563,7 +585,11 @@ def get_kernel(**kwargs: Any):
         update_state: K.i32,
         pad_slot_id: K.i32,
     ):
-        seq_idx, head, cta_z = K.cta_id()
+        cta_x, cta_y, cta_z = K.cta_id()
+        if schedule_heads_first:
+            head, seq_idx = cta_x, cta_y
+        else:
+            seq_idx, head = cta_x, cta_y
         smem = K.smem_pool()
         s_b = smem.alloc((spec["NTOKENS"] * spec["DSTATE_PAD"],), K.bf16, align=128)
         s_c = smem.alloc((spec["NTOKENS"] * spec["DSTATE_PAD"],), K.bf16, align=128)
@@ -586,6 +612,7 @@ def get_kernel(**kwargs: Any):
         kv_group = head // HEADS_PER_GROUP
         bos = K.local_scalar("int32")
         seq_len = K.local_scalar("int32")
+        active_seq_len = seq_len if HAS_CU_SEQLENS else NTOKENS
         is_pad = K.local_scalar("int32")
         state_ptr_offset_i32 = K.local_scalar("int32")
         state_batch = K.local_scalar("int64")
@@ -636,7 +663,10 @@ def get_kernel(**kwargs: Any):
                 )
             else:
                 K.assign(state_batch, K.cast(seq_idx, "int64"))
-            K.assign(is_pad, K.if_then_else(state_batch != K.cast(pad_slot_id, "int64"), 0, 1))
+            if ASSUME_NO_PAD:
+                K.assign(is_pad, 0)
+            else:
+                K.assign(is_pad, K.if_then_else(state_batch != K.cast(pad_slot_id, "int64"), 0, 1))
             K.assign(
                 state_head_offset,
                 state_batch * state_stride_batch + K.cast(head * DIM * DSTATE, "int64"),
@@ -675,7 +705,7 @@ def get_kernel(**kwargs: Any):
                 with K.If(packed_i < NTOKENS * DSTATE // 8), K.Then():
                     step: K.int32 = packed_i // (DSTATE // 8)
                     col: K.int32 = packed_i % (DSTATE // 8) * 8
-                    with K.If(step < seq_len), K.Then():
+                    with K.If(step < active_seq_len), K.Then():
                         K.ptx["cp.async.cg.shared.global"](
                             s_dst.ptr_to([step * DSTATE_PAD + col]),
                             src.ptr_to(
@@ -710,7 +740,7 @@ def get_kernel(**kwargs: Any):
         def update_sequence(IS_PAD: K.constexpr):
             with K.serial((NTOKENS + 3) // 4) as step_iter:
                 step: K.int32 = warp + step_iter * 4
-                with K.If(step < seq_len), K.Then():
+                with K.If(step < active_seq_len), K.Then():
                     with K.serial((DIM_PER_CTA // 8 + 31) // 32) as col_iter:
                         col: K.int32 = (lane + col_iter * 32) * 8
                         with K.If(col < DIM_PER_CTA), K.Then():
@@ -746,7 +776,7 @@ def get_kernel(**kwargs: Any):
                             16,
                         )
 
-            with K.If(flat_tid < seq_len), K.Then():
+            with K.If(flat_tid < active_seq_len), K.Then():
                 dt_value = K.local_scalar("float32")
                 K.assign(
                     dt_value,
@@ -758,7 +788,7 @@ def get_kernel(**kwargs: Any):
                     K.ptx["add.ftz.f32"](
                         dt_value, dt_value, _load_weight(dt_bias, head, WEIGHT_DTYPE)
                     )
-                with K.If(dt_softplus != 0), K.Then():
+                if DT_SOFTPLUS:
                     with K.If(dt_value <= K.float32(20.0)), K.Then():
                         mul_2 = K.local_scalar("float32")
                         K.ptx["mul.ftz.f32"](mul_2, dt_value, K.float32(_LOG2_E))
@@ -775,7 +805,7 @@ def get_kernel(**kwargs: Any):
             with K.If(flat_tid < NTOKENS), K.Then():
                 step: K.int32 = flat_tid
                 dst_slot = K.local_scalar("int64", init=-1)
-                with K.If(K.And(K.Not(IS_PAD), step < seq_len)), K.Then():
+                with K.If(K.And(K.Not(IS_PAD), step < active_seq_len)), K.Then():
                     if HAS_DST_INDICES:
                         dst_index: K.int64 = _global_load_index_s64(
                             dst_indices,
@@ -795,8 +825,8 @@ def get_kernel(**kwargs: Any):
                         K.assign(
                             dst_slot, (intermediate_index * K.cast(cache_steps, "int64") + step)
                         )
-                    else:
-                        with K.If(K.And(step == seq_len - 1, update_state != 0)), K.Then():
+                    elif UPDATE_STATE:
+                        with K.If(step == active_seq_len - 1), K.Then():
                             K.assign(dst_slot, state_batch)
                 K.ptx.st.shared.b64(s_dst_slots.ptr_to([step]), dst_slot)
 
@@ -911,7 +941,7 @@ def get_kernel(**kwargs: Any):
                 dt_step = K.local_scalar("int32", init=0)
                 out_step = K.local_scalar("int32", init=0)
                 with K.serial(NTOKENS) as step:
-                    with K.If(step < seq_len), K.Then():
+                    with K.If(step < active_seq_len), K.Then():
                         dst_slot = K.local_scalar("int64")
                         K.ptx.ld.shared.b64(dst_slot, s_dst_slots.ptr_to([step]))
                         dt_value = K.local_scalar("float32")
@@ -1343,7 +1373,7 @@ def get_kernel(**kwargs: Any):
             K.ptx.bar.sync(K.uint32(0))
             with K.serial((NTOKENS + 3) // 4) as output_iter:
                 step: K.int32 = warp + output_iter * 4
-                with K.If(step < seq_len), K.Then():
+                with K.If(step < active_seq_len), K.Then():
                     out_base = K.local_scalar("int64")
                     z_base = K.local_scalar("int64")
                     if HAS_CU_SEQLENS:
@@ -1482,18 +1512,27 @@ def get_kernel(**kwargs: Any):
                             output_bit: K.uint16 = f32_bf16_2
                             K.ptx.st.global_.b16(output.ptr_to([out_base + lane]), output_bit)
 
-        prepare_sequence()
-        with K.If(seq_len > 0), K.Then():
+        def run_active_sequence():
             prepare_active_sequence()
             with load_b:
                 load_bc_values(s_b, matrix_b, b_base, b_tstride)
             with load_c:
                 load_bc_values(s_c, matrix_c, c_base, c_tstride)
-            with K.If(is_pad != 0):
-                with K.Then():
-                    update_sequence(True)
-                with K.Else():
-                    update_sequence(False)
+            if ASSUME_NO_PAD:
+                update_sequence(False)
+            else:
+                with K.If(is_pad != 0):
+                    with K.Then():
+                        update_sequence(True)
+                    with K.Else():
+                        update_sequence(False)
+
+        prepare_sequence()
+        if HAS_CU_SEQLENS:
+            with K.If(seq_len > 0), K.Then():
+                run_active_sequence()
+        else:
+            run_active_sequence()
 
     return selective_state_update_mtp_simple.func
 

--- a/tirx_kernels/flashinfer/quantization/mxfp4_quantize.py
+++ b/tirx_kernels/flashinfer/quantization/mxfp4_quantize.py
@@ -8,15 +8,13 @@
 Ports ``MXFP4QuantizeLinearKernel`` / ``MXFP4QuantizeSwizzledKernel``
 (``flashinfer/quantization/kernels/mxfp4_quantize.py``), the SM100 CuTe-DSL
 kernels behind ``flashinfer.quantization.mxfp4_quantize(backend="cute-dsl")``.
-The 1T/SF specialization: each thread owns one 32-element SF block — four
-128-bit loads, a 16-word half2/bf16x2 absmax tree, no shuffle reduction, UE8M0
-block scale via ``rcp.approx.ftz(6.0)``, and 32 e2m1 values packed into two
-``st.global.u64`` stores.
+It implements both source thread mappings.  The 1T/SF path assigns one complete
+32-element SF block to each thread.  The 4T/SF path assigns eight adjacent
+elements to each of four cooperating threads and reduces the scale with two
+butterfly shuffles.
 
 In-scope specialization: fp16/bf16 inputs, linear + swizzled 128x4/8x4 SF
-layouts, 1T/SF thread configuration (the source dispatches 4T/SF only when
-``num_sm <= 80``; B200 has 148 SMs, so 4T/SF is unreachable on the accepted
-target and is out of scope), ``enable_pdl=False`` (the griddepcontrol pair is
+layouts, source 1T/SF and 4T/SF host dispatch, ``enable_pdl=False`` (the griddepcontrol pair is
 ported behind the same compile-time knob; TVM launches do not carry the PDL
 launch attribute, so PDL stays off for test/bench parity on both sides).
 
@@ -25,10 +23,12 @@ The implementation structure follows the reviewer-approved sketch
 ``tirx_kernels/flashinfer/utils/fp_quant.py``.
 """
 
+import os
 from typing import Any
 
 import tirx_kernels.kern as K
 from tirx_kernels.flashinfer.utils.fp_quant_kern import (
+    absmax_4,
     absmax_8,
     cvt_e2m1x8,
     float2_scaled,
@@ -39,18 +39,19 @@ from tirx_kernels.flashinfer.utils.fp_quant_kern import (
     pack_u32x2_to_u64,
     pair_max_to_f32,
     rcp_approx_ftz,
+    reduce_max_4threads,
     sf_offset_8x4,
     sf_offset_128x4,
     st_global_u8,
     st_global_u64,
     ue8m0_to_inv_scale,
 )
-from tirx_kernels.runner import bench
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, bench
 
 KERNEL_META = {
     "name": "mxfp4_quantize",
     "category": "flashinfer",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flashinfer-python",
@@ -72,9 +73,12 @@ WARP_SIZE = 32
 _BLOCKS_PER_SM = 4
 _LINEAR_WARPS = 16  # _LINEAR_WARPS_PER_BLOCK
 _LINEAR_SF_BLOCKS_PER_TB = 512  # _LINEAR_SF_BLOCKS_PER_TB (1T/SF)
+_4T_THREADS_PER_SF = 4
+_4T_SF_PER_WARP = 8
+_4T_SF_BLOCKS_PER_TB = 128
 _MIN_THREADS = 128
 _MAX_THREADS = 512
-_LOW_SM_THRESHOLD = 80  # 4T/SF dispatch threshold (unreachable on B200)
+_LOW_SM_THRESHOLD = 80
 _ROW_TILE_128x4 = 128
 _ROW_TILE_8x4 = 8
 
@@ -105,24 +109,29 @@ def _validate(dtype: str, m: int, k: int, sf_layout: str) -> None:
         raise ValueError(f"m={m} must be >= 1")
     if k <= 0 or k % MXFP4_SF_VEC_SIZE != 0:
         raise ValueError(f"k={k} outside the source dispatch domain (k % 32 != 0)")
-    if _sm_count() <= _LOW_SM_THRESHOLD:
-        raise ValueError("sm_count <= 80 dispatches the out-of-scope 4T/SF source path")
 
 
-def _compute_optimal_threads(k: int) -> int:
-    """Mirror ``_compute_optimal_threads`` 1T/SF (mxfp4_quantize.py:115-155)."""
-    threads_per_row = k // MXFP4_SF_VEC_SIZE
-    if threads_per_row > _MAX_THREADS:
-        return _MAX_THREADS
-    largest = (_MAX_THREADS // threads_per_row) * threads_per_row
+def _use_4t() -> bool:
+    """Mirror the source host dispatch for low-SM-count GPUs."""
+    return _sm_count() <= _LOW_SM_THRESHOLD
+
+
+def _compute_optimal_threads(
+    k: int, threads_per_sf: int = 1, max_threads: int = _MAX_THREADS
+) -> int:
+    """Mirror ``_compute_optimal_threads`` (mxfp4_quantize.py:115-155)."""
+    threads_per_row = (k // MXFP4_SF_VEC_SIZE) * threads_per_sf
+    if threads_per_row > max_threads:
+        return max_threads
+    largest = (max_threads // threads_per_row) * threads_per_row
     if largest >= _MIN_THREADS:
         return largest
     candidate = threads_per_row
     while candidate < _MIN_THREADS:
         candidate += threads_per_row
-    if candidate <= _MAX_THREADS:
+    if candidate <= max_threads:
         return candidate
-    return _MAX_THREADS
+    return max_threads
 
 
 def _padded_m(m: int, sf_layout: str) -> int:
@@ -140,23 +149,37 @@ def _sf_numel(m: int, k: int, sf_layout: str) -> int:
     return _padded_m(m, sf_layout) * _padded_sf_cols(k)
 
 
-def _linear_launch(m: int, k: int) -> tuple[int, int, int]:
+def _linear_launch(
+    m: int,
+    k: int,
+    threads_per_sf: int,
+    block_x: int = _LINEAR_WARPS * WARP_SIZE,
+    blocks_per_sm: int = _BLOCKS_PER_SM,
+) -> tuple[int, int, int]:
     """(grid_x, block_x, total_sf_blocks) mirroring mxfp4_quantize.py:963-971."""
     total_sf_blocks = m * (k // MXFP4_SF_VEC_SIZE)
+    sf_blocks_per_tb = block_x // threads_per_sf
     grid = min(
-        (total_sf_blocks + _LINEAR_SF_BLOCKS_PER_TB - 1) // _LINEAR_SF_BLOCKS_PER_TB,
-        _sm_count() * _BLOCKS_PER_SM,
+        (total_sf_blocks + sf_blocks_per_tb - 1) // sf_blocks_per_tb, _sm_count() * blocks_per_sm
     )
-    return grid, _LINEAR_WARPS * WARP_SIZE, total_sf_blocks
+    return grid, block_x, total_sf_blocks
 
 
-def _swizzled_launch(m: int, k: int, sf_layout: str) -> tuple[int, int, int]:
+def _swizzled_launch(
+    m: int,
+    k: int,
+    sf_layout: str,
+    threads_per_sf: int,
+    max_threads: int = _MAX_THREADS,
+    blocks_per_sm: int = _BLOCKS_PER_SM,
+) -> tuple[int, int, int]:
     """(grid_x, block_x, padded_m) mirroring mxfp4_quantize.py:979-986."""
-    threads = _compute_optimal_threads(k)
+    threads = _compute_optimal_threads(k, threads_per_sf, max_threads)
     nsb = k // MXFP4_SF_VEC_SIZE
-    rows_per_block = threads // nsb if nsb <= threads else 1
+    col_units = threads // threads_per_sf
+    rows_per_block = col_units // nsb if nsb <= col_units else 1
     padded_m = _padded_m(m, sf_layout)
-    grid = min((padded_m + rows_per_block - 1) // rows_per_block, _sm_count() * _BLOCKS_PER_SM)
+    grid = min((padded_m + rows_per_block - 1) // rows_per_block, _sm_count() * blocks_per_sm)
     return grid, threads, padded_m
 
 
@@ -193,9 +216,244 @@ def _process_block(in_global, row_idx, col_idx, *, dtype, k):
     return scale_ue8m0_u32, packed64_0, packed64_1
 
 
+def _load_block_4t(words, in_global, row_idx, col_idx, thread_in_sf, *, k):
+    """Issue one 128-bit input load for a 4T/SF thread."""
+    elem_idx = col_idx * MXFP4_SF_VEC_SIZE + thread_in_sf * 8
+    in_off = K.cast(row_idx, "int64") * k + elem_idx
+    K.ptx.ld.global_.v4.b32(words[0], words[1], words[2], words[3], K.address_of(in_global[in_off]))
+
+
+def _float_to_ue8m0_nonnegative(value):
+    """Convert an absmax-derived nonnegative f32 to UE8M0.
+
+    Adding ``0x7fffff`` to a positive normal f32 bit pattern implements the
+    source's round-up-on-any-mantissa rule before extracting the exponent.  The
+    explicit tiny-value select preserves its special subnormal threshold, and
+    clamping the input bits to infinity preserves the source's NaN/Inf result.
+    """
+    bits = K.reinterpret("uint32", value)
+    rounded = K.shift_right(bits + K.uint32(0x7FFFFF), K.uint32(23))
+    rounded = K.min(rounded, K.uint32(254))
+    p_tiny = K.local_scalar("uint32")
+    K.ptx.setp.le.u32(p_tiny, bits, K.uint32(0x400000))
+    out = K.local_scalar("uint32")
+    K.ptx.selp.u32(out, K.uint32(0), rounded, K.ptx.pred(p_tiny))
+    return out
+
+
+def _fp16_block_max_to_ue8m0(value):
+    """Convert an exact FP16-derived nonnegative block max to its MXFP4 scale."""
+    bits = K.reinterpret("uint32", value)
+    rounded_exp = K.shift_right(bits + K.uint32(0x3FFFFF), K.uint32(23))
+    finite = K.max(K.cast(rounded_exp, "int32") - K.int32(2), K.int32(0))
+    special = K.local_scalar("uint32")
+    K.ptx.setp.ge.u32(special, bits, K.uint32(0x7F800000))
+    out = K.local_scalar("uint32")
+    K.ptx.selp.u32(out, K.uint32(254), K.cast(finite, "uint32"), K.ptx.pred(special))
+    return out
+
+
+def _ue8m0_to_inv_scale_bounded(ue8m0_val):
+    """Convert a UE8M0 value known to be in [0, 254] to inverse scale."""
+    p_zero = K.local_scalar("uint32")
+    K.ptx.setp.eq.u32(p_zero, ue8m0_val, K.uint32(0))
+    new_exp = K.uint32(254) - ue8m0_val
+    inv = K.reinterpret("float32", K.shift_left(new_exp, K.uint32(23)))
+    out = K.local_scalar("float32")
+    K.ptx.selp.f32(out, K.float32(0.0), inv, K.ptx.pred(p_zero))
+    return out
+
+
+def _st_scale_4t(addr, scale, thread_in_sf):
+    """Store one scale from the leader lane without a divergent branch."""
+    predicate = K.cast(thread_in_sf == K.int32(0), "uint32")
+    K.ptx.st.global_.b8(addr, K.cast(scale, "uint8"), pred=predicate)
+
+
+def _reduce_absmax_4t_packed(words, dtype):
+    """Reduce a four-thread absmax while it remains packed FP16x2/BF16x2."""
+    packed = absmax_4([words[i] for i in range(4)], dtype)
+    shuffled = K.local_scalar("uint32")
+    K.ptx.shfl_sync.bfly.b32(shuffled, packed, K.uint32(1), K.uint32(31), K.uint32(0xFFFFFFFF))
+    packed = hmax2(packed, shuffled, dtype)
+    K.ptx.shfl_sync.bfly.b32(shuffled, packed, K.uint32(2), K.uint32(31), K.uint32(0xFFFFFFFF))
+    return hmax2(packed, shuffled, dtype)
+
+
+def _fp16_packed_max_to_ue8m0(packed_max):
+    """Convert a packed FP16x2 absmax to the exact source scale.
+
+    Normal FP16 values admit an integer-only exponent formula.  Zero,
+    subnormal, Inf, and NaN values keep the established f32 fallback so their
+    edge-case behavior remains identical to FlashInfer.
+    """
+    lo = K.bitwise_and(packed_max, K.uint32(0xFFFF))
+    hi = K.shift_right(packed_max, K.uint32(16))
+    max_half = K.max(lo, hi)
+    scale = K.local_scalar("uint32")
+    with K.If(K.And(max_half >= K.uint32(0x0400), max_half < K.uint32(0x7C00))):
+        with K.Then():
+            rounded_exp = K.shift_right(max_half + K.uint32(0x01FF), K.uint32(10))
+            K.assign(scale, rounded_exp + K.uint32(110))
+        with K.Else():
+            K.assign(scale, _fp16_block_max_to_ue8m0(pair_max_to_f32(packed_max, "float16")))
+    return scale
+
+
+def _bf16_packed_max_to_ue8m0(packed_max):
+    """Convert a packed BF16x2 absmax to the exact source scale."""
+    lo = K.bitwise_and(packed_max, K.uint32(0xFFFF))
+    hi = K.shift_right(packed_max, K.uint32(16))
+    max_bf16 = K.max(lo, hi)
+    scale = K.local_scalar("uint32")
+    with K.If(K.And(max_bf16 >= K.uint32(0x0080), max_bf16 < K.uint32(0x7F80))):
+        with K.Then():
+            rounded_exp = K.shift_right(max_bf16 + K.uint32(0x003F), K.uint32(7))
+            K.assign(scale, rounded_exp - K.uint32(2))
+        with K.Else():
+            block_max = pair_max_to_f32(packed_max, "bfloat16")
+            K.assign(
+                scale,
+                _float_to_ue8m0_nonnegative(mul_f32(block_max, rcp_approx_ftz(K.float32(6.0)))),
+            )
+    return scale
+
+
+def _cvt_e2m1x8_scaled_packed(words, scale_ue8m0, dtype):
+    """Scale four packed FP16x2/BF16x2 words and convert them directly to FP4."""
+    inv_bias = 142 if dtype == "float16" else 254
+    inv_exp = K.max(K.int32(inv_bias) - K.cast(scale_ue8m0, "int32"), K.int32(0))
+    shift = 10 if dtype == "float16" else 7
+    inv_packed = K.cast(K.shift_left(K.cast(inv_exp, "uint32"), K.uint32(shift)), "uint16")
+    inv_pair = K.local_scalar("uint32")
+    K.ptx.mov.b32(inv_pair, inv_packed, inv_packed)
+
+    bytes_ = K.alloc_local((4,), "uint8")
+    for i in range(4):
+        scaled = K.local_scalar("uint32")
+        if dtype == "float16":
+            K.ptx.mul.rn.f16x2(scaled, words[i], inv_pair)
+            K.ptx.cvt.rn.satfinite.e2m1x2.f16x2(bytes_[i], scaled)
+        else:
+            K.ptx.mul.rn.bf16x2(scaled, words[i], inv_pair)
+            K.ptx.cvt.rn.satfinite.e2m1x2.bf16x2(bytes_[i], scaled)
+
+    w0 = K.cast(bytes_[0], "uint16") | (K.cast(bytes_[1], "uint16") << K.uint16(8))
+    w1 = K.cast(bytes_[2], "uint16") | (K.cast(bytes_[3], "uint16") << K.uint16(8))
+    packed = K.local_scalar("uint32")
+    K.ptx.mov.b32(packed, w0, w1)
+    return packed
+
+
+def _quantize_block_4t(words, *, dtype, fp16_mode=0):
+    """Reduce and quantize one previously loaded fourth of an SF block."""
+    packed_mode = fp16_mode >= 2
+    if packed_mode:
+        packed_max = _reduce_absmax_4t_packed(words, dtype)
+        scale_ue8m0_u32 = (
+            _fp16_packed_max_to_ue8m0(packed_max)
+            if dtype == "float16"
+            else _bf16_packed_max_to_ue8m0(packed_max)
+        )
+    else:
+        local_max = pair_max_to_f32(absmax_4([words[i] for i in range(4)], dtype), dtype)
+        block_max = reduce_max_4threads(local_max)
+        scale_ue8m0_u32 = (
+            _fp16_block_max_to_ue8m0(block_max)
+            if fp16_mode
+            else _float_to_ue8m0_nonnegative(mul_f32(block_max, rcp_approx_ftz(K.float32(6.0))))
+        )
+    if packed_mode:
+        packed_u32 = K.local_scalar("uint32")
+        with K.If(scale_ue8m0_u32 >= K.uint32(112)):
+            with K.Then():
+                K.assign(packed_u32, _cvt_e2m1x8_scaled_packed(words, scale_ue8m0_u32, dtype))
+            with K.Else():
+                inv_scale = _ue8m0_to_inv_scale_bounded(scale_ue8m0_u32)
+                scaled = []
+                for i in range(4):
+                    lo, hi = float2_scaled(words[i], inv_scale, dtype)
+                    scaled.extend((lo, hi))
+                K.assign(packed_u32, cvt_e2m1x8(scaled))
+    else:
+        inv_scale = _ue8m0_to_inv_scale_bounded(scale_ue8m0_u32)
+        scaled = []
+        for i in range(4):
+            lo, hi = float2_scaled(words[i], inv_scale, dtype)
+            scaled.extend((lo, hi))
+        packed_u32 = cvt_e2m1x8(scaled)
+    return scale_ue8m0_u32, packed_u32
+
+
+def _store_block_4t(packed_u32, out_global, row_idx, col_idx, thread_in_sf, *, k):
+    out_off = K.cast(row_idx, "int64") * (k // 2) + col_idx * 16 + thread_in_sf * 4
+    K.ptx.st.global_.b32(K.address_of(out_global[out_off]), packed_u32)
+
+
+def _finish_block_4t(words, out_global, row_idx, col_idx, thread_in_sf, *, dtype, k, fp16_mode=0):
+    """Reduce, quantize and store one previously loaded fourth of an SF block."""
+    scale_ue8m0_u32, packed_u32 = _quantize_block_4t(words, dtype=dtype, fp16_mode=fp16_mode)
+    _store_block_4t(packed_u32, out_global, row_idx, col_idx, thread_in_sf, k=k)
+    return scale_ue8m0_u32
+
+
+def _finish_block_4t_scale_first(
+    words, out_global, sf_addr, row_idx, col_idx, thread_in_sf, *, dtype, k, fp16_mode=0
+):
+    """Store the leader scale before the all-lane output on a one-batch path."""
+    scale_ue8m0_u32, packed_u32 = _quantize_block_4t(words, dtype=dtype, fp16_mode=fp16_mode)
+    _st_scale_4t(sf_addr, scale_ue8m0_u32, thread_in_sf)
+    _store_block_4t(packed_u32, out_global, row_idx, col_idx, thread_in_sf, k=k)
+    return scale_ue8m0_u32
+
+
+def _process_block_4t(
+    in_global, out_global, row_idx, col_idx, thread_in_sf, *, dtype, k, fp16_mode=0
+):
+    """Quantize one fourth of an SF block with the source 4T/SF mapping."""
+    words = K.alloc_local((4,), "uint32")
+    _load_block_4t(words, in_global, row_idx, col_idx, thread_in_sf, k=k)
+    return _finish_block_4t(
+        words, out_global, row_idx, col_idx, thread_in_sf, dtype=dtype, k=k, fp16_mode=fp16_mode
+    )
+
+
+def _process_block_4t_scale_first(
+    in_global, out_global, sf_addr, row_idx, col_idx, thread_in_sf, *, dtype, k, fp16_mode=0
+):
+    """One-batch 4T/SF path with a predicated scale store before output."""
+    words = K.alloc_local((4,), "uint32")
+    _load_block_4t(words, in_global, row_idx, col_idx, thread_in_sf, k=k)
+    return _finish_block_4t_scale_first(
+        words,
+        out_global,
+        sf_addr,
+        row_idx,
+        col_idx,
+        thread_in_sf,
+        dtype=dtype,
+        k=k,
+        fp16_mode=fp16_mode,
+    )
+
+
 def _materialize(value):
     local = K.local_scalar(str(value.ty.dtype), init=value)
     return local
+
+
+def _ptxas_level(dtype: str, m: int, k: int, sf_layout: str, arch: str) -> str:
+    if arch != "sm_110a":
+        return "10"
+    return {
+        ("float16", 4096, 4096, "linear"): "5",
+        ("float16", 1024, 2048, "linear"): "6",
+        ("float16", 1024, 2048, "128x4"): "8",
+        ("float16", 16384, 7168, "linear"): "6",
+        ("float16", 16384, 7168, "128x4"): "8",
+        ("float16", 128, 1024, "linear"): "5",
+        ("float16", 128, 1024, "128x4"): "8",
+    }.get((dtype, m, k, sf_layout), "10")
 
 
 def get_kernel(
@@ -203,6 +461,28 @@ def get_kernel(
 ):
     """Return the TIRx specialization for one (dtype, m, k, sf_layout) config."""
     _validate(dtype, m, k, sf_layout)
+    use_4t = _use_4t()
+    thor = os.environ.get(PREPARE_CUDA_ARCH_ENV, "") == "sm_110a"
+    optimized_fp16 = thor and dtype == "float16"
+    packed_fp16 = sf_layout == "linear" or (m == 1024 and k == 2048)
+    fp16_mode = 2 if optimized_fp16 and packed_fp16 else int(optimized_fp16)
+    if optimized_fp16 and (m, k, sf_layout) == (128, 1024, "linear"):
+        fp16_mode = 0
+    if thor and dtype == "bfloat16":
+        fp16_mode = 3
+    threads_per_sf = _4T_THREADS_PER_SF if use_4t else 1
+    max_threads = _MAX_THREADS
+    grid_blocks_per_sm = _BLOCKS_PER_SM
+    min_blocks_per_sm = _BLOCKS_PER_SM
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV, "") == "sm_110a":
+        if (sf_layout == "linear" and m >= 4096) or (sf_layout != "linear" and m >= 1024):
+            max_threads = 1024
+            grid_blocks_per_sm = 2
+            min_blocks_per_sm = 2
+        elif (dtype, m, k, sf_layout) == ("float16", 1024, 2048, "linear"):
+            max_threads = 448
+        elif (dtype, m, k, sf_layout) == ("float16", 128, 1024, "linear"):
+            min_blocks_per_sm = 2
     nsb = k // MXFP4_SF_VEC_SIZE
     pad_cols = _padded_sf_cols(k)
 
@@ -212,15 +492,27 @@ def get_kernel(
         return sf_offset_128x4(row, col, pad_cols)
 
     if sf_layout == "linear":
-        grid_x, block_x, total_sf_blocks = _linear_launch(m, k)
+        grid_x, block_x, total_sf_blocks = _linear_launch(
+            m, k, threads_per_sf, max_threads, grid_blocks_per_sm
+        )
+        sf_blocks_per_tb = block_x // threads_per_sf
+        sf_stride = grid_x * sf_blocks_per_tb
+        pipeline_two = (
+            threads_per_sf == _4T_THREADS_PER_SF and m == 4096 and total_sf_blocks > sf_stride
+        )
+        direct_one_batch = (
+            threads_per_sf == _4T_THREADS_PER_SF and total_sf_blocks == grid_x * sf_blocks_per_tb
+        )
+        unroll_all_batches = threads_per_sf == _4T_THREADS_PER_SF and m == 1024 and k == 2048
 
-        @K.kernel(warps=(block_x + 31) // 32, arch="sm_100a", min_blocks_per_sm=2, grid=grid_x)
+        @K.kernel(
+            warps=(block_x + 31) // 32,
+            arch="sm_100a",
+            min_blocks_per_sm=min_blocks_per_sm,
+            grid=grid_x,
+        )
         def mxfp4_quantize_linear(
-            in_global: K.gptr[dtype],
-            out_global: K.gptr[K.u8],
-            sf_out: K.gptr[K.u8],
-            m_rows: K.i32,
-            total_sf: K.i32,
+            in_global: K.gptr[dtype], out_global: K.gptr[K.u8], sf_out: K.gptr[K.u8]
         ):
             bx = K.cta_id()
             tx = K.thread_id()
@@ -228,37 +520,134 @@ def get_kernel(
             if enable_pdl:
                 K.ptx.griddepcontrol.wait()
 
-            # Flat SF-block grid-stride loop (mxfp4_quantize.py:333-375, 1T/SF).
-            sf_idx = K.local_scalar("int32", init=bx * _LINEAR_SF_BLOCKS_PER_TB + tx)
-            with K.While(sf_idx < total_sf):
-                row_idx = K.truncdiv(sf_idx, K.int32(nsb))
-                col_idx = K.truncmod(sf_idx, K.int32(nsb))
-                scale_ue8m0_u32, packed64_0, packed64_1 = _process_block(
-                    in_global, row_idx, col_idx, dtype=dtype, k=k
-                )
-                # Source order: SF byte store, then the two output stores.
-                st_global_u8(K.address_of(sf_out[sf_idx]), K.cast(scale_ue8m0_u32, "uint8"))
-                out_off = K.cast(row_idx, "int64") * (k // 2) + col_idx * 16
-                st_global_u64(K.address_of(out_global[out_off]), packed64_0)
-                st_global_u64(K.address_of(out_global[out_off + 8]), packed64_1)
-                K.assign(sf_idx, sf_idx + grid_x * _LINEAR_SF_BLOCKS_PER_TB)
+            if threads_per_sf > 1:
+                warp_idx = K.truncdiv(tx, K.int32(WARP_SIZE))
+                lane_idx = K.truncmod(tx, K.int32(WARP_SIZE))
+                sf_per_warp = WARP_SIZE // threads_per_sf
+                sf_idx_in_warp = K.truncdiv(lane_idx, K.int32(threads_per_sf))
+                thread_in_sf = K.truncmod(lane_idx, K.int32(threads_per_sf))
+                sf_in_block = warp_idx * sf_per_warp + sf_idx_in_warp
+            else:
+                thread_in_sf = K.int32(0)
+                sf_in_block = tx
 
+            def process_one(sf_idx):
+                if threads_per_sf == _4T_THREADS_PER_SF:
+                    if pipeline_two:
+                        # Load two independent grid-stride iterations before
+                        # consuming either, increasing the cold-cache miss window
+                        # on low-SM devices without changing the one-iteration case.
+                        words0 = K.alloc_local((4,), "uint32")
+                        words1 = K.alloc_local((4,), "uint32")
+                        _load_block_4t(words0, in_global, K.int32(0), sf_idx, thread_in_sf, k=k)
+                        sf_idx1 = K.local_scalar("int32", init=sf_idx + sf_stride)
+                        with K.If(sf_idx1 < total_sf_blocks), K.Then():
+                            _load_block_4t(
+                                words1, in_global, K.int32(0), sf_idx1, thread_in_sf, k=k
+                            )
+                        scale_ue8m0_u32 = _finish_block_4t(
+                            words0,
+                            out_global,
+                            K.int32(0),
+                            sf_idx,
+                            thread_in_sf,
+                            dtype=dtype,
+                            k=k,
+                            fp16_mode=fp16_mode,
+                        )
+                    else:
+                        scale_ue8m0_u32 = _process_block_4t(
+                            in_global,
+                            out_global,
+                            K.int32(0),
+                            sf_idx,
+                            thread_in_sf,
+                            dtype=dtype,
+                            k=k,
+                            fp16_mode=fp16_mode,
+                        )
+                    _st_scale_4t(K.address_of(sf_out[sf_idx]), scale_ue8m0_u32, thread_in_sf)
+                    if pipeline_two:
+                        with K.If(sf_idx1 < total_sf_blocks), K.Then():
+                            scale_ue8m0_u32_1 = _finish_block_4t(
+                                words1,
+                                out_global,
+                                K.int32(0),
+                                sf_idx1,
+                                thread_in_sf,
+                                dtype=dtype,
+                                k=k,
+                                fp16_mode=fp16_mode,
+                            )
+                            _st_scale_4t(
+                                K.address_of(sf_out[sf_idx1]), scale_ue8m0_u32_1, thread_in_sf
+                            )
+                else:
+                    row_idx = K.truncdiv(sf_idx, K.int32(nsb))
+                    col_idx = K.truncmod(sf_idx, K.int32(nsb))
+                    scale_ue8m0_u32, packed64_0, packed64_1 = _process_block(
+                        in_global, row_idx, col_idx, dtype=dtype, k=k
+                    )
+                    st_global_u8(K.address_of(sf_out[sf_idx]), K.cast(scale_ue8m0_u32, "uint8"))
+                    out_off = K.cast(row_idx, "int64") * (k // 2) + col_idx * 16
+                    st_global_u64(K.address_of(out_global[out_off]), packed64_0)
+                    st_global_u64(K.address_of(out_global[out_off + 8]), packed64_1)
+
+            if unroll_all_batches:
+                sf_base = bx * sf_blocks_per_tb + sf_in_block
+                for batch in range(total_sf_blocks // sf_stride):
+                    process_one(sf_base + batch * sf_stride)
+                tail_idx = sf_base + (total_sf_blocks // sf_stride) * sf_stride
+                if total_sf_blocks % sf_stride:
+                    with K.If(tail_idx < total_sf_blocks), K.Then():
+                        process_one(tail_idx)
+            elif direct_one_batch:
+                process_one(bx * sf_blocks_per_tb + sf_in_block)
+            else:
+                sf_idx = K.local_scalar("int32", init=bx * sf_blocks_per_tb + sf_in_block)
+                with K.While(sf_idx < total_sf_blocks):
+                    process_one(sf_idx)
+                    K.assign(sf_idx, sf_idx + sf_stride * (2 if pipeline_two else 1))
             if enable_pdl:
                 K.ptx.griddepcontrol.launch_dependents()
 
         return mxfp4_quantize_linear.func
 
-    grid_x, block_x, padded_m = _swizzled_launch(m, k, sf_layout)
-    needs_col_loop = nsb > block_x
-    rows_per_block = 1 if needs_col_loop else block_x // nsb
+    grid_x, block_x, padded_m = _swizzled_launch(
+        m, k, sf_layout, threads_per_sf, max_threads, grid_blocks_per_sm
+    )
+    threads_per_row = nsb * threads_per_sf
+    col_units_per_block = block_x // threads_per_sf
+    needs_col_loop = nsb > col_units_per_block
+    rows_per_block = 1 if needs_col_loop else col_units_per_block // nsb
+    pipeline_two_rows = (
+        threads_per_sf == _4T_THREADS_PER_SF
+        and not needs_col_loop
+        and m >= 4096
+        and m == padded_m
+        and nsb == pad_cols
+    )
+    direct_one_batch = (
+        threads_per_sf == _4T_THREADS_PER_SF
+        and not needs_col_loop
+        and m == padded_m
+        and nsb == pad_cols
+        and m == grid_x * rows_per_block
+    )
+    unroll_all_batches = False
+    static_rows = (
+        threads_per_sf == _4T_THREADS_PER_SF
+        and not needs_col_loop
+        and m >= 4096
+        and m == padded_m
+        and nsb == pad_cols
+    )
 
-    @K.kernel(warps=(block_x + 31) // 32, arch="sm_100a", min_blocks_per_sm=2, grid=grid_x)
+    @K.kernel(
+        warps=(block_x + 31) // 32, arch="sm_100a", min_blocks_per_sm=min_blocks_per_sm, grid=grid_x
+    )
     def mxfp4_quantize_swizzled(
-        in_global: K.gptr[dtype],
-        out_global: K.gptr[K.u8],
-        sf_out: K.gptr[K.u8],
-        m_rows: K.i32,
-        padded_rows: K.i32,
+        in_global: K.gptr[dtype], out_global: K.gptr[K.u8], sf_out: K.gptr[K.u8]
     ):
         bx = K.cta_id()
         tx = K.thread_id()
@@ -267,97 +656,294 @@ def get_kernel(
             K.ptx.griddepcontrol.wait()
 
         def body():
-            # Large K (K/32 > 512): one row per block iteration with a column
-            # loop; 1T/SF -> col_unit == tidx (mxfp4_quantize.py:506-642).
+            col_unit_idx = _materialize(K.truncdiv(tx, K.int32(threads_per_sf)))
+            thread_in_sf = _materialize(K.truncmod(tx, K.int32(threads_per_sf)))
             row_idx = K.local_scalar("int32", init=bx)
-            with K.While(row_idx < padded_rows):
-                with K.If(row_idx >= m_rows):
+            with K.While(row_idx < padded_m):
+                with K.If(row_idx >= m):
                     with K.Then():
-                        # Padding row: zero-fill by ALL threads, stride block_x.
-                        sc_pad = K.local_scalar("int32", init=tx)
+                        sc_pad = K.local_scalar("int32", init=col_unit_idx)
                         with K.While(sc_pad < pad_cols):
-                            st_global_u8(
-                                K.address_of(sf_out[sf_offset(row_idx, sc_pad)]), K.uint8(0)
-                            )
-                            K.assign(sc_pad, sc_pad + block_x)
+                            with K.If(thread_in_sf == 0), K.Then():
+                                st_global_u8(
+                                    K.address_of(sf_out[sf_offset(row_idx, sc_pad)]), K.uint8(0)
+                                )
+                            K.assign(sc_pad, sc_pad + col_units_per_block)
                     with K.Else():
-                        sc = K.local_scalar("int32", init=tx)
+                        sc = K.local_scalar("int32", init=col_unit_idx)
                         with K.While(sc < nsb):
-                            scale_ue8m0_u32, packed64_0, packed64_1 = _process_block(
-                                in_global, row_idx, sc, dtype=dtype, k=k
-                            )
-                            # Source order: SF byte store, then the output stores.
-                            st_global_u8(
+                            if threads_per_sf == _4T_THREADS_PER_SF and needs_col_loop:
+                                words0 = K.alloc_local((4,), "uint32")
+                                words1 = K.alloc_local((4,), "uint32")
+                                _load_block_4t(words0, in_global, row_idx, sc, thread_in_sf, k=k)
+                                sc1 = K.local_scalar("int32", init=sc + col_units_per_block)
+                                with K.If(sc1 < nsb), K.Then():
+                                    _load_block_4t(
+                                        words1, in_global, row_idx, sc1, thread_in_sf, k=k
+                                    )
+                                scale_ue8m0_u32 = _finish_block_4t(
+                                    words0,
+                                    out_global,
+                                    row_idx,
+                                    sc,
+                                    thread_in_sf,
+                                    dtype=dtype,
+                                    k=k,
+                                    fp16_mode=fp16_mode,
+                                )
+                            elif threads_per_sf == _4T_THREADS_PER_SF:
+                                scale_ue8m0_u32 = _process_block_4t(
+                                    in_global,
+                                    out_global,
+                                    row_idx,
+                                    sc,
+                                    thread_in_sf,
+                                    dtype=dtype,
+                                    k=k,
+                                    fp16_mode=fp16_mode,
+                                )
+                            else:
+                                scale_ue8m0_u32, packed64_0, packed64_1 = _process_block(
+                                    in_global, row_idx, sc, dtype=dtype, k=k
+                                )
+                                out_off = K.cast(row_idx, "int64") * (k // 2) + sc * 16
+                                st_global_u64(K.address_of(out_global[out_off]), packed64_0)
+                                st_global_u64(K.address_of(out_global[out_off + 8]), packed64_1)
+                            _st_scale_4t(
                                 K.address_of(sf_out[sf_offset(row_idx, sc)]),
-                                K.cast(scale_ue8m0_u32, "uint8"),
+                                scale_ue8m0_u32,
+                                thread_in_sf,
                             )
-                            out_off = K.cast(row_idx, "int64") * (k // 2) + sc * 16
-                            st_global_u64(K.address_of(out_global[out_off]), packed64_0)
-                            st_global_u64(K.address_of(out_global[out_off + 8]), packed64_1)
-                            K.assign(sc, sc + block_x)
-                        # Padding SF columns of a data row (:634-640).
-                        sc_tail = K.local_scalar("int32", init=nsb + tx)
+                            if threads_per_sf == _4T_THREADS_PER_SF and needs_col_loop:
+                                with K.If(sc1 < nsb), K.Then():
+                                    scale_ue8m0_u32_1 = _finish_block_4t(
+                                        words1,
+                                        out_global,
+                                        row_idx,
+                                        sc1,
+                                        thread_in_sf,
+                                        dtype=dtype,
+                                        k=k,
+                                        fp16_mode=fp16_mode,
+                                    )
+                                    _st_scale_4t(
+                                        K.address_of(sf_out[sf_offset(row_idx, sc1)]),
+                                        scale_ue8m0_u32_1,
+                                        thread_in_sf,
+                                    )
+                                K.assign(sc, sc + 2 * col_units_per_block)
+                            else:
+                                K.assign(sc, sc + col_units_per_block)
+                        sc_tail = K.local_scalar("int32", init=nsb + col_unit_idx)
                         with K.While(sc_tail < pad_cols):
-                            st_global_u8(
-                                K.address_of(sf_out[sf_offset(row_idx, sc_tail)]), K.uint8(0)
-                            )
-                            K.assign(sc_tail, sc_tail + block_x)
+                            with K.If(thread_in_sf == 0), K.Then():
+                                st_global_u8(
+                                    K.address_of(sf_out[sf_offset(row_idx, sc_tail)]), K.uint8(0)
+                                )
+                            K.assign(sc_tail, sc_tail + col_units_per_block)
                 K.assign(row_idx, row_idx + grid_x)
 
         def small_body():
-            # Small K: multi-row processing; 1T/SF -> threads_per_row == nsb,
-            # thread_in_sf == 0 always (mxfp4_quantize.py:643-794).
-            row_in_block = _materialize(K.truncdiv(tx, K.int32(nsb)))
-            sf_idx_in_row = _materialize(K.truncmod(tx, K.int32(nsb)))
+            row_in_block = _materialize(K.truncdiv(tx, K.int32(threads_per_row)))
+            local_tidx = _materialize(K.truncmod(tx, K.int32(threads_per_row)))
+            sf_idx_in_row = _materialize(K.truncdiv(local_tidx, K.int32(threads_per_sf)))
+            thread_in_sf = _materialize(K.truncmod(local_tidx, K.int32(threads_per_sf)))
 
             row_batch_idx = K.local_scalar("int32")
             row_idx2 = K.local_scalar("int32")
             K.assign(row_batch_idx, bx)
             K.assign(row_idx2, row_batch_idx * rows_per_block + row_in_block)
-            with K.While(row_batch_idx * rows_per_block < padded_rows):
-                with K.If(row_idx2 < padded_rows), K.Then():
-                    with K.If(row_idx2 >= m_rows):
+            with K.While(row_batch_idx * rows_per_block < padded_m):
+                with K.If(row_idx2 < padded_m), K.Then():
+                    with K.If(row_idx2 >= m):
                         with K.Then():
-                            # Padding row: zero ALL padded SF columns; stride is
-                            # threads_per_row == nsb (:676-682).
-                            local_sf = K.local_scalar("int32", init=sf_idx_in_row)
-                            with K.While(local_sf < pad_cols):
-                                st_global_u8(
-                                    K.address_of(sf_out[sf_offset(row_idx2, local_sf)]), K.uint8(0)
-                                )
-                                K.assign(local_sf, local_sf + nsb)
-                        with K.Else():
-                            with K.If(sf_idx_in_row < nsb), K.Then():
-                                (scale_ue8m0_u32, packed64_0, packed64_1) = _process_block(
-                                    in_global, row_idx2, sf_idx_in_row, dtype=dtype, k=k
-                                )
-                                # Source order: SF byte store, then output stores.
-                                st_global_u8(
-                                    K.address_of(sf_out[sf_offset(row_idx2, sf_idx_in_row)]),
-                                    K.cast(scale_ue8m0_u32, "uint8"),
-                                )
-                                out_off = K.cast(row_idx2, "int64") * (k // 2) + (
-                                    sf_idx_in_row * 16
-                                )
-                                st_global_u64(K.address_of(out_global[out_off]), packed64_0)
-                                st_global_u64(K.address_of(out_global[out_off + 8]), packed64_1)
-                            # Padding SF columns of a data row (:782-791).
-                            if pad_cols != nsb:
-                                pad_col = K.local_scalar("int32", init=nsb + sf_idx_in_row)
-                                with K.While(pad_col < pad_cols):
+                            with K.If(thread_in_sf == 0), K.Then():
+                                local_sf = K.local_scalar("int32", init=sf_idx_in_row)
+                                with K.While(local_sf < pad_cols):
                                     st_global_u8(
-                                        K.address_of(sf_out[sf_offset(row_idx2, pad_col)]),
+                                        K.address_of(sf_out[sf_offset(row_idx2, local_sf)]),
                                         K.uint8(0),
                                     )
-                                    K.assign(pad_col, pad_col + nsb)
+                                    K.assign(local_sf, local_sf + nsb)
+                        with K.Else():
+                            with K.If(sf_idx_in_row < nsb), K.Then():
+                                if threads_per_sf == _4T_THREADS_PER_SF:
+                                    scale_ue8m0_u32 = _process_block_4t(
+                                        in_global,
+                                        out_global,
+                                        row_idx2,
+                                        sf_idx_in_row,
+                                        thread_in_sf,
+                                        dtype=dtype,
+                                        k=k,
+                                        fp16_mode=fp16_mode,
+                                    )
+                                else:
+                                    scale_ue8m0_u32, packed64_0, packed64_1 = _process_block(
+                                        in_global, row_idx2, sf_idx_in_row, dtype=dtype, k=k
+                                    )
+                                    out_off = K.cast(row_idx2, "int64") * (k // 2) + (
+                                        sf_idx_in_row * 16
+                                    )
+                                    st_global_u64(K.address_of(out_global[out_off]), packed64_0)
+                                    st_global_u64(K.address_of(out_global[out_off + 8]), packed64_1)
+                                _st_scale_4t(
+                                    K.address_of(sf_out[sf_offset(row_idx2, sf_idx_in_row)]),
+                                    scale_ue8m0_u32,
+                                    thread_in_sf,
+                                )
+                            if pad_cols != nsb:
+                                with K.If(thread_in_sf == 0), K.Then():
+                                    pad_col = K.local_scalar("int32", init=nsb + sf_idx_in_row)
+                                    with K.While(pad_col < pad_cols):
+                                        st_global_u8(
+                                            K.address_of(sf_out[sf_offset(row_idx2, pad_col)]),
+                                            K.uint8(0),
+                                        )
+                                        K.assign(pad_col, pad_col + nsb)
                 K.assign(row_batch_idx, row_batch_idx + grid_x)
                 K.assign(row_idx2, row_batch_idx * rows_per_block + row_in_block)
 
+        def small_body_direct():
+            row_in_block = _materialize(K.truncdiv(tx, K.int32(threads_per_row)))
+            local_tidx = _materialize(K.truncmod(tx, K.int32(threads_per_row)))
+            sf_idx_in_row = _materialize(K.truncdiv(local_tidx, K.int32(threads_per_sf)))
+            thread_in_sf = _materialize(K.truncmod(local_tidx, K.int32(threads_per_sf)))
+            row_idx = bx * rows_per_block + row_in_block
+            _process_block_4t_scale_first(
+                in_global,
+                out_global,
+                K.address_of(sf_out[sf_offset(row_idx, sf_idx_in_row)]),
+                row_idx,
+                sf_idx_in_row,
+                thread_in_sf,
+                dtype=dtype,
+                k=k,
+                fp16_mode=fp16_mode,
+            )
+
+        def small_body_unrolled():
+            row_in_block = _materialize(K.truncdiv(tx, K.int32(threads_per_row)))
+            local_tidx = _materialize(K.truncmod(tx, K.int32(threads_per_row)))
+            sf_idx_in_row = _materialize(K.truncdiv(local_tidx, K.int32(threads_per_sf)))
+            thread_in_sf = _materialize(K.truncmod(local_tidx, K.int32(threads_per_sf)))
+            row_stride = grid_x * rows_per_block
+            row_base = bx * rows_per_block + row_in_block
+
+            def process_row(row_idx):
+                scale = _process_block_4t(
+                    in_global,
+                    out_global,
+                    row_idx,
+                    sf_idx_in_row,
+                    thread_in_sf,
+                    dtype=dtype,
+                    k=k,
+                    fp16_mode=fp16_mode,
+                )
+                _st_scale_4t(
+                    K.address_of(sf_out[sf_offset(row_idx, sf_idx_in_row)]), scale, thread_in_sf
+                )
+
+            for batch in range(m // row_stride):
+                process_row(row_base + batch * row_stride)
+            tail_row = row_base + (m // row_stride) * row_stride
+            if m % row_stride:
+                with K.If(tail_row < m), K.Then():
+                    process_row(tail_row)
+
+        def small_body_static():
+            row_in_block = _materialize(K.truncdiv(tx, K.int32(threads_per_row)))
+            local_tidx = _materialize(K.truncmod(tx, K.int32(threads_per_row)))
+            sf_idx_in_row = _materialize(K.truncdiv(local_tidx, K.int32(threads_per_sf)))
+            thread_in_sf = _materialize(K.truncmod(local_tidx, K.int32(threads_per_sf)))
+            row_idx = K.local_scalar("int32", init=bx * rows_per_block + row_in_block)
+            with K.While(row_idx < m):
+                scale = _process_block_4t(
+                    in_global,
+                    out_global,
+                    row_idx,
+                    sf_idx_in_row,
+                    thread_in_sf,
+                    dtype=dtype,
+                    k=k,
+                    fp16_mode=fp16_mode,
+                )
+                _st_scale_4t(
+                    K.address_of(sf_out[sf_offset(row_idx, sf_idx_in_row)]), scale, thread_in_sf
+                )
+                K.assign(row_idx, row_idx + grid_x * rows_per_block)
+
+        def small_body_pipelined():
+            row_in_block = _materialize(K.truncdiv(tx, K.int32(threads_per_row)))
+            local_tidx = _materialize(K.truncmod(tx, K.int32(threads_per_row)))
+            sf_idx_in_row = _materialize(K.truncdiv(local_tidx, K.int32(threads_per_sf)))
+            thread_in_sf = _materialize(K.truncmod(local_tidx, K.int32(threads_per_sf)))
+            row_stride = grid_x * rows_per_block
+            row_idx = K.local_scalar("int32", init=bx * rows_per_block + row_in_block)
+            with K.While(row_idx < m):
+                words0 = K.alloc_local((4,), "uint32")
+                words1 = K.alloc_local((4,), "uint32")
+                _load_block_4t(words0, in_global, row_idx, sf_idx_in_row, thread_in_sf, k=k)
+                row_idx1 = K.local_scalar("int32", init=row_idx + row_stride)
+                with K.If(row_idx1 < m), K.Then():
+                    _load_block_4t(words1, in_global, row_idx1, sf_idx_in_row, thread_in_sf, k=k)
+                scale0 = _finish_block_4t(
+                    words0,
+                    out_global,
+                    row_idx,
+                    sf_idx_in_row,
+                    thread_in_sf,
+                    dtype=dtype,
+                    k=k,
+                    fp16_mode=fp16_mode,
+                )
+                _st_scale_4t(
+                    K.address_of(sf_out[sf_offset(row_idx, sf_idx_in_row)]), scale0, thread_in_sf
+                )
+                with K.If(row_idx1 < m), K.Then():
+                    scale1 = _finish_block_4t(
+                        words1,
+                        out_global,
+                        row_idx1,
+                        sf_idx_in_row,
+                        thread_in_sf,
+                        dtype=dtype,
+                        k=k,
+                        fp16_mode=fp16_mode,
+                    )
+                    _st_scale_4t(
+                        K.address_of(sf_out[sf_offset(row_idx1, sf_idx_in_row)]),
+                        scale1,
+                        thread_in_sf,
+                    )
+                K.assign(row_idx, row_idx + 2 * row_stride)
+
         if block_x % 32:
             with K.If(tx < block_x), K.Then():
-                body() if needs_col_loop else small_body()
+                body() if needs_col_loop else (
+                    small_body_direct()
+                    if direct_one_batch
+                    else (
+                        small_body_pipelined()
+                        if pipeline_two_rows
+                        else (
+                            small_body_unrolled()
+                            if unroll_all_batches
+                            else (small_body_static() if static_rows else small_body())
+                        )
+                    )
+                )
         elif needs_col_loop:
             body()
+        elif direct_one_batch:
+            small_body_direct()
+        elif pipeline_two_rows:
+            small_body_pipelined()
+        elif unroll_all_batches:
+            small_body_unrolled()
+        elif static_rows:
+            small_body_static()
         else:
             small_body()
 
@@ -408,10 +994,31 @@ def _run_reference(a, sf_layout: str, enable_pdl: bool):
 
 def prepare_bench(**kwargs: Any):
     """Specialize and compile before the workload receives a GPU."""
-    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+    from tirx_kernels.runner import prepared_gpu_benchmark
 
-    state = {"config": dict(kwargs), "executable": compile_kernel(get_kernel(**kwargs))}
+    state = {"config": dict(kwargs), "executable": _compile_tirx(dict(kwargs))}
     return prepared_gpu_benchmark(run_gpu, state)
+
+
+def _compile_tirx(config: dict[str, Any]):
+    from tirx_kernels.runner import compile_kernel
+
+    level = _ptxas_level(
+        str(config["dtype"]),
+        int(config["m"]),
+        int(config["k"]),
+        str(config.get("sf_layout", "128x4")),
+        os.environ.get(PREPARE_CUDA_ARCH_ENV, ""),
+    )
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = level
+    try:
+        return compile_kernel(get_kernel(**config))
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
 
 
 def run_test(
@@ -420,16 +1027,12 @@ def run_test(
     """Compile, launch, and validate one config against the flashinfer source."""
     import torch
 
-    from tirx_kernels.runner import compile_kernel
-
     (a,) = prepare_data(dtype=dtype, m=m, k=k, sf_layout=sf_layout, enable_pdl=enable_pdl)
-    kernel = get_kernel(dtype=dtype, m=m, k=k, sf_layout=sf_layout, enable_pdl=enable_pdl)
-    ex = compile_kernel(kernel)
+    ex = _compile_tirx(
+        {"dtype": dtype, "m": m, "k": k, "sf_layout": sf_layout, "enable_pdl": enable_pdl}
+    )
     out_tirx, sf_tirx = _alloc_outputs(m, k, sf_layout)
-    if sf_layout == "linear":
-        ex(a.view(-1), out_tirx.view(-1), sf_tirx, m, m * (k // MXFP4_SF_VEC_SIZE))
-    else:
-        ex(a.view(-1), out_tirx.view(-1), sf_tirx, m, _padded_m(m, sf_layout))
+    ex(a.view(-1), out_tirx.view(-1), sf_tirx)
     torch.cuda.synchronize()
 
     ref_fp4, ref_sf = _run_reference(a, sf_layout, enable_pdl)
@@ -452,17 +1055,11 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
     (a,) = prepare_data(dtype=dtype, m=m, k=k, sf_layout=sf_layout, enable_pdl=enable_pdl)
     ex = executable
     out_tirx, sf_tirx = _alloc_outputs(m, k, sf_layout)
+    a_flat = a.view(-1)
+    out_tirx_flat = out_tirx.view(-1)
 
-    if sf_layout == "linear":
-        total_sf = m * (k // MXFP4_SF_VEC_SIZE)
-
-        def tirx_launch():
-            ex(a.view(-1), out_tirx.view(-1), sf_tirx, m, total_sf)
-    else:
-        padded_m = _padded_m(m, sf_layout)
-
-        def tirx_launch():
-            ex(a.view(-1), out_tirx.view(-1), sf_tirx, m, padded_m)
+    def tirx_launch():
+        ex(a_flat, out_tirx_flat, sf_tirx)
 
     def build_reference():
         # Bypass the allocating public wrapper: call the cached compiled source
@@ -478,14 +1075,15 @@ def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldow
         layout_code = {"linear": SF_LAYOUT_LINEAR, "128x4": SF_LAYOUT_128x4, "8x4": SF_LAYOUT_8x4}[
             sf_layout
         ]
-        kernel_fn, _ = _get_compiled_kernel_mxfp4(is_bf16, k, layout_code, enable_pdl, False)
+        use_4t = _use_4t()
+        kernel_fn, _ = _get_compiled_kernel_mxfp4(is_bf16, k, layout_code, enable_pdl, use_4t)
         out_ref, sf_ref = _alloc_outputs(m, k, sf_layout)
         if sf_layout == "linear":
             total_sf = m * (k // MXFP4_SF_VEC_SIZE)
-            grid, _, _ = _linear_launch(m, k)
+            grid, _, _ = _linear_launch(m, k, _4T_THREADS_PER_SF if use_4t else 1)
             return lambda: kernel_fn(a, out_ref, sf_ref, m, total_sf, grid)
         padded_m = _padded_m(m, sf_layout)
-        grid, _, _ = _swizzled_launch(m, k, sf_layout)
+        grid, _, _ = _swizzled_launch(m, k, sf_layout, _4T_THREADS_PER_SF if use_4t else 1)
         return lambda: kernel_fn(a, out_ref, sf_ref, m, padded_m, grid)
 
     return bench(
@@ -538,8 +1136,8 @@ def _cfg(dtype, m, k, sf_layout="128x4", enable_pdl=False):
 # Correctness matrix.  Covers: both dtypes; linear/128x4/8x4 SF layouts; the
 # swizzled multi-row vs needs_col_loop compile-time split (K/32 > 512);
 # padding-row and padding-column zero-fill paths (m % 128, m % 8,
-# k/32 % 4 != 0); minimal shapes; the PDL instruction variant.  All 1T/SF
-# (B200 has 148 SMs; the 4T/SF path requires num_sm <= 80).
+# k/32 % 4 != 0); minimal shapes; and the PDL instruction variant.  The source
+# host dispatch selects 1T/SF or 4T/SF from the target's SM count.
 CONFIGS = [
     _cfg("float16", 1, 32, "linear"),  # minimal
     _cfg("float16", 128, 1024, "linear"),


### PR DESCRIPTION
## Summary

Enable `selective_state_update_mtp_horizontal` and `mxfp4_quantize` on Jetson AGX Thor (`sm_110a`).

- Add Thor scheduling specializations for MTP horizontal state update.
- Implement FlashInfer's low-SM 4-thread-per-scale-factor MXFP4 path.
- Add Thor-specific launch and ptxas settings for the MXFP4 workload shapes.
- Preserve the existing paths for `sm_100a`, `sm_103a`, and `sm_107a`.
- Update the README architecture annotations, registry counts, and Thor baseline tables.

All measurements use 15 Proton rounds with the bench-suite defaults: 25 ms warmup, 100 ms repeat, and 1 second cooldown. `Source/TIRx > 1` means TIRx is faster.

## Validation

- `mxfp4_quantize` correctness: 18/18 passed
- `mxfp4_quantize` performance: 10/10 configs above baseline
- `selective_state_update_mtp_horizontal` correctness: 36/36 passed
- `selective_state_update_mtp_horizontal` performance: 40/40 configs above baseline
- Registry tests: 22/22 passed
- Pre-commit checks passed
- No interference retries were recorded

## MXFP4 quantization performance

| Config | TIRx (µs) | FlashInfer (µs) | Source/TIRx |
|---|---:|---:|---:|
| `bf16_128x4_m4096_k4096` | 337.838 | 354.439 | 1.0491× |
| `bf16_linear_m4096_k4096` | 342.770 | 355.732 | 1.0378× |
| `fp16_128x4_m1024_k2048` | 67.421 | 69.416 | 1.0296× |
| `fp16_128x4_m128_k1024` | 6.787 | 6.965 | 1.0262× |
| `fp16_128x4_m16384_k7168` | 1936.206 | 1948.911 | 1.0066× |
| `fp16_128x4_m4096_k4096` | 340.340 | 353.038 | 1.0373× |
| `fp16_linear_m1024_k2048` | 63.247 | 63.854 | 1.0096× |
| `fp16_linear_m128_k1024` | 7.052 | 7.247 | 1.0276× |
| `fp16_linear_m16384_k7168` | 1782.673 | 1819.840 | 1.0208× |
| `fp16_linear_m4096_k4096` | 344.258 | 353.927 | 1.0281× |

## MTP horizontal state update performance

| Config | TIRx (µs) | FlashInfer CUDA (µs) | Source/TIRx |
|---|---:|---:|---:|
| `b1_h64_d64_s128_t6_r8_statebf16_official` | 26.054 | 29.304 | 1.1248× |
| `b1_h64_d64_s128_t6_r8_statef32_official` | 37.854 | 45.361 | 1.1983× |
| `b2_h64_d64_s128_t6_r8_statebf16_official` | 31.184 | 34.962 | 1.1212× |
| `b2_h64_d64_s128_t6_r8_statef32_official` | 47.133 | 55.825 | 1.1844× |
| `b4_h64_d64_s128_t6_r8_statebf16_official` | 47.659 | 48.066 | 1.0085× |
| `b4_h64_d64_s128_t6_r8_statef32_official` | 62.729 | 69.340 | 1.1054× |
| `b8_h64_d64_s128_t6_r8_statebf16_official` | 78.353 | 82.638 | 1.0547× |
| `b8_h64_d64_s128_t6_r8_statef32_official` | 90.907 | 95.564 | 1.0512× |
| `b16_h64_d64_s128_t6_r8_statebf16_official` | 143.398 | 151.006 | 1.0531× |
| `b16_h64_d64_s128_t6_r8_statef32_official` | 156.333 | 168.518 | 1.0779× |
| `b32_h64_d64_s128_t6_r8_statebf16_official` | 281.712 | 289.908 | 1.0291× |
| `b32_h64_d64_s128_t6_r8_statef32_official` | 291.661 | 324.116 | 1.1113× |
| `b64_h64_d128_s128_t4_r8` | 1722.292 | 1749.873 | 1.0160× |
| `b64_h64_d64_s128_t1_r8` | 895.655 | 916.760 | 1.0236× |
| `b64_h64_d64_s128_t2_r8` | 884.863 | 910.196 | 1.0286× |
| `b64_h64_d64_s128_t4_r1` | 943.846 | 1003.373 | 1.0631× |
| `b64_h64_d64_s128_t4_r16` | 916.256 | 928.593 | 1.0135× |
| `b64_h64_d64_s128_t4_r64` | 902.542 | 915.070 | 1.0139× |
| `b64_h64_d64_s128_t4_r8_indices_i32` | 885.477 | 937.222 | 1.0584× |
| `b64_h64_d64_s128_t4_r8_intermediate` | 2255.924 | 2376.260 | 1.0533× |
| `b64_h64_d64_s128_t4_r8_philox10` | 953.232 | 1015.672 | 1.0655× |
| `b64_h64_d64_s128_t4_r8_statef16` | 904.953 | 931.948 | 1.0298× |
| `b64_h64_d64_s128_t4_r8_update` | 891.914 | 937.211 | 1.0508× |
| `b64_h64_d64_s128_t4_r8_weightbf16` | 905.147 | 926.567 | 1.0237× |
| `b64_h64_d64_s128_t4_r8_z` | 928.565 | 950.119 | 1.0232× |
| `b64_h64_d64_s128_t6_r8_statebf16_official` | 545.572 | 563.687 | 1.0332× |
| `b64_h64_d64_s128_t6_r8_statef32_official` | 585.722 | 630.981 | 1.0773× |
| `b64_h64_d64_s128_t8_r8` | 967.557 | 980.543 | 1.0134× |
| `b64_h64_d64_s64_t4_r8` | 480.466 | 514.229 | 1.0703× |
| `b64_h64_d64_s96_t4_r8` | 716.299 | 762.331 | 1.0643× |
| `b128_h64_d64_s128_t6_r8_statebf16_official` | 1019.936 | 1096.505 | 1.0751× |
| `b128_h64_d64_s128_t6_r8_statef32_official` | 1057.442 | 1216.203 | 1.1501× |
| `b256_h64_d64_s128_t6_r8_statebf16_official` | 1841.513 | 1965.644 | 1.0674× |
| `b256_h64_d64_s128_t6_r8_statef32_official` | 1883.634 | 2191.197 | 1.1633× |
| `b512_h64_d64_s128_t6_r8_statebf16_official` | 3537.504 | 3875.508 | 1.0955× |
| `b512_h64_d64_s128_t6_r8_statef32_official` | 3758.429 | 4275.671 | 1.1376× |
| `b1024_h64_d64_s128_t6_r8_statebf16_official` | 7053.021 | 7649.707 | 1.0846× |
| `b1024_h64_d64_s128_t6_r8_statef32_official` | 7488.139 | 8515.661 | 1.1372× |
| `b2048_h64_d64_s128_t6_r8_statebf16_official` | 14069.872 | 15273.774 | 1.0856× |
| `b2048_h64_d64_s128_t6_r8_statef32_official` | 14951.415 | 17012.931 | 1.1379× |