### PR TITLE
feat(kernel): port FlashInfer merge_state

### DIFF
--- a/.agents/sketch/flashinfer/cascade/merge_state.md
+++ b/.agents/sketch/flashinfer/cascade/merge_state.md
@@ -1,0 +1,371 @@
+<!--
+Copyright (c) 2026 The TIRx Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This design sketch documents a TIRx port of FlashInfer's
+include/flashinfer/attention/cascade.cuh (MergeStateKernel), the kernel
+behind flashinfer.cascade.merge_state.
+-->
+
+# merge_state SM100: coarse WASP pipeline sketch
+
+This non-executable design sketch describes the thread roles, control flow,
+register storage, and PTX-level operations of
+[`tirx_kernels/flashinfer/cascade/merge_state.py`](../../../../tirx_kernels/flashinfer/cascade/merge_state.py).
+That TIRx module is the authoritative implementation.
+
+The source is fixed at FlashInfer commit
+`f2e04400e330fb2debe0bf8730d9424a1d37927f`:
+`include/flashinfer/attention/cascade.cuh` L45-71 (`MergeStateKernel`) and
+L572-587 (host `MergeState`, the launch formulae), with `vec_t` load/cast
+helpers from `include/flashinfer/vec_dtypes.cuh` and `math::ptx_exp2` /
+`math::ptx_log2` from `include/flashinfer/math.cuh`.
+
+The four instantiations are `DTYPE in {f16, bf16}` crossed with
+`VEC in {8, 16}`, each mirroring one `MergeStateKernel<vec_size, DTypeIn,
+DTypeO>` template instantiation with `DTypeIn == DTypeO` (the only pairing the
+`csrc/cascade.cu` binding produces). `VEC` is the source's
+`max(16 / sizeof(DTypeIn), HEAD_DIM / 32)`: 8 for `head_dim` 64/128/256 and 16
+for `head_dim` 512. `seq_len`, `num_heads`, and `head_dim` are static per
+config; the source passes `num_heads`/`head_dim` as runtime `uint32_t` kernel
+arguments, and folding them changes only address arithmetic. Out of scope:
+`MergeStateInPlaceKernel` (in-place, optional mask), `MergeStatesKernel` and
+the persistent variable-length kernels (many index sets), f32/fp8 dtypes
+(rejected by `DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16`), `head_dim` outside
+`DISPATCH_HEAD_DIM`, shared-memory staging, PDL (the source launches with no
+attribute and emits no `griddepcontrol`), and tile (`Tx`) primitives.
+
+## Pipeline at a glance
+
+| Warps | Role-local program | Publication/reuse edges |
+| --- | --- | --- |
+| all (uniform) | Every thread `(tx, ty)` of CTA `pos` runs the same single-role straight-line program: two scalar lse loads, `max`/`sub`/`ex2`/`add`/two approximate divisions for the two blend weights, `VEC/8` 16-byte loads of `v_a` and of `v_b`, `VEC` widen-multiply-fma steps, `VEC/2` pack conversions, `VEC/8` 16-byte stores, then a pointer-null-guarded `lg2`/`add`/scalar store of the merged lse. | none — no SMEM, no mbarriers, no cross-thread data; the kernel has no synchronization at all |
+
+There is one CTA per position (`blockIdx.x == pos`), one thread row per head
+(`threadIdx.y == head_idx`), and `BDX = head_dim / VEC` threads per head
+(`threadIdx.x == tx`), each owning one `VEC`-element slice. Every loop (the
+`VEC`-wide element loop and the `vec_t` load/store and `vec_cast` helper loops)
+is fully unrolled; the only branch is the `s_merged != nullptr` guard.
+
+## Primitive vocabulary
+
+Structural operations declare placement without moving data:
+
+```python
+specialize(...)       # compile-time variant selection
+launch(...)           # compile-time launch topology
+reg_tile(...)         # per-thread register tile
+```
+
+Copies state their direction and width:
+
+```python
+copy_g2r_b32(src_addr, dst)        # one scalar 32-bit global -> register load
+copy_g2r_v4(src_addr, dst_b32x4)   # one 16-byte global -> register vector load
+copy_r2g_v4(src_b32x4, dst_addr)   # one 16-byte register -> global vector store
+copy_r2g_b32(src, dst_addr)        # one scalar 32-bit register -> global store
+```
+
+The compute vocabulary is deliberately primitive; every f32 arithmetic op is
+annotated with its production `-use_fast_math` form (`.ftz` modifiers,
+approximate division), the flags the FlashInfer JIT builds the shipped cubin
+with (`flashinfer/jit/core.py`: `-std=c++17 -use_fast_math -DNDEBUG -O3`):
+
+```python
+max(dst, lhs, rhs)          # f32 maximum
+sub(dst, lhs, rhs)
+add(dst, lhs, rhs)
+mul(dst, lhs, rhs)
+fma(dst, lhs, rhs, acc)
+exp2_fast(dst, src)         # math::ptx_exp2 -> ex2.approx.ftz.f32 (inline asm in the source)
+log2_fast(dst, src)         # math::ptx_log2 -> lg2.approx.ftz.f32 (inline asm in the source)
+div_fast(dst, lhs, rhs)     # fp32 `/` under -use_fast_math -> div.approx.ftz.f32
+unpack2(lo_b16, hi_b16, word_b32)   # mov.b32 {lo, hi}, word
+cast(dst_f32, src_b16)      # cvt.f32.f16 (DTYPE=f16) | cvt.f32.bf16 (DTYPE=bf16)
+cast2x(dst_b32, lo, hi)     # cvt.rn.f16x2.f32 | cvt.rn.bf16x2.f32 (hi operand first)
+isnull(pred, ptr)           # setp.eq.s64 pred, ptr, 0 (+ predicated branch)
+```
+
+`thread_id`, `cta_id` are schedule operations. Address expressions are shown
+directly; they do not hide copies, computation, role changes, or
+synchronization.
+
+The audit evidence below comes from a fresh line-info export of the exact four
+instantiations (explicit template instantiation of `MergeStateKernel` inside
+`namespace flashinfer`, `nvcc -std=c++17 -use_fast_math -DNDEBUG -O3
+-DFLASHINFER_ENABLE_F16 -DFLASHINFER_ENABLE_BF16 ... -arch=sm_103a -ptx
+-lineinfo`, CUDA 13.1 V13.1.80), preserved at
+`.porting/merge_state/ptx/merge_state_sm103a_prod.ptx` (plus the identical
+`-arch=sm_100a` export, the `sm_103a` SASS, and `ptxas -v`). The per-entry
+slices are `entry_v8_half.ptx`, `entry_v8_bf16.ptx`, `entry_v16_half.ptx`,
+`entry_v16_bf16.ptx` in the same directory.
+
+## Complete sketch
+
+```python
+# ===========================================================================
+# Static specialization, runtime ABI, and launch
+# ===========================================================================
+
+variant = specialize(DTYPE=("f16", "bf16"), VEC=(8, 16), target="sm_100a")
+# instruction_selection: none; extent: four compile-time instantiations
+
+VEC = max(8, HEAD_DIM // 32)      # source: max(16 / sizeof(DTypeIn), HEAD_DIM / 32)
+BDX = HEAD_DIM // VEC             # 8 | 16 | 32 | 32 for head_dim 64 | 128 | 256 | 512
+BDY = NUM_HEADS                   # one thread row per head
+NWORDS = VEC // 2                 # packed b32 words per slice: 4 | 8
+
+launch_config = launch(
+    grid=(SEQ_LEN, 1, 1),
+    block=(BDX, BDY, 1),          # BDX * BDY <= 1024
+    dynamic_smem_bytes=0,
+)
+# instruction_selection: none; extent: static launch metadata
+
+def merge_state(v_a,        # DTYPE [SEQ_LEN, NUM_HEADS, HEAD_DIM], direct global pointer
+                s_a,        # f32   [SEQ_LEN, NUM_HEADS]
+                v_b,        # DTYPE [SEQ_LEN, NUM_HEADS, HEAD_DIM]
+                s_b,        # f32   [SEQ_LEN, NUM_HEADS]
+                v_merged,   # DTYPE [SEQ_LEN, NUM_HEADS, HEAD_DIM]
+                s_merged,   # f32   [SEQ_LEN, NUM_HEADS]; may be null in the source ABI
+                ):
+    pos = cta_id(axis="x", extent=SEQ_LEN)
+    # instruction_selection: mov.u32 from %ctaid.x; extent: scalar per thread
+    tx = thread_id(axis="x", extent=BDX)          # vector-slice index
+    ty = thread_id(axis="y", extent=BDY)          # head_idx
+    # instruction_selection: mov.u32 from %tid.x, mov.u32 from %tid.y; extent: scalar per thread
+    # (the port owns one flat thread axis and derives tx = tid % BDX, ty = tid / BDX;
+    #  same thread order tid = ty * BDX + tx, so slice and head ownership are unchanged)
+
+    # =======================================================================
+    # Blend weights from the two log2-sum-exp values (source L53-59)
+    # =======================================================================
+
+    row = pos * NUM_HEADS + ty                    # (pos, head) scalar index
+    # instruction_selection: mad.lo.s32 + mul.wide.u32 + add.s64 address family; extent: per thread
+
+    s_a_val = reg_tile("f32", [1])
+    s_b_val = reg_tile("f32", [1])
+    # instruction_selection: none; extent: two f32 registers per thread
+    copy_g2r_b32(s_a + row, s_a_val)
+    # instruction_selection: ld.global.nc.b32; extent: one scalar load
+    copy_g2r_b32(s_b + row, s_b_val)
+    # instruction_selection: ld.global.nc.b32; extent: one scalar load
+
+    s_max = max(s_a_val, s_b_val)
+    # instruction_selection: max.ftz.f32; extent: one scalar
+    e_a = exp2_fast(sub(s_a_val, s_max))
+    # instruction_selection: sub.ftz.f32 + ex2.approx.ftz.f32; extent: one scalar each
+    e_b = exp2_fast(sub(s_b_val, s_max))
+    # instruction_selection: sub.ftz.f32 + ex2.approx.ftz.f32; extent: one scalar each
+    denom = add(e_a, e_b)
+    # instruction_selection: add.ftz.f32; extent: one scalar (shared by both divisions and the lse)
+    a_scale = div_fast(e_a, denom)
+    # instruction_selection: div.approx.ftz.f32; extent: one scalar
+    b_scale = div_fast(e_b, denom)
+    # instruction_selection: div.approx.ftz.f32; extent: one scalar (ptxas realizes both as one MUFU.RCP + two FMUL.FTZ)
+
+    # =======================================================================
+    # Vector loads: vec_t<float, VEC>::cast_load of v_a (L61) then v_b (L62) (source L60-62)
+    # =======================================================================
+
+    slice = row * HEAD_DIM + tx * VEC             # first element of this thread's slice
+    # instruction_selection: mul.lo.s32, cvt.u64.u32, mul.wide.u32, add.s64, shl.b64, add.s64 family; extent: per thread
+
+    # cast_load = one 16-byte load per 8 elements (vec_t::load), then the pairwise
+    # widen (vec_cast<float, DTYPE>); the source issues it for v_a, then for v_b.
+    a_bits = reg_tile("b32", [NWORDS])
+    a_vec = reg_tile("f32", [VEC])
+    # instruction_selection: none; extent: NWORDS b32 + VEC f32 registers per thread
+    for k in static_range(VEC // 8):
+        copy_g2r_v4(v_a + slice + 8 * k, a_bits[4 * k : 4 * k + 4])
+        # instruction_selection: ld.global.nc.v4.b32; extent: one 16-byte vector load (VEC//8 total; the second at [addr+16])
+    for w in static_range(NWORDS):                # vec_cast<float, DTYPE>: pairwise widen
+        lo, hi = unpack2(a_bits[w])
+        # instruction_selection: mov.b32 {lo, hi}; extent: one per word (the source's __half22float2 asm re-issues it per half: 2 per word for f16, 1 per word for bf16)
+        cast(a_vec[2 * w], lo); cast(a_vec[2 * w + 1], hi)
+        # instruction_selection: cvt.f32.f16 (f16) | cvt.f32.bf16 (bf16); extent: two scalars per word, VEC total
+
+    b_bits = reg_tile("b32", [NWORDS])
+    b_vec = reg_tile("f32", [VEC])
+    # instruction_selection: none; extent: NWORDS b32 + VEC f32 registers per thread
+    for k in static_range(VEC // 8):
+        copy_g2r_v4(v_b + slice + 8 * k, b_bits[4 * k : 4 * k + 4])
+        # instruction_selection: ld.global.nc.v4.b32; extent: one 16-byte vector load (VEC//8 total; the second at [addr+16])
+    for w in static_range(NWORDS):
+        lo, hi = unpack2(b_bits[w])
+        # instruction_selection: mov.b32 {lo, hi}; extent: one per word
+        cast(b_vec[2 * w], lo); cast(b_vec[2 * w + 1], hi)
+        # instruction_selection: cvt.f32.f16 (f16) | cvt.f32.bf16 (bf16); extent: two scalars per word, VEC total
+
+    # =======================================================================
+    # Blend: v_merged[i] = a_scale * v_a[i] + b_scale * v_b[i] (source L63-66)
+    # =======================================================================
+
+    o_vec = reg_tile("f32", [VEC])
+    # instruction_selection: none; extent: VEC f32 registers per thread
+    for i in static_range(VEC):                   # #pragma unroll, fully unrolled
+        t = mul(b_scale, b_vec[i])
+        # instruction_selection: mul.ftz.f32; extent: one scalar per element, VEC total
+        fma(o_vec[i], a_scale, a_vec[i], t)
+        # instruction_selection: fma.rn.ftz.f32; extent: one scalar per element, VEC total (nvcc contracts a*va + (b*vb) into mul + fma in this order)
+
+    # =======================================================================
+    # Vector store: vec_t<float, VEC>::cast_store into v_merged (source L67)
+    # =======================================================================
+
+    o_bits = reg_tile("b32", [NWORDS])
+    # instruction_selection: none; extent: NWORDS packed output registers per thread
+    for w in static_range(NWORDS):                # vec_cast<DTYPE, float>: pairwise narrow
+        cast2x(o_bits[w], o_vec[2 * w], o_vec[2 * w + 1])
+        # instruction_selection: cvt.rn.f16x2.f32 (f16) | cvt.rn.bf16x2.f32 (bf16), hi operand first; extent: one packed pair conversion, NWORDS total
+    for k in static_range(VEC // 8):
+        copy_r2g_v4(o_bits[4 * k : 4 * k + 4], v_merged + slice + 8 * k)
+        # instruction_selection: st.global.v4.b32; extent: one 16-byte vector store (VEC//8 total; the second at [addr+16])
+
+    # =======================================================================
+    # Merged log2-sum-exp, guarded by the source's null-pointer test (source L68-70)
+    # =======================================================================
+
+    if not isnull(s_merged):
+        # instruction_selection: setp.eq.s64 %p, s_merged, 0 + @%p bra (branch over the tail); extent: one predicate, kernel-uniform
+        lse = add(s_max, log2_fast(denom))
+        # instruction_selection: lg2.approx.ftz.f32 + add.ftz.f32; extent: one scalar each (log2(e_a + e_b) + s_max; the export commutes the add operands: add.ftz.f32 %r, s_max, lg2)
+        copy_r2g_b32(lse, s_merged + row)
+        # instruction_selection: st.global.b32; extent: one scalar store (every tx of the head writes the same value)
+```
+
+## Host wrapper and validation
+
+The Python module performs host-only work; none of it emits device PTX:
+
+```python
+def prepare_data(dtype, seq_len, num_heads, head_dim):
+    host_assert(dtype in ("float16", "bfloat16"))            # DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16
+    host_assert(head_dim in (64, 128, 256, 512))            # DISPATCH_HEAD_DIM
+    host_assert(head_dim // VEC * num_heads <= 1024)        # block limit (unchecked by the source)
+    v_a, v_b = seeded_randn((seq_len, num_heads, head_dim), dtype)
+    s_a, s_b = seeded_randn((seq_len, num_heads), f32)
+    # instruction_selection: none; extent: four tensor constructions
+
+launch_args = (v_a, s_a, v_b, s_b, v_merged, s_merged)     # flat six-pointer launch ABI
+# instruction_selection: none; extent: matches the source kernel's six pointer params;
+# the source's trailing (num_heads, head_dim) scalars are static in the port
+
+# run_test compares against flashinfer.merge_state(v_a, s_a, v_b, s_b) with the
+# source test tolerance rtol=1e-3, atol=1e-3 on both v_merged and s_merged.
+# run_bench times the primfunc launch (tirx) against the source module op
+# get_cascade_module().merge_state with preallocated outputs; both closures are
+# no-argument.
+```
+
+## Static specialization boundary
+
+| Fact | Static or runtime | Consequence |
+| --- | --- | --- |
+| `DTYPE` | static per config | selects f16/bf16 cvt opcode families; same layout |
+| `head_dim` | static per config | fixes `VEC` (8 or 16), `BDX`, the number of 16-byte loads/stores per operand (1 or 2), and the unrolled element count |
+| `num_heads` | static per config | `BDY`; folds into the `(pos, head)` and slice address arithmetic (a runtime `uint32_t` argument in the source) |
+| `seq_len` | static per config | grid extent |
+| `s_merged != nullptr` | runtime pointer predicate | kept as in the source (`setp.eq.s64` + branch); the Python path always passes a non-null pointer, so the tail always executes |
+| `-use_fast_math` | build flag | `.ftz` arithmetic, `div.approx.ftz.f32` division; `ex2`/`lg2` are already explicit `.approx.ftz` inline asm in the source |
+| unroll hints | static | the `VEC`-wide element loop carries `#pragma unroll` and is fully unrolled; there is no other loop |
+
+Automatic dispatch is outside the kernel: the source host wrapper reads
+`seq_len`, `num_heads`, `head_dim` from tensor shapes at every call and
+switches on `head_dim`; this module bakes the same values per config.
+
+## TIRx module and benchmark contract
+
+- `KERNEL_META = {"name": "merge_state", "category": "flashinfer",
+  "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"]}`.
+- The executable kernel is expressed entirely in plain TIRx: register buffers,
+  explicit global loads/stores, and native `K.ptx.*` forms for every non-trivial
+  instruction (`ld.global.nc.b32`, `ld.global.nc.v4.b32`, `max.ftz.f32`,
+  `sub.ftz.f32`, `ex2.approx.ftz.f32`, `add.ftz.f32`, `div.approx.ftz.f32`,
+  `mov.b32` unpack, `cvt.f32.f16`/`cvt.f32.bf16`, `mul.ftz.f32`,
+  `fma.rn.ftz.f32`, `cvt.rn.f16x2.f32`/`cvt.rn.bf16x2.f32`, `st.global.v4.b32`,
+  `lg2.approx.ftz.f32`, `st.global.b32`). The null test is the codegen's
+  pointer comparison (`K.isnullptr`), which lowers to `setp.eq.s64`. There is
+  no `T.cuda.func_call`, no shared memory, and no `Tx` tile primitives.
+- `get_kernel(dtype, seq_len, num_heads, head_dim)` returns the specialized
+  primfunc; `prepare_data`, `run_test`, `run_bench` follow the repository
+  contract.
+- The timed implementation is named `tirx`; flashinfer is a lazy reference
+  builder. Allocation, compilation, and correctness checks stay outside timing.
+- Correctness reference is the source implementation itself
+  (`flashinfer.merge_state`), tolerance `rtol=1e-3, atol=1e-3` as in the source
+  test suite (`tests/attention/test_shared_prefix_kernels.py`).
+
+## Instruction selection is a lowering consequence
+
+The sketch above never requests a hardware instruction beyond the two
+`math::` inline-asm wrappers the source itself spells (`ex2`, `lg2`). The
+following lowering families follow from storage direction, shape, dtype, and
+the production build flags. PTX names and static counts are taken from the
+fresh line-info export cited above (`sm_103a`; the `sm_100a` export differs
+only in its `.target` line and in re-loading the `s_merged` parameter inside
+the guarded tail instead of reusing the entry register — register-allocation
+noise with the same instruction families); they are audit evidence, not
+operands.
+
+| Primitive/schedule pattern | PTX family (fresh export) |
+| --- | --- |
+| `copy_g2r_b32` lse loads | `ld.global.nc.b32` (2) |
+| `copy_g2r_v4` v_a/v_b loads | `ld.global.nc.v4.b32` (2 for VEC=8, 4 for VEC=16; the second of a pair addresses `[base+16]`) |
+| `max` | `max.ftz.f32` (1) |
+| `sub` before each `ex2` | `sub.ftz.f32` (2) |
+| `exp2_fast` (`math::ptx_exp2`) | `ex2.approx.ftz.f32` (2), SASS `MUFU.EX2` x2 |
+| `add` denominator, `add` lse | `add.ftz.f32` (2) |
+| `div_fast` | `div.approx.ftz.f32` (2); SASS: one `MUFU.RCP` + `FMUL.FTZ` x2 |
+| `unpack2` | `mov.b32 {lo, hi}` (f16: 2 per word = 2*VEC total because `__half22float2` re-unpacks per half; bf16: 1 per word = VEC total) |
+| `cast` widen | `cvt.f32.f16` (VEC*2 total) for f16, SASS `HADD2.F32`; `cvt.f32.bf16` (VEC*2 total) for bf16, SASS `PRMT` + `SHF.L.U32` / `IMAD.U32 ..., 0x10000` (both shift-left-16 forms) |
+| blend `mul`/`fma` | `mul.ftz.f32` (VEC) + `fma.rn.ftz.f32` (VEC) |
+| `cast2x` narrow | `cvt.rn.f16x2.f32` / `cvt.rn.bf16x2.f32` (NWORDS), SASS `F2FP.{F16,BF16}.F32.PACK_AB` |
+| `copy_r2g_v4` store | `st.global.v4.b32` (1 for VEC=8, 2 for VEC=16) |
+| `isnull` guard | `setp.eq.s64` (1) + `@%p bra` (1); SASS `ISETP.NE.U32.AND` + `ISETP.NE.AND.EX` + `@!P0 EXIT` |
+| `log2_fast` (`math::ptx_log2`) | `lg2.approx.ftz.f32` (1), SASS `MUFU.LG2` |
+| `copy_r2g_b32` lse store | `st.global.b32` (1) |
+| address/index arithmetic | `mad.lo.s32`, `mul.lo.s32`, `mul.wide.u32`, `cvt.u64.u32`, `shl.b64`, `add.s64`; `cvta.to.global.u64` entry-only |
+
+Static PTX opcode counts per exported instantiation (straight-line kernel, no
+loops; instruction lines, none predicated except the one `bra`):
+
+| Family | f16 VEC=8 | bf16 VEC=8 | f16 VEC=16 | bf16 VEC=16 |
+| --- | ---: | ---: | ---: | ---: |
+| `ld.global.nc.b32` | 2 | 2 | 2 | 2 |
+| `ld.global.nc.v4.b32` | 2 | 2 | 4 | 4 |
+| `max.ftz.f32` | 1 | 1 | 1 | 1 |
+| `sub.ftz.f32` | 2 | 2 | 2 | 2 |
+| `ex2.approx.ftz.f32` | 2 | 2 | 2 | 2 |
+| `add.ftz.f32` | 2 | 2 | 2 | 2 |
+| `div.approx.ftz.f32` | 2 | 2 | 2 | 2 |
+| `mov.b32` (unpack) | 16 | 8 | 32 | 16 |
+| `cvt.f32.f16` / `cvt.f32.bf16` | 16 | 16 | 32 | 32 |
+| `mul.ftz.f32` | 8 | 8 | 16 | 16 |
+| `fma.rn.ftz.f32` | 8 | 8 | 16 | 16 |
+| `cvt.rn.f16x2.f32` / `cvt.rn.bf16x2.f32` | 4 | 4 | 8 | 8 |
+| `st.global.v4.b32` | 1 | 1 | 2 | 2 |
+| `setp.eq.s64` / `bra` | 1 / 1 | 1 / 1 | 1 / 1 | 1 / 1 |
+| `lg2.approx.ftz.f32` | 1 | 1 | 1 | 1 |
+| `st.global.b32` | 1 | 1 | 1 | 1 |
+| ptxas registers (`-v`, sm_103a) | 31 | 28 | 32 | 32 |
+
+The bf16 entries differ from f16 only in the unpack/widen and pack opcode
+suffixes (`cvt.f32.bf16`, `cvt.rn.bf16x2.f32`) and in issuing one `mov.b32`
+per word instead of two; the SASS realizes the bf16 widen as `PRMT` plus
+`SHF.L.U32` / `IMAD.U32` shift-left-16 forms where f16 uses `HADD2.F32`. The VEC=16 entries run the same
+per-element sequence 16-wide between two 16-byte loads per operand and two
+16-byte stores.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ keeps them in sync.
 
 | Architecture | Kernels |
 |---|---:|
