### PR TITLE
fix(kern): preserve authored CUDA architecture

### DIFF
--- a/tests/test_kern_api.py
+++ b/tests/test_kern_api.py
@@ -17,12 +17,25 @@ def test_kernel_target_honors_prepared_compile_arch(monkeypatch):
 
     monkeypatch.delenv("TIRX_PREPARE_CUDA_ARCH", raising=False)
     assert probe.target().arch == "sm_100a"
+    assert probe.func.attrs["tirx.cuda_arch"] == "sm_100a"
 
     monkeypatch.setenv("TIRX_PREPARE_CUDA_ARCH", "sm_103a")
     assert probe.target().arch == "sm_103a"
 
     monkeypatch.setenv("TIRX_PREPARE_CUDA_ARCH", "sm_107a")
     assert probe.target().arch == "sm_107a"
+    # The override selects a compile target; it must not rewrite the authored
+    # architecture retained in the immutable PrimFunc.
+    assert probe.func.attrs["tirx.cuda_arch"] == "sm_100a"
+
+
+def test_kernel_primfunc_preserves_sm107_architecture():
+    @K.kernel(warps=1, arch="sm_107a", grid=False)
+    def probe(out: K.gptr("float32")):
+        K.ptx.st.global_.f32(out.ptr_to([0]), K.float32(1.0))
+
+    assert probe.arch == "sm_107a"
+    assert probe.func.attrs["tirx.cuda_arch"] == "sm_107a"
 
 
 def _tir(build_body):

--- a/tirx_kernels/kern/entry.py
+++ b/tirx_kernels/kern/entry.py
@@ -549,7 +549,11 @@ def kernel(
         with IRBuilder() as ib:
             with I.prim_func():
                 I.func_name(fn.__name__)
-                I.func_attr({"global_symbol": fn.__name__})
+                # Keep the authored/default target on the PrimFunc itself.
+                # Consumers such as NumSim receive ``Kernel.func`` rather than
+                # the wrapper, so ``Kernel.arch`` alone loses an ISA fact that
+                # affects SM100 versus SM107 descriptor decoding.
+                I.func_attr({"global_symbol": fn.__name__, "tirx.cuda_arch": arch})
                 args = []
                 scalar_params = {
                     pname: _scalar_param(pname, param.annotation)


### PR DESCRIPTION
## Summary

- retain the `arch=` supplied to `@K.kernel` as the `tirx.cuda_arch` PrimFunc attribute
- preserve the authored architecture when `TIRX_PREPARE_CUDA_ARCH` temporarily selects a different compile target
- cover both the default SM100 path and an explicitly authored SM107 kernel

## Motivation

`Kernel.arch` lives only on the Python wrapper, while many kernel factories and analysis consumers pass around the bare `Kernel.func`. Without an equivalent PrimFunc attribute, architecture-sensitive consumers such as NumSim cannot recover the authored ISA semantics after the wrapper is discarded. This matters for exact SM100/SM103/SM107 TCGEN descriptor decoding and architecture-specific simulated resource geometry.

`TIRX_PREPARE_CUDA_ARCH` remains a compile-time target override; it does not mutate the immutable authored PrimFunc metadata.

## Validation

- `python -m pytest -q tests/test_kern_api.py`
- `25 passed`