### PR TITLE
perf(thor): enable KDA, GDN prefill, GDN2 prefill, and FA4 backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ intermediate candidates remain outside this package. See the
 contract and results.
 
 - **KDA forward:**
-  [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py)
+  [`agent_evolved_kda_forward_b1_t8192`](tirx_kernels/agent_evolved/kda_forward_b1_t8192.py) ⟨+sm_110a⟩
 - **DeepSeek-V3 FP8 MoE:**
   [`agent_evolved_moe_fp8_blockscale_dsv3`](tirx_kernels/agent_evolved/moe_fp8_blockscale_dsv3.py) ⟨sm_100a⟩
 
@@ -54,9 +54,9 @@ contract and results.
   [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
 - **Linear attention:**
   [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
-  [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py),
+  [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
-  [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py),
+  [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py),
   [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),
   [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
@@ -80,7 +80,7 @@ contract and results.
   [`flash_attention4`](tirx_kernels/flashattention/flash_attention4.py) ⟨+sm_110a⟩,
   [`flash_attention4_fp4`](tirx_kernels/flashattention/flash_attention4_fp4.py) ⟨sm_103a⟩
 - **Backward:**
-  [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py)
+  [`flash_attention_backward_sm100`](tirx_kernels/flashattention/flash_attention_backward.py) ⟨+sm_110a⟩
 
 ### FlashInfer ports
 

--- a/tirx_kernels/agent_evolved/kda_forward_b1_t8192.py
+++ b/tirx_kernels/agent_evolved/kda_forward_b1_t8192.py
@@ -2423,7 +2423,7 @@ CONFIGS = [
 KERNEL_META = {
     "name": "agent_evolved_kda_forward_b1_t8192",
     "category": "agent_evolved",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flash-linear-attention",

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -523,6 +523,60 @@ Grouped workloads show one row per config and one timing column per implementati
 
 ## Jetson AGX Thor (`sm_110a`)
 
+### agent_evolved_kda_forward_b1_t8192
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `h96_fixed` | tirx | 6531.8080 | flash_kda | 16013.1360 | 2.452 | — |
+| `h96_uniform` | tirx | 6719.4230 | flash_kda | 17103.4660 | 2.545 | — |
+| `h64_uniform` | tirx | 4590.0820 | flash_kda | 11915.7180 | 2.596 | — |
+
+### cudnn_sm100_gdn_prefill_f16
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `perf_b16_s8192_h64_nostate` | tirx | 48456.4055 | cudnn_frontend | 52156.1827 | 1.076 | — |
+| `perf_b16_s8192_h64_state` | tirx | 71834.9177 | cudnn_frontend | 75027.4035 | 1.044 | — |
+| `perf_b1_s8192_h64_nostate` | tirx | 3373.5589 | cudnn_frontend | 3566.0714 | 1.057 | — |
+| `perf_b1_s8192_h64_state` | tirx | 5417.8802 | cudnn_frontend | 5562.0063 | 1.027 | — |
+| `perf_b2_s8192_h64_nostate` | tirx | 6463.8619 | cudnn_frontend | 6917.2765 | 1.070 | — |
+| `perf_b2_s8192_h64_state` | tirx | 10431.7077 | cudnn_frontend | 10610.2611 | 1.017 | — |
+| `perf_b4_s16384_h64_nostate` | tirx | 25375.6592 | cudnn_frontend | 27125.7366 | 1.069 | — |
+| `perf_b4_s16384_h64_state` | tirx | 41456.0619 | cudnn_frontend | 43139.1787 | 1.041 | — |
+| `perf_b4_s2048_h64_nostate` | tirx | 3392.6928 | cudnn_frontend | 3608.9931 | 1.064 | — |
+| `perf_b4_s2048_h64_state` | tirx | 5434.0191 | cudnn_frontend | 5449.2560 | 1.003 | — |
+| `perf_b4_s32768_h64_nostate` | tirx | 47628.0536 | cudnn_frontend | 48091.0625 | 1.010 | — |
+| `perf_b4_s32768_h64_state` | tirx | 73405.5111 | cudnn_frontend | 76815.0665 | 1.046 | — |
+| `perf_b4_s4096_h64_nostate` | tirx | 6533.7592 | cudnn_frontend | 6961.6331 | 1.065 | — |
+| `perf_b4_s4096_h64_state` | tirx | 10595.4457 | cudnn_frontend | 10616.4183 | 1.002 | — |
+| `perf_b4_s8192_h64_nostate` | tirx | 12767.4998 | cudnn_frontend | 13657.9609 | 1.070 | — |
+| `perf_b4_s8192_h64_state` | tirx | 20791.4739 | cudnn_frontend | 21065.2219 | 1.013 | — |
+| `perf_b8_s8192_h64_nostate` | tirx | 25599.3496 | cudnn_frontend | 27247.8958 | 1.064 | — |
+| `perf_b8_s8192_h64_state` | tirx | 41343.4019 | cudnn_frontend | 42291.6150 | 1.023 | — |
+
+### cudnn_sm100_gdn2_prefill_f16
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `perf_b16_s8192_h64_nostate` | tirx | 78938.2119 | cudnn_frontend | 78879.5303 | 0.999 | — |
+| `perf_b16_s8192_h64_state` | tirx | 180406.9697 | cudnn_frontend | 181084.9209 | 1.004 | — |
+| `perf_b1_s8192_h64_nostate` | tirx | 6255.8655 | cudnn_frontend | 6251.1093 | 0.999 | — |
+| `perf_b1_s8192_h64_state` | tirx | 13170.8713 | cudnn_frontend | 13347.0925 | 1.013 | — |
+| `perf_b2_s8192_h64_nostate` | tirx | 12370.3989 | cudnn_frontend | 12396.8920 | 1.002 | — |
+| `perf_b2_s8192_h64_state` | tirx | 26657.2028 | cudnn_frontend | 26803.9108 | 1.006 | — |
+| `perf_b4_s16384_h64_nostate` | tirx | 48496.3097 | cudnn_frontend | 48350.7485 | 0.997 | — |
+| `perf_b4_s16384_h64_state` | tirx | 90927.5278 | cudnn_frontend | 91365.3754 | 1.005 | — |
+| `perf_b4_s2048_h64_nostate` | tirx | 6435.7558 | cudnn_frontend | 6380.4742 | 0.991 | — |
+| `perf_b4_s2048_h64_state` | tirx | 13426.7858 | cudnn_frontend | 13415.9042 | 0.999 | — |
+| `perf_b4_s32768_h64_nostate` | tirx | 79049.2524 | cudnn_frontend | 79937.7245 | 1.011 | — |
+| `perf_b4_s32768_h64_state` | tirx | 181559.6007 | cudnn_frontend | 183771.2308 | 1.012 | — |
+| `perf_b4_s4096_h64_nostate` | tirx | 12451.8207 | cudnn_frontend | 12536.4522 | 1.007 | — |
+| `perf_b4_s4096_h64_state` | tirx | 26711.5806 | cudnn_frontend | 26665.7060 | 0.998 | — |
+| `perf_b4_s8192_h64_nostate` | tirx | 24713.4659 | cudnn_frontend | 24845.8069 | 1.005 | — |
+| `perf_b4_s8192_h64_state` | tirx | 51844.8926 | cudnn_frontend | 51587.0895 | 0.995 | — |
+| `perf_b8_s8192_h64_nostate` | tirx | 48076.4737 | cudnn_frontend | 49628.3408 | 1.032 | — |
+| `perf_b8_s8192_h64_state` | tirx | 90596.7627 | cudnn_frontend | 91286.9752 | 1.008 | — |
+
 ### fast_topk_clusters
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
@@ -546,6 +600,18 @@ Grouped workloads show one row per config and one timing column per implementati
 | `s1024_h32kv4` | tir | 155.3829 | flashattn_sm100 | 165.1326 | 1.063 | — |
 | `s4096_h32kv4_causal` | tir | 890.7954 | flashattn_sm100 | 929.1618 | 1.043 | — |
 | `s8192_h32kv32` | tir | 8086.6973 | flashattn_sm100 | 8267.8324 | 1.022 | — |
+
+### flash_attention_backward_sm100
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `b1_s2048_h16_causal` | tir | 936.8841 | flashattn_sm100 | 937.3432 | 1.000 | — |
+| `b1_s4096_h16_causal` | tir | 2302.5478 | flashattn_sm100 | 2339.1055 | 1.016 | — |
+| `b1_s8192_h16_causal` | tir | 7479.3079 | flashattn_sm100 | 7585.5064 | 1.014 | — |
+| `b1_s8192_h16_noncausal` | tir | 12660.2311 | flashattn_sm100 | 13064.2535 | 1.032 | — |
+| `b2_s4096_h16_causal` | tir | 4714.6003 | flashattn_sm100 | 4738.3381 | 1.005 | — |
+| `b4_s8192_h16_causal` | tir | 30542.4081 | flashattn_sm100 | 30776.4327 | 1.008 | — |
+| `b4_s8192_h16_noncausal` | tir | 50738.2705 | flashattn_sm100 | 52405.0081 | 1.033 | — |
 
 ### flashinfer_layernorm
 

--- a/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py
@@ -10,12 +10,14 @@ Upstream source:
 (``prologue_kernel``, ``kernel``, and the two-launch ``run_prefill`` entry).
 """
 
+import os
+
 import tirx_kernels.kern as K
 
 KERNEL_META = {
     "name": "cudnn_sm100_gdn2_prefill_f16",
     "category": "cudnn",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "nvidia-cudnn-frontend",
@@ -638,11 +640,19 @@ def _tcgen_mma_ts(
 
 
 def _make_prologue(
-    *, run_order, order_generate, dynamic_scheduler, n_heads_out, checkpoints, cu_dtype
+    *,
+    run_order,
+    order_generate,
+    uniform_generated_order,
+    dynamic_scheduler,
+    n_heads_out,
+    checkpoints,
+    cu_dtype,
 ):
     cu_t = K.i64 if cu_dtype == "int64" else K.i32
+    prologue_warps = 8 if uniform_generated_order else 32
 
-    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    @K.kernel(warps=prologue_warps, arch="sm_100a", grid=1)
     def prologue(
         base_q: K.gptr[K.i64],
         base_k: K.gptr[K.i64],
@@ -712,12 +722,14 @@ def _make_prologue(
                         K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
                         K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
 
-            with K.If(item_count > 4096), K.Then():
+            direct_condition = K.bool(True) if uniform_generated_order else item_count > 4096
+            with K.If(direct_condition), K.Then():
                 item = K.local_scalar("int32", init=thread)
                 with K.While(item < item_count):
                     write_work_item(item, item)
-                    K.assign(item, item + 1024)
-            with K.If(item_count <= 4096), K.Then():
+                    K.assign(item, item + prologue_warps * 32)
+            sort_condition = K.bool(False) if uniform_generated_order else item_count <= 4096
+            with K.If(sort_condition), K.Then():
                 with K.If(thread == 0), K.Then():
                     K.ptx.st.shared.v2.u32(
                         order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
@@ -871,6 +883,9 @@ def _make_prologue(
 def _make_main(
     *,
     num_sms,
+    cg1_regs,
+    support_regs,
+    short_epilogue_live_ranges,
     io_dtype,
     state_dtype,
     cu_dtype,
@@ -972,11 +987,11 @@ def _make_main(
         K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
         roles = K.specialize()
         cg0 = roles.role("cg0", warps=range(0, 8), regs=160)
-        cg1 = roles.role("cg1", warps=range(8, 12), regs=136)
-        super_mma = roles.role("super_mma", warps=[12], regs=56)
-        tcgen = roles.role("tcgen", warps=[13], regs=56)
-        tma = roles.role("tma", warps=[14], regs=56)
-        epilogue = roles.role("epilogue", warps=[15], regs=56)
+        cg1 = roles.role("cg1", warps=range(8, 12), regs=cg1_regs)
+        super_mma = roles.role("super_mma", warps=[12], regs=support_regs)
+        tcgen = roles.role("tcgen", warps=[13], regs=support_regs)
+        tma = roles.role("tma", warps=[14], regs=support_regs)
+        epilogue = roles.role("epilogue", warps=[15], regs=support_regs)
 
         # Warp 14: descriptor acquire, six input TMA rings, scheduler producer.
         with tma:
@@ -1416,22 +1431,24 @@ def _make_main(
 
         # Warp 15: causal register MMA and one-behind checkpoint/O TMA drain.
         with epilogue:
-            rhs_row = lane % 8 + K.if_then_else(lane // 16 != 0, 8, 0)
-            rhs_col = K.if_then_else((lane // 8) % 2 != 0, 8, 0)
-            lhs_row = lane % 8 + K.if_then_else((lane // 8) % 2 != 0, 8, 0)
-            lhs_col = K.if_then_else(lane // 8 >= 2, 8, 0)
-            store_row = (lane & 7) + K.if_then_else((lane // 8) & 1 != 0, 8, 0)
-            store_col = K.if_then_else(lane // 8 >= 2, 8, 0)
-            store_linear = store_row * 16 + (store_col ^ 8)
-            store_swizzled = K.bitwise_xor(
-                store_linear,
-                K.shift_left(
-                    K.bitwise_and(K.shift_right(store_linear, K.uint32(6)), K.uint32(1)),
-                    K.uint32(3),
-                ),
-            )
-            row_lo = lane // 4
-            row_hi = row_lo + 8
+            if not short_epilogue_live_ranges:
+                mma_lane = lane
+                rhs_row = lane % 8 + K.if_then_else(lane // 16 != 0, 8, 0)
+                rhs_col = K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+                lhs_row = lane % 8 + K.if_then_else((lane // 8) % 2 != 0, 8, 0)
+                lhs_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+                store_row = (lane & 7) + K.if_then_else((lane // 8) & 1 != 0, 8, 0)
+                store_col = K.if_then_else(lane // 8 >= 2, 8, 0)
+                store_linear = store_row * 16 + (store_col ^ 8)
+                store_swizzled = K.bitwise_xor(
+                    store_linear,
+                    K.shift_left(
+                        K.bitwise_and(K.shift_right(store_linear, K.uint32(6)), K.uint32(1)),
+                        K.uint32(3),
+                    ),
+                )
+                row_lo = lane // 4
+                row_hi = row_lo + 8
             qk_scale = K.PipelineState(4, phase=0)
             checkpoint_ready = K.PipelineState(checkpoint_stages, phase=0)
             sched_consumer = K.PipelineState(8, phase=0)
@@ -1484,6 +1501,27 @@ def _make_main(
                     decay_stage = serial % 2
                     inter_stage = serial % 2
                     diag_stage = qk_scale.stage
+                    if short_epilogue_live_ranges:
+                        mma_lane = K.local_scalar("uint32")
+                        K.ptx.mov.b32(mma_lane, lane)
+                        rhs_row = mma_lane % 8 + K.if_then_else(mma_lane // 16 != 0, 8, 0)
+                        rhs_col = K.if_then_else((mma_lane // 8) % 2 != 0, 8, 0)
+                        lhs_row = mma_lane % 8 + K.if_then_else((mma_lane // 8) % 2 != 0, 8, 0)
+                        lhs_col = K.if_then_else(mma_lane // 8 >= 2, 8, 0)
+                        store_row = (mma_lane & 7) + K.if_then_else((mma_lane // 8) & 1 != 0, 8, 0)
+                        store_col = K.if_then_else(mma_lane // 8 >= 2, 8, 0)
+                        store_linear = store_row * 16 + (store_col ^ 8)
+                        store_swizzled = K.bitwise_xor(
+                            store_linear,
+                            K.shift_left(
+                                K.bitwise_and(
+                                    K.shift_right(store_linear, K.uint32(6)), K.uint32(1)
+                                ),
+                                K.uint32(3),
+                            ),
+                        )
+                        row_lo = mma_lane // 4
+                        row_hi = row_lo + 8
                     _wait_barrier(arena, protocol[16][0], diag_stage, qk_scale.phase)
                     a_acc = K.alloc_local((8,), "float32")
                     for accum in range(8):
@@ -1519,7 +1557,7 @@ def _make_main(
                         for parity in range(2):
                             accum = pair * 2 + parity
                             row_coord = row_hi if accum % 4 >= 2 else row_lo
-                            col_coord = (accum // 4) * 8 + 2 * (lane % 4) + (accum & 1)
+                            col_coord = (accum // 4) * 8 + 2 * (mma_lane % 4) + (accum & 1)
                             K.assign(
                                 a_acc[accum],
                                 K.if_then_else(
@@ -2637,6 +2675,8 @@ def _make_main(
 def _normalized_config(config):
     import math
 
+    from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, hardware_num_sms
+
     config = {key: value for key, value in config.items() if key != "label"}
     config.setdefault("seq_lens", (64,))
     config["seq_lens"] = tuple(int(value) for value in config["seq_lens"])
@@ -2647,9 +2687,36 @@ def _normalized_config(config):
     config.setdefault("io_dtype", "bfloat16")
     config.setdefault("state_dtype", "float32")
     config.setdefault("cu_dtype", "int32")
+    explicit_num_sms = "num_sms" in config
     config.setdefault("num_sms", 148)
     config.setdefault("scale", 1.0 / (_DK**0.5))
     config.setdefault("checkpoint_every_n_tokens", config.pop("checkpoint", 0))
+    if (
+        not explicit_num_sms
+        and os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a"
+        and int(config["checkpoint_every_n_tokens"]) > 0
+        and (
+            len(config["seq_lens"]) == 1
+            or (len(config["seq_lens"]) == 4 and config["seq_lens"][0] == 8_192)
+        )
+    ):
+        config["num_sms"] = max(1, 3 * hardware_num_sms() // 5)
+    elif (
+        not explicit_num_sms
+        and os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a"
+        and (
+            int(config["checkpoint_every_n_tokens"]) > 0
+            or len(config["seq_lens"]) <= 2
+            or len(config["seq_lens"]) >= 16
+        )
+    ):
+        config["num_sms"] = hardware_num_sms()
+    elif (
+        not explicit_num_sms
+        and os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a"
+        and len(config["seq_lens"]) == 8
+    ):
+        config["num_sms"] = 7 * hardware_num_sms()
     config.setdefault("gate_lower_bound", -5.0)
     config.setdefault("use_initial_state", False)
     config.setdefault("store_final_state", True)
@@ -2716,12 +2783,19 @@ def _work_rows(seq_lens, heads, *, split):
 
 def get_kernel(**config):
     """Return the source-ordered prologue and persistent main kernels."""
+    from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV
+
     config = _normalized_config(config)
     rows = _work_rows(config["seq_lens"], config["heads"], split=config["split"])
     num_ctas = min(int(config["num_sms"]), max(len(rows), 1))
+    thor = os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a"
+    tune_cg1 = thor and int(config["checkpoint_every_n_tokens"]) > 0
+    cg1_regs = 144 if tune_cg1 and len(config["seq_lens"]) >= 8 else 152 if tune_cg1 else 136
+    support_regs = 48 if cg1_regs == 144 else 40 if cg1_regs == 152 else 56
     prologue = _make_prologue(
         run_order=True,
         order_generate=bool(config["order_generate"]),
+        uniform_generated_order=thor and len(set(config["seq_lens"])) <= 1,
         dynamic_scheduler=bool(config["dynamic_scheduler"]),
         n_heads_out=int(config["heads"]),
         checkpoints=int(config["checkpoint_every_n_tokens"]) > 0,
@@ -2729,6 +2803,9 @@ def get_kernel(**config):
     )
     main = _make_main(
         num_sms=num_ctas,
+        cg1_regs=cg1_regs,
+        support_regs=support_regs,
+        short_epilogue_live_ranges=thor,
         io_dtype=config["io_dtype"],
         state_dtype=config["state_dtype"],
         cu_dtype=config["cu_dtype"],
@@ -3138,15 +3215,42 @@ def _validate_outputs(data, *, sources):
         )
 
 
+def _compile_tirx(config):
+    from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, compile_kernel
+
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        has_checkpoints = int(config["checkpoint_every_n_tokens"]) > 0
+        batch = len(config["seq_lens"])
+        if has_checkpoints and (batch == 8 or (batch == 4 and config["seq_lens"][0] == 8_192)):
+            reg_level = "0"
+        elif has_checkpoints and batch >= 16:
+            reg_level = "2"
+        elif not has_checkpoints and batch == 4 and config["seq_lens"][0] == 16_384:
+            reg_level = "9"
+        elif not has_checkpoints and batch in (2, 8):
+            reg_level = "0"
+        elif not has_checkpoints and batch == 4:
+            reg_level = "1"
+        else:
+            reg_level = "5"
+        os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = reg_level
+    try:
+        return [compile_kernel(func) for func in get_kernel(**config)]
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
 def run_test(**config):
     """Compare TIRx with the upstream kernel on identical inputs."""
     import torch
 
-    from tirx_kernels.runner import compile_kernel
-
     config = _normalized_config(config)
     data = _prepare_data(config)
-    executables = [compile_kernel(func) for func in get_kernel(**config)]
+    executables = _compile_tirx(config)
     tirx_launch = _tirx_launch(executables, data)
     source_launch = _source_launch(data)
     tirx_launch()
@@ -3158,13 +3262,10 @@ def run_test(**config):
 
 def prepare_bench(**config):
     """Compile both TIRx launches without importing torch or touching CUDA."""
-    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+    from tirx_kernels.runner import prepared_gpu_benchmark
 
     config = _normalized_config(config)
-    state = {
-        "config": config,
-        "executables": [compile_kernel(func) for func in get_kernel(**config)],
-    }
+    state = {"config": config, "executables": _compile_tirx(config)}
     return prepared_gpu_benchmark(run_gpu, state)
 
 

--- a/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py
@@ -11,12 +11,14 @@ Upstream source:
 driven by the ``chunk_gdn_sm100`` THD/varlen host entry).
 """
 
+import os
+
 import tirx_kernels.kern as K
 
 KERNEL_META = {
     "name": "cudnn_sm100_gdn_prefill_f16",
     "category": "cudnn",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "nvidia-cudnn-frontend",
@@ -3343,15 +3345,28 @@ def _validate_outputs(data, *, sources):
         )
 
 
+def _compile_tirx(config):
+    from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, compile_kernel
+
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = "6"
+    try:
+        return [compile_kernel(func) for func in get_kernel(**config)]
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
 def run_test(**config):
     """Compare TIRx with the upstream kernel on identical inputs."""
     import torch
 
-    from tirx_kernels.runner import compile_kernel
-
     config = _normalized_config(config)
     data = _prepare_data(config)
-    executables = [compile_kernel(func) for func in get_kernel(**config)]
+    executables = _compile_tirx(config)
     tirx_launch = _tirx_launch(executables, data)
     source_launch = _source_launch(data)
     tirx_launch()
@@ -3363,13 +3378,10 @@ def run_test(**config):
 
 def prepare_bench(**config):
     """Compile both TIRx launches without importing torch or touching CUDA."""
-    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+    from tirx_kernels.runner import prepared_gpu_benchmark
 
     config = _normalized_config(config)
-    state = {
-        "config": config,
-        "executables": [compile_kernel(func) for func in get_kernel(**config)],
-    }
+    state = {"config": config, "executables": _compile_tirx(config)}
     return prepared_gpu_benchmark(run_gpu, state)
 
 

--- a/tirx_kernels/flashattention/flash_attention_backward.py
+++ b/tirx_kernels/flashattention/flash_attention_backward.py
@@ -16,6 +16,7 @@ annotations directly.
 
 import ctypes
 import math
+import os
 from functools import cache
 
 import torch
@@ -132,6 +133,7 @@ def build_preprocess(B, S, H, D):
     rows_per_wave = PRE_BLOCK // PRE_THREADS_PER_ROW
     row_iters = PRE_ROWS_PER_BLOCK // rows_per_wave
     nblk = S // PRE_ROWS_PER_BLOCK
+    thor = os.environ.get("TIRX_PREPARE_CUDA_ARCH") == "sm_110a"
 
     @K.kernel(warps=PRE_BLOCK // 32, arch="sm_100a", grid=(nblk, H, B))
     def preprocess_kernel(
@@ -155,22 +157,28 @@ def build_preprocess(B, S, H, D):
             rhs_words = K.alloc_local([4], "uint32")
             lhs_halves = K.alloc_local([2], "uint16")
             rhs_halves = K.alloc_local([2], "uint16")
-            lhs_value = K.alloc_local([2], "float32")
-            rhs_value = K.alloc_local([2], "float32")
+            if not thor:
+                lhs_value = K.alloc_local([2], "float32")
+                rhs_value = K.alloc_local([2], "float32")
             K.ptx.ld.global_.nc.v4.b32(lhs_words[0], lhs_words[1], lhs_words[2], lhs_words[3], lhs)
             K.ptx.ld.global_.nc.v4.b32(rhs_words[0], rhs_words[1], rhs_words[2], rhs_words[3], rhs)
             K.assign(dst[0], K.float32(0))
             for pair in range(4):
                 K.ptx.mov.b32(lhs_halves[0], lhs_halves[1], lhs_words[pair])
-                for element in range(2):
-                    K.ptx.cvt.f32.f16(lhs_value[element], lhs_halves[element])
+                if not thor:
+                    for element in range(2):
+                        K.ptx.cvt.f32.f16(lhs_value[element], lhs_halves[element])
                 K.ptx.mov.b32(rhs_halves[0], rhs_halves[1], rhs_words[pair])
-                for element in range(2):
-                    K.ptx.cvt.f32.f16(rhs_value[element], rhs_halves[element])
-                for element in range(2):
-                    # CUDA's default fast-math path lowers the original fmaf
-                    # chain with FTZ; spelling it keeps the same schedule.
-                    K.ptx.fma.rn.ftz.f32(dst[0], lhs_value[element], rhs_value[element], dst[0])
+                if thor:
+                    for element in range(2):
+                        K.ptx.fma.rn.f32.f16(
+                            dst[0], lhs_halves[element], rhs_halves[element], dst[0]
+                        )
+                else:
+                    for element in range(2):
+                        K.ptx.cvt.f32.f16(rhs_value[element], rhs_halves[element])
+                    for element in range(2):
+                        K.ptx.fma.rn.ftz.f32(dst[0], lhs_value[element], rhs_value[element], dst[0])
 
         # Overlap the independent LSE load with the O/dO dot products.
         lse_for_log2 = K.local_scalar("float32", init=K.float32(0))
@@ -229,8 +237,8 @@ def build_preprocess(B, S, H, D):
 # ---------------------------------------------------------------------------
 
 
-def build_cast_f32_to_f16(B, S, H, D, scale):
-    """Scale and transpose the head-major accumulator to sequence-major f16."""
+def _build_cast_f32_to_f16_default(B, S, H, D, scale):
+    """Build the original cast path used by the existing SM100 family."""
     groups_per_block = CAST_BLOCK * CAST_GROUPS_PER_THREAD
     num_groups = B * S * H * (D // CAST_GROUP_WIDTH)
     nblk = (num_groups + groups_per_block - 1) // groups_per_block
@@ -259,9 +267,6 @@ def build_cast_f32_to_f16(B, S, H, D, scale):
                 s = group // (D // CAST_GROUP_WIDTH * H) % S
                 b = group // (D // CAST_GROUP_WIDTH * H * S)
                 d = d_group * CAST_GROUP_WIDTH
-                # The raw tcgen05 dQ accumulator uses the physical 128x128
-                # C-fragment bit layout. Decode it while producing the public
-                # sequence-major dQ.
                 s_in_block = s % 128
                 src_s = (
                     s // 128 * 128
@@ -277,6 +282,80 @@ def build_cast_f32_to_f16(B, S, H, D, scale):
                 )
 
     return cast_kernel
+
+
+def _build_cast_f32_to_f16_thor(B, S, H, D, scale):
+    """Scale and transpose the head-major accumulator to sequence-major f16."""
+    if S % 128:
+        raise ValueError("the SM100 backward cast requires seq_len divisible by 128")
+
+    tile_rows = 128
+    tile_elements = tile_rows * D
+    groups_per_tile = tile_elements // CAST_GROUP_WIDTH
+
+    @K.kernel(warps=4, arch="sm_100a", grid=(S // tile_rows, H, B))
+    def cast_kernel(src: K.gptr[K.f32], dst: K.gptr[K.f16]):
+        bx, by, bz = K.cta_id()
+        tx = K.thread_id()
+        staging = K.alloc_buffer((tile_elements,), K.f32, scope="shared.dyn", align=1024)
+        values = K.alloc_local((4,), "float32")
+        scaled = K.alloc_local((4,), "float32")
+        packed = K.alloc_local((2,), "uint32")
+        tile_src = ((bz * H + by) * S + bx * tile_rows) * D
+
+        def staging_ptr(row, col):
+            # The TCGen05 fragment remap below makes one warp visit source rows
+            # 0,4,...,60,2,6,...,62 at a fixed four-float column.  Spread that
+            # permutation over all 32 vector banks while keeping the physical
+            # coalesced-load deposit conflict-free as well.
+            row_bank = (row // 4) % 16 + ((row // 2) % 2) * 16
+            group = K.bitwise_xor(col // CAST_GROUP_WIDTH, row_bank)
+            return staging.ptr_to([row * D + group * CAST_GROUP_WIDTH])
+
+        # Coalesce the physical accumulator read before remapping its TCGen05
+        # fragment layout.  This matches FA4's one-CTA-per-128-row staging.
+        for group_pass in range(groups_per_tile // 128):
+            group = group_pass * 128 + tx
+            element = group * CAST_GROUP_WIDTH
+            K.ptx.ld.global_.v4.f32(
+                values[0], values[1], values[2], values[3], src.ptr_to([tile_src + element])
+            )
+            K.ptx.st.shared.v4.f32(
+                staging_ptr(element // D, element % D), values[0], values[1], values[2], values[3]
+            )
+        K.cuda.cta_sync()
+
+        for group_pass in range(groups_per_tile // 128):
+            group = group_pass * 128 + tx
+            s_in_block = group // (D // CAST_GROUP_WIDTH)
+            d = group % (D // CAST_GROUP_WIDTH) * CAST_GROUP_WIDTH
+            src_s = (
+                ((s_in_block >> 5) & 1)
+                + (((d >> 6) & 1) << 1)
+                + (((d >> 2) & 15) << 2)
+                + (((s_in_block >> 6) & 1) << 6)
+            )
+            src_d = (s_in_block & 31) << 2
+            K.ptx.ld.shared.v4.f32(
+                values[0], values[1], values[2], values[3], staging_ptr(src_s, src_d)
+            )
+            for element in range(4):
+                K.ptx.mul.rn.f32(scaled[element], values[element], K.float32(scale))
+            K.ptx.cvt.rn.f16x2.f32(packed[0], scaled[1], scaled[0])
+            K.ptx.cvt.rn.f16x2.f32(packed[1], scaled[3], scaled[2])
+            output_s = bx * tile_rows + s_in_block
+            K.ptx.st.global_.v2.b32(
+                dst.ptr_to([((bz * S + output_s) * H + by) * D + d]), packed[0], packed[1]
+            )
+
+    return cast_kernel
+
+
+def build_cast_f32_to_f16(B, S, H, D, scale):
+    """Scale and transpose dQ, selecting Thor's coalesced staging schedule."""
+    if os.environ.get("TIRX_PREPARE_CUDA_ARCH") == "sm_110a":
+        return _build_cast_f32_to_f16_thor(B, S, H, D, scale)
+    return _build_cast_f32_to_f16_default(B, S, H, D, scale)
 
 
 # ---------------------------------------------------------------------------
@@ -579,8 +658,8 @@ def build_kernel(
         # ================================================================
         # roles. The original's `wg_id == 3` / `1 <= wg_id <= 2` / else split,
         # stated as the warp partition it is. kern checks the exact partition
-        # of 0..15, contiguity, regs 8-aligned in [24, 256], budget <= 65536
-        # (this kernel uses all of it), and setmaxnreg warpgroup-uniformity.
+        # of 0..15, contiguity, regs 8-aligned in [24, 256], budget <= 65536,
+        # and setmaxnreg warpgroup-uniformity.
         # ================================================================
         sp = K.specialize()
         mma = sp.role("mma", warps=[12], regs=104)
@@ -1317,11 +1396,19 @@ def build_kernel(
 
 @cache
 def _compile_pipeline(B: int, H: int, S: int, D: int, causal: bool, attention_scale: float):
-    return (
-        build_preprocess(B, S, H, D).compile(),
-        build_kernel(B, H, S, D, causal=causal, attention_scale=attention_scale).compile(),
-        build_cast_f32_to_f16(B, S, H, D, attention_scale).compile(),
-    )
+    preprocess = build_preprocess(B, S, H, D).compile()
+    previous_reg_level = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    if os.environ.get("TIRX_PREPARE_CUDA_ARCH") == "sm_110a" and S >= 8192:
+        os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = "5"
+    try:
+        core = build_kernel(B, H, S, D, causal=causal, attention_scale=attention_scale).compile()
+    finally:
+        if previous_reg_level is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous_reg_level
+    cast = build_cast_f32_to_f16(B, S, H, D, attention_scale).compile()
+    return preprocess, core, cast
 
 
 def setup(data, B, H, S, D, *, executables=None):
@@ -1393,7 +1480,7 @@ def setup(data, B, H, S, D, *, executables=None):
 KERNEL_META = {
     "name": "flash_attention_backward_sm100",
     "category": "flashattention",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "flash-attn-4",


### PR DESCRIPTION
Add Jetson AGX Thor (`sm_110a`) support for four kernels:

- `agent_evolved_kda_forward_b1_t8192`
- `cudnn_sm100_gdn_prefill_f16`
- `cudnn_sm100_gdn2_prefill_f16`
- `flash_attention_backward_sm100`

All 46 benchmark configurations satisfy the repository performance gate of `reference/TIRx > 0.99`.

## Changes

- Register all four kernels for `sm_110a`.
- Compile GDN prefill with the Thor-specific ptxas optimization level.
- Add Thor-specific GDN2 scheduling:
  - use a smaller direct prologue for uniform generated work orders;
  - select CTA counts according to the workload;
  - tune warp-group register budgets;
  - shorten epilogue live ranges;
  - select ptxas optimization levels according to the workload.
- Add Thor-specific FA4 backward preprocessing and output conversion:
  - use native FP16 multiply-accumulate instructions during preprocessing;
  - use coalesced shared-memory staging for the dQ conversion;
  - tune ptxas optimization for long sequences.
- Update the architecture registry, README support annotations, and benchmark results.

Thor-specific paths are selected only when preparing for `sm_110a`. Representative generated-IR comparisons confirmed that the existing B200, GB300, and Rubin paths remain unchanged.

## Performance

Measurements were collected on Jetson AGX Thor with the standard bench-suite procedure:

- 15 rounds
- Proton default 25 ms warmup
- Proton default 100 ms repeat window
- 1 second cooldown
- serial preparation
- zero interference retries

`ref/TIRx` is the reference latency divided by the TIRx latency. Values greater than `1.0` mean TIRx is faster.

### KDA forward

Reference: Flash KDA

| Config | TIRx (µs) | Reference (µs) | ref/TIRx |
|---|---:|---:|---:|
| `h96_fixed` | 6531.8080 | 16013.1360 | 2.452 |
| `h96_uniform` | 6719.4230 | 17103.4660 | 2.545 |
| `h64_uniform` | 4590.0820 | 11915.7180 | 2.596 |

Result: **3/3 configurations pass**

### GDN prefill

Reference: cuDNN Frontend

| Config | TIRx (µs) | Reference (µs) | ref/TIRx |
|---|---:|---:|---:|
| `perf_b16_s8192_h64_nostate` | 48456.4055 | 52156.1827 | 1.076 |
| `perf_b16_s8192_h64_state` | 71834.9177 | 75027.4035 | 1.044 |
| `perf_b1_s8192_h64_nostate` | 3373.5589 | 3566.0714 | 1.057 |
| `perf_b1_s8192_h64_state` | 5417.8802 | 5562.0063 | 1.027 |
| `perf_b2_s8192_h64_nostate` | 6463.8619 | 6917.2765 | 1.070 |
| `perf_b2_s8192_h64_state` | 10431.7077 | 10610.2611 | 1.017 |
| `perf_b4_s16384_h64_nostate` | 25375.6592 | 27125.7366 | 1.069 |
| `perf_b4_s16384_h64_state` | 41456.0619 | 43139.1787 | 1.041 |
| `perf_b4_s2048_h64_nostate` | 3392.6928 | 3608.9931 | 1.064 |
| `perf_b4_s2048_h64_state` | 5434.0191 | 5449.2560 | 1.003 |
| `perf_b4_s32768_h64_nostate` | 47628.0536 | 48091.0625 | 1.010 |
| `perf_b4_s32768_h64_state` | 73405.5111 | 76815.0665 | 1.046 |
| `perf_b4_s4096_h64_nostate` | 6533.7592 | 6961.6331 | 1.065 |
| `perf_b4_s4096_h64_state` | 10595.4457 | 10616.4183 | 1.002 |
| `perf_b4_s8192_h64_nostate` | 12767.4998 | 13657.9609 | 1.070 |
| `perf_b4_s8192_h64_state` | 20791.4739 | 21065.2219 | 1.013 |
| `perf_b8_s8192_h64_nostate` | 25599.3496 | 27247.8958 | 1.064 |
| `perf_b8_s8192_h64_state` | 41343.4019 | 42291.6150 | 1.023 |

Result: **18/18 configurations pass**

### GDN2 prefill

Reference: cuDNN Frontend

| Config | TIRx (µs) | Reference (µs) | ref/TIRx |
|---|---:|---:|---:|
| `perf_b16_s8192_h64_nostate` | 78938.2119 | 78879.5303 | 0.999 |
| `perf_b16_s8192_h64_state` | 180406.9697 | 181084.9209 | 1.004 |
| `perf_b1_s8192_h64_nostate` | 6255.8655 | 6251.1093 | 0.999 |
| `perf_b1_s8192_h64_state` | 13170.8713 | 13347.0925 | 1.013 |
| `perf_b2_s8192_h64_nostate` | 12370.3989 | 12396.8920 | 1.002 |
| `perf_b2_s8192_h64_state` | 26657.2028 | 26803.9108 | 1.006 |
| `perf_b4_s16384_h64_nostate` | 48496.3097 | 48350.7485 | 0.997 |
| `perf_b4_s16384_h64_state` | 90927.5278 | 91365.3754 | 1.005 |
| `perf_b4_s2048_h64_nostate` | 6435.7558 | 6380.4742 | 0.991 |
| `perf_b4_s2048_h64_state` | 13426.7858 | 13415.9042 | 0.999 |
| `perf_b4_s32768_h64_nostate` | 79049.2524 | 79937.7245 | 1.011 |
| `perf_b4_s32768_h64_state` | 181559.6007 | 183771.2308 | 1.012 |
| `perf_b4_s4096_h64_nostate` | 12451.8207 | 12536.4522 | 1.007 |
| `perf_b4_s4096_h64_state` | 26711.5806 | 26665.7060 | 0.998 |
| `perf_b4_s8192_h64_nostate` | 24713.4659 | 24845.8069 | 1.005 |
| `perf_b4_s8192_h64_state` | 51844.8926 | 51587.0895 | 0.995 |
| `perf_b8_s8192_h64_nostate` | 48076.4737 | 49628.3408 | 1.032 |
| `perf_b8_s8192_h64_state` | 90596.7627 | 91286.9752 | 1.008 |

Result: **18/18 configurations pass**. The lowest unrounded ratio is `0.991410`.

### FA4 backward

Reference: upstream FlashAttention SM100 implementation

| Config | TIRx (µs) | Reference (µs) | ref/TIRx |
|---|---:|---:|---:|
| `b1_s2048_h16_causal` | 936.8841 | 937.3432 | 1.000 |
| `b1_s4096_h16_causal` | 2302.5478 | 2339.1055 | 1.016 |
| `b1_s8192_h16_causal` | 7479.3079 | 7585.5064 | 1.014 |
| `b1_s8192_h16_noncausal` | 12660.2311 | 13064.2535 | 1.032 |
| `b2_s4096_h16_causal` | 4714.6003 | 4738.3381 | 1.005 |
| `b4_s8192_h16_causal` | 30542.4081 | 30776.4327 | 1.008 |
| `b4_s8192_h16_noncausal` | 50738.2705 | 52405.0081 | 1.033 |

Result: **7/7 configurations pass**. The lowest unrounded ratio is `1.000490`.

## Correctness

- KDA forward: **6/6 passed**
- GDN prefill: **14/14 passed**
- GDN2 prefill: **14/14 passed**
- FA4 backward: **7/7 passed**

## Validation

- `tests/test_registry.py`: **22 passed**
- README kernel-list validation: passed
- Ruff lint: passed
- Ruff format check: passed
- Python compilation checks: passed
- `git diff --check`: passed
- Representative non-Thor generated-IR comparisons: unchanged