-| `sm_100a` | 103 |
-| `sm_103a` | 98 |
-| `sm_107a` | 94 |
+| `sm_100a` | 104 |
+| `sm_103a` | 99 |
+| `sm_107a` | 95 |
 | `sm_110a` | 12 |
 
 ### Native TIRx
@@ -94,6 +94,8 @@ Grouped by the FlashInfer Python entry point each port backs.
 - **`flashinfer.activation`:**
   [`act_and_mul`](tirx_kernels/flashinfer/activation/act_and_mul.py),
   [`silu_and_mul_nvfp4_experts_quantize`](tirx_kernels/flashinfer/activation/silu_and_mul_nvfp4_experts_quantize.py)
+- **`flashinfer.cascade`:**
+  [`merge_state`](tirx_kernels/flashinfer/cascade/merge_state.py)
 - **`flashinfer.quantization`:**
   [`nvfp4_quantize`](tirx_kernels/flashinfer/quantization/nvfp4_quantize.py),
   [`nvfp4_quantize_per_token`](tirx_kernels/flashinfer/quantization/nvfp4_quantize_per_token.py),

--- a/tests/test_bench_suite_run.py
+++ b/tests/test_bench_suite_run.py
@@ -220,11 +220,11 @@ def test_default_roster_is_available_on_sm103_and_sm107():
     def kernels(rows):
         return {workload["kernel"] for workload in rows}
 
-    # There are 310 default rows. The three FlexAttention kernels contribute three rows each:
+    # There are 313 default rows. The three FlexAttention kernels contribute three rows each:
     # backward is sm_100a-only, forward_hd256 supports sm_100a/sm_103a, and generic forward is
     # sm_103a-only. The exact compatible and incompatible rosters below also cover the existing
     # single-architecture kernels from the mirror.
-    assert len(sm107) == 274
+    assert len(sm107) == 277
     assert len(sm107_incompatible) == 36
     assert kernels(sm107_incompatible) == {
         "blackwell_msa_decode_q1_bf16_query_fp8_kv_xform2_paged_sm103",
@@ -240,7 +240,7 @@ def test_default_roster_is_available_on_sm103_and_sm107():
         "fastcu_nvfp4_gemm_gb300",
         "flash_attention4_fp4",
     }
-    assert len(sm103) == 286
+    assert len(sm103) == 289
     assert len(sm103_incompatible) == 24
     assert kernels(sm103_incompatible) == {
         "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin",
@@ -252,7 +252,7 @@ def test_default_roster_is_available_on_sm103_and_sm107():
         "dense_blockscaled_gemm_sm107",
         "grouped_gemm_masked_rubin",
     }
-    assert len(sm100) == 277
+    assert len(sm100) == 280
     assert len(sm100_incompatible) == 33
     assert kernels(sm100_incompatible) == {
         "blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion_rubin",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -61,7 +61,7 @@ def test_exact_architectures_are_stored_in_source_index():
         ("sm_100a",): 12,
         ("sm_103a",): 7,
         ("sm_107a",): 4,
-        ("sm_100a", "sm_103a", "sm_107a"): 78,
+        ("sm_100a", "sm_103a", "sm_107a"): 79,
         ("sm_100a", "sm_103a", "sm_107a", "sm_110a"): 12,
     }
 

--- a/tirx_kernels/bench_suite/README.md
+++ b/tirx_kernels/bench_suite/README.md
@@ -15,12 +15,13 @@ replace the direct verdict. The same flag exists on
 registered kernel has one file. Files with `default_suite: true` select one to
 three representative single-GPU rows with `default: true`; curated three-row
 files label them `small`, `medium`, and `large`. The current default roster is
-284 rows across 97 device kernels: 260 rows from 89 kernels validated on
-`sm_100a`, `sm_103a`, and `sm_107a`, plus three rows each from eight
-single-architecture kernels (the `sm_107a`-only Rubin BMM and SM107 block-scaled
-GEMM, the `sm_100a`-only Cake VSA blk128/longseq/ultrasparse ports, and the
-`sm_103a`-only Cake VSA longseq, fast.cu NVFP4 GEMM, and FP4 FA4 forward). Thus
-an SM107 run selects 266 rows while SM100 and SM103 runs select 269.
+313 rows across 106 device kernels: 265 rows from 90 kernels validated on
+`sm_100a`, `sm_103a`, and `sm_107a`, three rows each from fifteen
+single-architecture kernels (`sm_107a`-only Rubin ports, `sm_100a`-only Cake
+VSA, MSA and FlexAttention backward ports, `sm_103a`-only Cake VSA longseq,
+fast.cu NVFP4 GEMM, FP4 FA4 forward, MSA and FlexAttention forward ports), and
+three rows from the `sm_100a`/`sm_103a` FlexAttention hd256 forward. Thus an
+SM107 run selects 277 rows, an SM103 run 289, and an SM100 run 280.
 GPU runs retain only rows registered for the pool's exact architecture.
 
 With no `--workloads`, the suite writes the selected rows to

--- a/tirx_kernels/bench_suite/config/flashinfer/cascade/merge_state.yaml
+++ b/tirx_kernels/bench_suite/config/flashinfer/cascade/merge_state.yaml
@@ -1,0 +1,11 @@
+kernel: merge_state
+selection_rationale: A decode-sized f16 head_dim-128 merge, the docstring-sized f16 case, and the largest bf16 prefill case span grid scale and dtype; the head_dim 64/256/512 rows cover the other vec_size/bdx specializations without being default.
+configs:
+  - {config: fp16_s128_h32_d128, default: true, selection_role: small}
+  - {config: fp16_s2048_h32_d128, default: true, selection_role: medium}
+  - {config: fp16_s16384_h32_d128, default: false}
+  - {config: bf16_s2048_h32_d128, default: false}
+  - {config: bf16_s16384_h32_d128, default: true, selection_role: large}
+  - {config: fp16_s2048_h32_d64, default: false}
+  - {config: fp16_s2048_h32_d256, default: false}
+  - {config: fp16_s2048_h8_d512, default: false}

--- a/tirx_kernels/flashinfer/cascade/__init__.py
+++ b/tirx_kernels/flashinfer/cascade/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""Ports of the kernels behind ``flashinfer.cascade``."""

--- a/tirx_kernels/flashinfer/cascade/merge_state.py
+++ b/tirx_kernels/flashinfer/cascade/merge_state.py
@@ -1,0 +1,395 @@
+# This file is a TIRx port of code from FlashInfer
+# (https://github.com/flashinfer-ai/flashinfer @ f2e04400), Copyright (c) 2023 by FlashInfer team.
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright TIRx authors
+
+"""FlashInfer ``MergeStateKernel`` port.
+
+Ports ``flashinfer::MergeStateKernel<vec_size, DTypeIn, DTypeO>``
+(``include/flashinfer/attention/cascade.cuh``), the kernel behind
+``flashinfer.cascade.merge_state``: it merges the partial attention outputs
+``v_a``/``v_b`` and their base-2 log-sum-exp values ``s_a``/``s_b`` of two
+KV segments into the output of the concatenated segment.  ``dtype`` mirrors
+the f16/bf16 runtime dispatch of ``csrc/cascade.cu``; ``head_dim`` selects the
+``vec_size`` template argument through ``DISPATCH_HEAD_DIM`` exactly as the
+source host launcher ``flashinfer::MergeState`` does.  One CTA per position,
+``head_dim / vec_size`` threads per head along ``x`` and one head per ``y``.
+"""
+
+from typing import Any
+
+import tirx_kernels.kern as K
+from tirx_kernels.runner import bench
+
+KERNEL_META = {
+    "name": "merge_state",
+    "category": "flashinfer",
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "reference_requirements": (
+        {
+            "package": "flashinfer-python",
+            "git": {
+                "url": "https://github.com/flashinfer-ai/flashinfer.git",
+                "commit": "f2e04400e330fb2debe0bf8730d9424a1d37927f",
+            },
+            "import": "flashinfer",
+        },
+        {"package": "nvidia-cutlass-dsl", "specifier": "==4.8.0.dev0", "import": "cutlass"},
+    ),
+}
+
+# Source dispatch domain: DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16 (f16/bf16 only) and
+# DISPATCH_HEAD_DIM (utils.cuh) with the MergeState launch formulae.
+_DTYPES = ("float16", "bfloat16")
+_HEAD_DIMS = (64, 128, 256, 512)
+ELEM_BYTES = 2  # fp16/bf16
+MAX_THREADS = 1024
+
+
+def _vec_size(head_dim: int) -> int:
+    # MergeState: constexpr vec_size = max(16 / sizeof(DTypeIn), HEAD_DIM / 32)
+    return max(16 // ELEM_BYTES, head_dim // 32)
+
+
+def _bdx(head_dim: int) -> int:
+    return head_dim // _vec_size(head_dim)
+
+
+def _validate(dtype: str, seq_len: int, num_heads: int, head_dim: int) -> None:
+    if dtype not in _DTYPES:
+        raise ValueError(f"Unsupported dtype: {dtype}")
+    if head_dim not in _HEAD_DIMS:
+        raise ValueError(f"head_dim={head_dim} outside the source DISPATCH_HEAD_DIM domain")
+    if seq_len < 1 or num_heads < 1:
+        raise ValueError("seq_len and num_heads must be positive")
+    if _bdx(head_dim) * num_heads > MAX_THREADS:
+        raise ValueError(
+            f"bdx*bdy = {_bdx(head_dim)}*{num_heads} exceeds the {MAX_THREADS}-thread block limit"
+        )
+
+
+def _torch_dtype(dtype: str):
+    import torch
+
+    return {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
+
+
+def get_kernel(dtype: str, seq_len: int, num_heads: int, head_dim: int, **kwargs):
+    """Return the TIRx specialization for one (dtype, seq_len, num_heads, head_dim) config."""
+    _validate(dtype, seq_len, num_heads, head_dim)
+    vec = _vec_size(head_dim)  # source template vec_size
+    bdx = _bdx(head_dim)  # source blockDim.x
+    nwords = vec // 2  # packed b32 words per slice
+    nthreads = bdx * num_heads  # source blockDim.x * blockDim.y
+    warps = (nthreads + 31) // 32
+    bdx_shift = bdx.bit_length() - 1  # bdx is 8, 16, or 32
+    is_f16 = dtype == "float16"
+
+    def widen_pair(dst, w, word):
+        # vec_cast<float, DTypeIn>: one packed pair -> two f32.
+        if is_f16:
+            # __half22float2: mov.b32 {lo, hi} + cvt.f32.f16 x2 (K.idioms spells the same sequence).
+            K.idioms.cast_f16x2_to_f32x2(dst, w, word)
+        else:
+            # __bfloat1622float2: mov.b32 {lo, hi} + cvt.f32.bf16 x2.
+            halves = K.alloc_local([2], "uint16")
+            K.ptx.mov.b32(halves[0], halves[1], word)
+            K.ptx.cvt.f32.bf16(dst[2 * w], halves[0])
+            K.ptx.cvt.f32.bf16(dst[2 * w + 1], halves[1])
+
+    def narrow_pair(dst, lo, hi):
+        # vec_cast<DTypeO, float>: __float22half2_rn / __float22bfloat162_rn, hi operand first.
+        if is_f16:
+            K.ptx.cvt.rn.f16x2.f32(dst, hi, lo)
+        else:
+            K.ptx.cvt.rn.bf16x2.f32(dst, hi, lo)
+
+    @K.kernel(warps=warps, arch="sm_100a", grid=seq_len)
+    def merge_state(
+        v_a: K.gptr[dtype],
+        s_a: K.gptr[K.f32],
+        v_b: K.gptr[dtype],
+        s_b: K.gptr[K.f32],
+        v_merged: K.gptr[dtype],
+        s_merged: K.gptr[K.f32],
+    ):
+        pos = K.cta_id()  # blockIdx.x
+        tid = K.thread_id()
+        # The source launches a (bdx, bdy) block and reads threadIdx.x / threadIdx.y.
+        # Kern owns one flat thread axis of the same order (tid = ty * bdx + tx).
+        if bdx == 32:
+            # One warp per head: the lane and warp ids are exactly (tx, ty).
+            tx = K.lane_id()
+            ty = K.warp_id()  # head_idx, warp-uniform
+        else:
+            tx = tid & (bdx - 1)
+            ty = tid >> bdx_shift  # head_idx
+
+        def body():
+            # ---- blend weights from the two log2-sum-exp values (source L53-59) ----
+            row = K.local_scalar("int32", init=pos * num_heads + ty)  # pos * num_heads + head_idx
+            row64 = K.Cast("int64", row)
+            s_a_val = K.local_scalar("float32")
+            s_b_val = K.local_scalar("float32")
+            K.ptx.ld.global_.nc.b32(s_a_val, s_a.ptr_to([row64]))
+            K.ptx.ld.global_.nc.b32(s_b_val, s_b.ptr_to([row64]))
+            s_max = K.local_scalar("float32")
+            K.ptx.max.ftz.f32(s_max, s_a_val, s_b_val)
+            d_a = K.local_scalar("float32")
+            d_b = K.local_scalar("float32")
+            e_a = K.local_scalar("float32")
+            e_b = K.local_scalar("float32")
+            K.ptx.sub.ftz.f32(d_a, s_a_val, s_max)
+            K.ptx.ex2.approx.ftz.f32(e_a, d_a)  # math::ptx_exp2
+            K.ptx.sub.ftz.f32(d_b, s_b_val, s_max)
+            K.ptx.ex2.approx.ftz.f32(e_b, d_b)  # math::ptx_exp2
+            denom = K.local_scalar("float32")
+            K.ptx.add.ftz.f32(denom, e_a, e_b)
+            a_scale = K.local_scalar("float32")
+            b_scale = K.local_scalar("float32")
+            # `/` under the production -use_fast_math build: div.approx.ftz.f32.
+            K.ptx.div.approx.ftz.f32(a_scale, e_a, denom)
+            K.ptx.div.approx.ftz.f32(b_scale, e_b, denom)
+
+            # ---- cast_load of the vec_size slice: v_a (L61), then v_b (L62) ----
+            slice_ = K.local_scalar("int32", init=row * head_dim + tx * vec)
+            slice64 = K.Cast("int64", slice_)
+
+            a_bits = K.alloc_local([nwords], "uint32")
+            a_vec = K.alloc_local([vec], "float32")
+            for k in range(vec // 8):
+                K.ptx.ld.global_.nc.v4.b32(
+                    a_bits[4 * k],
+                    a_bits[4 * k + 1],
+                    a_bits[4 * k + 2],
+                    a_bits[4 * k + 3],
+                    v_a.ptr_to([slice64 + 8 * k]),
+                )
+            for w in range(nwords):
+                widen_pair(a_vec, w, a_bits[w])
+
+            b_bits = K.alloc_local([nwords], "uint32")
+            b_vec = K.alloc_local([vec], "float32")
+            for k in range(vec // 8):
+                K.ptx.ld.global_.nc.v4.b32(
+                    b_bits[4 * k],
+                    b_bits[4 * k + 1],
+                    b_bits[4 * k + 2],
+                    b_bits[4 * k + 3],
+                    v_b.ptr_to([slice64 + 8 * k]),
+                )
+            for w in range(nwords):
+                widen_pair(b_vec, w, b_bits[w])
+
+            # ---- v_merged[i] = a_scale * v_a[i] + b_scale * v_b[i] (L63-66) ----
+            # nvcc contracts the source expression into mul(b_scale, v_b) + fma(a_scale, v_a, .).
+            o_vec = K.alloc_local([vec], "float32")
+            bt = K.alloc_local([vec], "float32")
+            for i in range(vec):
+                K.ptx.mul.ftz.f32(bt[i], b_scale, b_vec[i])
+                K.ptx.fma.rn.ftz.f32(o_vec[i], a_scale, a_vec[i], bt[i])
+
+            # ---- cast_store of the merged slice (L67) ----
+            o_bits = K.alloc_local([nwords], "uint32")
+            for w in range(nwords):
+                narrow_pair(o_bits[w], o_vec[2 * w], o_vec[2 * w + 1])
+            for k in range(vec // 8):
+                K.ptx.st.global_.v4.b32(
+                    v_merged.ptr_to([slice64 + 8 * k]),
+                    o_bits[4 * k],
+                    o_bits[4 * k + 1],
+                    o_bits[4 * k + 2],
+                    o_bits[4 * k + 3],
+                )
+
+            # ---- merged log2-sum-exp behind the source's null-pointer guard (L68-70) ----
+            with K.If(K.Not(K.isnullptr(s_merged.data))), K.Then():
+                lg = K.local_scalar("float32")
+                lse = K.local_scalar("float32")
+                K.ptx.lg2.approx.ftz.f32(lg, denom)  # math::ptx_log2
+                K.ptx.add.ftz.f32(lse, s_max, lg)
+                K.ptx.st.global_.b32(s_merged.ptr_to([row64]), lse)
+
+        if nthreads % 32 == 0:
+            body()
+        else:
+            # The source block is exactly bdx * bdy threads; Kern pads it to whole
+            # warps, so the padding threads (which would alias head bdy) must idle.
+            with K.If(tid < nthreads), K.Then():
+                body()
+
+    return merge_state.func
+
+
+def prepare_data(dtype: str, seq_len: int, num_heads: int, head_dim: int, **kwargs):
+    """Create the logical inputs: v_a/v_b (seq_len, num_heads, head_dim), s_a/s_b (seq_len, num_heads)."""
+    import torch
+
+    _validate(dtype, seq_len, num_heads, head_dim)
+    torch.manual_seed(42)
+    tdt = _torch_dtype(dtype)
+    v_a = torch.randn(seq_len, num_heads, head_dim, dtype=tdt, device="cuda")
+    s_a = torch.randn(seq_len, num_heads, dtype=torch.float32, device="cuda")
+    v_b = torch.randn(seq_len, num_heads, head_dim, dtype=tdt, device="cuda")
+    s_b = torch.randn(seq_len, num_heads, dtype=torch.float32, device="cuda")
+    return v_a, s_a, v_b, s_b
+
+
+def _kernel_args(v_a, s_a, v_b, s_b, v_merged, s_merged):
+    return (
+        v_a.view(-1),
+        s_a.view(-1),
+        v_b.view(-1),
+        s_b.view(-1),
+        v_merged.view(-1),
+        s_merged.view(-1),
+    )
+
+
+def prepare_bench(**kwargs: Any):
+    """Specialize and compile before the workload receives a GPU."""
+    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+
+    state = {"config": dict(kwargs), "executable": compile_kernel(get_kernel(**kwargs))}
+    return prepared_gpu_benchmark(run_gpu, state)
+
+
+def run_test(dtype: str, seq_len: int, num_heads: int, head_dim: int, **kwargs):
+    """Compile, launch, and validate one config against the flashinfer source."""
+    import torch
+
+    from tirx_kernels.runner import compile_kernel
+
+    v_a, s_a, v_b, s_b = prepare_data(
+        dtype=dtype, seq_len=seq_len, num_heads=num_heads, head_dim=head_dim
+    )
+    kernel = get_kernel(dtype=dtype, seq_len=seq_len, num_heads=num_heads, head_dim=head_dim)
+    ex = compile_kernel(kernel)
+    v_out = torch.empty_like(v_a)
+    s_out = torch.empty_like(s_a)
+    ex(*_kernel_args(v_a, s_a, v_b, s_b, v_out, s_out))
+    torch.cuda.synchronize()
+
+    import flashinfer
+
+    v_ref, s_ref = flashinfer.merge_state(v_a, s_a, v_b, s_b)
+    torch.cuda.synchronize()
+    # Source test tolerance (tests/attention/test_shared_prefix_kernels.py): rtol=1e-3, atol=1e-3.
+    torch.testing.assert_close(v_out, v_ref, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(s_out, s_ref, rtol=1e-3, atol=1e-3)
+
+
+def run_gpu(prepared, *, warmup=None, repeat=None, timer=None, rounds=1, cooldown_s=1.0, **kwargs):
+    """Benchmark the TIRx port against the flashinfer source kernel."""
+    config = dict(prepared["config"])
+    dtype = config.pop("dtype")
+    seq_len = config.pop("seq_len")
+    num_heads = config.pop("num_heads")
+    head_dim = config.pop("head_dim")
+    config.update(kwargs)
+    kwargs = config
+    executable = prepared["executable"]
+    import torch
+
+    v_a, s_a, v_b, s_b = prepare_data(
+        dtype=dtype, seq_len=seq_len, num_heads=num_heads, head_dim=head_dim
+    )
+    v_out = torch.empty_like(v_a)
+    s_out = torch.empty_like(s_a)
+    args = _kernel_args(v_a, s_a, v_b, s_b, v_out, s_out)
+
+    funcs = {"tirx": lambda: executable(*args)}
+
+    def build_reference():
+        # The source module op with preallocated outputs, i.e. exactly the launch
+        # flashinfer.merge_state performs after its two torch.empty_like calls.
+        from flashinfer.cascade import get_cascade_module
+
+        op = get_cascade_module().merge_state
+        v_fi = torch.empty_like(v_a)
+        s_fi = torch.empty_like(s_a)
+        return lambda: op(v_a, s_a, v_b, s_b, v_fi, s_fi)
+
+    return bench(
+        funcs,
+        references={"flashinfer": build_reference},
+        warmup=warmup,
+        repeat=repeat,
+        timer=timer,
+        rounds=rounds,
+        cooldown_s=cooldown_s,
+    )
+
+
+def run_bench(
+    dtype: str,
+    seq_len: int,
+    num_heads: int,
+    head_dim: int,
+    *,
+    warmup=None,
+    repeat=None,
+    timer=None,
+    rounds=1,
+    cooldown_s=1.0,
+    **kwargs,
+):
+    config = dict(kwargs)
+    prepared = prepare_bench(
+        dtype=dtype, seq_len=seq_len, num_heads=num_heads, head_dim=head_dim, **config
+    )
+    return prepared.run_gpu(
+        warmup=warmup, repeat=repeat, timer=timer, rounds=rounds, cooldown_s=cooldown_s
+    )
+
+
+def _cfg(dtype, seq_len, num_heads, head_dim):
+    dt = {"float16": "fp16", "bfloat16": "bf16"}[dtype]
+    return {
+        "label": f"{dt}_s{seq_len}_h{num_heads}_d{head_dim}",
+        "dtype": dtype,
+        "seq_len": seq_len,
+        "num_heads": num_heads,
+        "head_dim": head_dim,
+    }
+
+
+# Correctness matrix.  Covers: both dtypes; every DISPATCH_HEAD_DIM branch
+# (64/128/256 -> vec_size 8 with bdx 8/16/32, 512 -> vec_size 16); the
+# 1024-thread block bound for each bdx; single-position and odd grids; and the
+# source test shape (seq_len 512, 32 heads, head_dim 128).
+CONFIGS = [
+    # head_dim branches on a standard head count
+    _cfg("float16", 37, 8, 64),
+    _cfg("float16", 37, 8, 128),
+    _cfg("float16", 37, 8, 256),
+    _cfg("float16", 37, 8, 512),
+    _cfg("bfloat16", 37, 8, 128),
+    _cfg("bfloat16", 37, 8, 256),
+    _cfg("bfloat16", 37, 8, 512),
+    # block bound: bdx * num_heads == 1024 for bdx 8 / 16 / 32
+    _cfg("float16", 5, 128, 64),
+    _cfg("float16", 3, 64, 128),
+    _cfg("float16", 3, 32, 256),
+    _cfg("bfloat16", 2, 32, 512),
+    # single head, single position (one partial warp)
+    _cfg("float16", 1, 1, 128),
+    _cfg("bfloat16", 1, 1, 64),
+    # source test shape and the docstring example
+    _cfg("float16", 512, 32, 128),
+    _cfg("bfloat16", 2048, 32, 128),
+]
+
+# Benchmark sweep: cascade-inference merge shapes.  seq_len = 128 (decode
+# batch), 2048 (docstring example), 16384 (large prefill); head_dim 64/128/256
+# with 32 heads and 512 with 8 heads; f16 and bf16.
+BENCH_CONFIGS = [
+    _cfg("float16", 128, 32, 128),
+    _cfg("float16", 2048, 32, 128),
+    _cfg("float16", 16384, 32, 128),
+    _cfg("bfloat16", 2048, 32, 128),
+    _cfg("bfloat16", 16384, 32, 128),
+    _cfg("float16", 2048, 32, 64),
+    _cfg("float16", 2048, 32, 256),
+    _cfg("float16", 2048, 8, 512),
+]


### PR DESCRIPTION
## Summary

- port FlashInfer `MergeStateKernel<vec_size, DTypeIn, DTypeO>` (`include/flashinfer/attention/cascade.cuh`, the kernel behind `flashinfer.cascade.merge_state`) from commit `f2e04400e330fb2debe0bf8730d9424a1d37927f`, as a new `flashinfer.cascade` group
- cover the source dispatch domain: FP16/BF16 (`DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16`) and head_dim 64/128/256/512 (`DISPATCH_HEAD_DIM`), i.e. `vec_size` 8 (bdx 8/16/32) and 16 (bdx 32)
- preserve the source launch shape (one CTA per position, `head_dim / vec_size` threads per head), the `ex2.approx.ftz` / `div.approx.ftz` blend weights, 16-byte `cast_load`/`cast_store` paths, the `mul + fma` blend, and the runtime `s_merged != nullptr` guard around `lg2.approx.ftz`
- add the reviewed kernel sketch (`.agents/sketch/flashinfer/cascade/merge_state.md`), 15 correctness configurations, 8 benchmark configurations, the curated bench-suite workloads, and README registration
- refresh the bench-suite roster counts in `tirx_kernels/bench_suite/README.md` and `test_default_roster_is_available_on_sm103_and_sm107`, which had drifted from the 310 default rows already in the tree

## Validation

- `python -m tirx_kernels.test --kernel merge_state`: 15/15 passed, 0 failed, 0 skipped against `flashinfer.merge_state` (rtol/atol 1e-3; covers every head_dim branch, the 1024-thread block bound for each bdx, single-position and partial-warp grids, and the source test shape 512x32x128)
- reference-enabled bench-suite on the full 8-shape benchmark matrix: 8/8 `status=ok`, every shape above `0.99x`; minimum `flashinfer / tirx` ratio `0.9935`
- paired NCU (d256 and s16384 shapes): identical DRAM bytes, L1/L2 sectors, and global load/store instruction counts; the port executes 4.8% fewer warp instructions, 31 registers on both sides, no local memory
- `python -m tirx_kernels.bench_suite --check-imports`, `tests/test_registry.py`, `tests/test_bench_suite_run.py`, `tests/test_kern_api.py` passed
- `pre-commit run --all-files` passed (ruff check, ruff format, clang-format, license headers, README kernel listing)

Hardware note: validated on an sm_103a (B300) pod only. `runtime_cuda_archs` lists sm_100a/sm_103a/sm_107a because the source kernel has no architecture-specific code; happy to narrow it to sm_103a, and the baseline was not refreshed for the same reason.

## Benchmark

`python -m tirx_kernels.bench_suite --workloads <all 8 configs> --with-references --rounds 15`, proton timer, sm_103a. Reference is the source module op `get_cascade_module().merge_state` with preallocated outputs, i.e. exactly the launch `flashinfer.merge_state` performs.

| config | tirx (µs) | flashinfer (µs) | flashinfer / tirx |
|---|---:|---:|---:|
| `fp16_s128_h32_d128` | 2.825 | 2.824 | 1.000 |
| `fp16_s2048_h32_d128` | 10.530 | 10.533 | 1.000 |
| `fp16_s16384_h32_d128` | 65.198 | 65.230 | 1.001 |
| `bf16_s2048_h32_d128` | 11.102 | 11.300 | 1.018 |
| `bf16_s16384_h32_d128` | 65.384 | 65.232 | 0.998 |
| `fp16_s2048_h32_d64` | 6.867 | 6.914 | 1.007 |
| `fp16_s2048_h32_d256` | 19.908 | 19.780 | 0.994 |
| `fp16_s2048_h8_d512` | 10.439 | 10.378 | 0.994 |

The kernel is bandwidth-bound (the two 16384-position shapes reach the same ~70% combined memory throughput on both sides); the two lowest ratios are within the observed ±1% run-to-run spread of both implementations across repeated runs (d256 measured 0.987–1.004 over five runs, with the reference itself moving between 19.57 and 20.01 µs).
