### PR TITLE
perf(thor): enable GDN/GDN2 recompute and KDA backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ contract and results.
   [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py) ⟨+sm_110a⟩,
-  [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py),
+  [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),
   [`cudnn_sm100_gdn_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn_bprop_f16.py)
 - **CSA compression:**

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ contract and results.
   [`cudnn_sm100_moe_blockscaled_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py),
   [`cudnn_sm100_moe_grouped_gemm_dglu_dbias`](tirx_kernels/cudnn/dglu/moe_grouped_gemm_dglu_dbias.py)
 - **Linear attention:**
-  [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py),
+  [`cudnn_sm100_kda_bprop_f16`](tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn_prefill_f16.py) ⟨+sm_110a⟩,
-  [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py),
+  [`cudnn_sm100_gdn_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn2_prefill_f16`](tirx_kernels/cudnn/linear_attention/gdn2_prefill_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn2_recompute_f16`](tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py) ⟨+sm_110a⟩,
   [`cudnn_sm100_gdn2_bprop_f16`](tirx_kernels/cudnn/linear_attention/gdn2_bprop_f16.py),

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -577,6 +577,29 @@ Grouped workloads show one row per config and one timing column per implementati
 | `perf_b8_s8192_h64_nostate` | tirx | 48076.4737 | cudnn_frontend | 49628.3408 | 1.032 | — |
 | `perf_b8_s8192_h64_state` | tirx | 90596.7627 | cudnn_frontend | 91286.9752 | 1.008 | — |
 
+### cudnn_sm100_gdn2_recompute_f16
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `perf_b16_s8192_h64_nostate` | tirx | 155070.8620 | cudnn_frontend | 159703.9119 | 1.030 | — |
+| `perf_b16_s8192_h64_state` | tirx | 156298.5425 | cudnn_frontend | 161099.5008 | 1.031 | — |
+| `perf_b1_s8192_h64_nostate` | tirx | 11509.1100 | cudnn_frontend | 11647.3288 | 1.012 | — |
+| `perf_b1_s8192_h64_state` | tirx | 11614.8180 | cudnn_frontend | 11779.7155 | 1.014 | — |
+| `perf_b2_s8192_h64_nostate` | tirx | 23095.8568 | cudnn_frontend | 23228.4264 | 1.006 | — |
+| `perf_b2_s8192_h64_state` | tirx | 23240.6585 | cudnn_frontend | 23429.0805 | 1.008 | — |
+| `perf_b4_s16384_h64_nostate` | tirx | 77818.0166 | cudnn_frontend | 79805.2748 | 1.026 | — |
+| `perf_b4_s16384_h64_state` | tirx | 77934.0186 | cudnn_frontend | 79998.0010 | 1.026 | — |
+| `perf_b4_s2048_h64_nostate` | tirx | 11353.1798 | cudnn_frontend | 11619.6198 | 1.023 | — |
+| `perf_b4_s2048_h64_state` | tirx | 11764.0243 | cudnn_frontend | 11979.3038 | 1.018 | — |
+| `perf_b4_s32768_h64_nostate` | tirx | 155591.2415 | cudnn_frontend | 159374.3670 | 1.024 | — |
+| `perf_b4_s32768_h64_state` | tirx | 156032.5627 | cudnn_frontend | 159735.5274 | 1.024 | — |
+| `perf_b4_s4096_h64_nostate` | tirx | 22992.7032 | cudnn_frontend | 23278.9249 | 1.012 | — |
+| `perf_b4_s4096_h64_state` | tirx | 23258.3996 | cudnn_frontend | 23580.7693 | 1.014 | — |
+| `perf_b4_s8192_h64_nostate` | tirx | 45392.1619 | cudnn_frontend | 46261.4040 | 1.019 | — |
+| `perf_b4_s8192_h64_state` | tirx | 45835.6203 | cudnn_frontend | 46391.9832 | 1.012 | — |
+| `perf_b8_s8192_h64_nostate` | tirx | 77944.0310 | cudnn_frontend | 79614.7813 | 1.021 | — |
+| `perf_b8_s8192_h64_state` | tirx | 77929.7797 | cudnn_frontend | 80522.5522 | 1.033 | — |
+
 ### fast_topk_clusters
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |

--- a/tirx_kernels/bench_suite/baseline.md
+++ b/tirx_kernels/bench_suite/baseline.md
@@ -554,6 +554,29 @@ Grouped workloads show one row per config and one timing column per implementati
 | `perf_b8_s8192_h64_nostate` | tirx | 25599.3496 | cudnn_frontend | 27247.8958 | 1.064 | — |
 | `perf_b8_s8192_h64_state` | tirx | 41343.4019 | cudnn_frontend | 42291.6150 | 1.023 | — |
 
+### cudnn_sm100_gdn_recompute_f16
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `perf_b16_s8192_h64_nostate` | tirx | 51563.4015 | cudnn_frontend | 51890.5075 | 1.006 | — |
+| `perf_b16_s8192_h64_state` | tirx | 52091.0372 | cudnn_frontend | 53434.5061 | 1.026 | — |
+| `perf_b1_s8192_h64_nostate` | tirx | 3560.5046 | cudnn_frontend | 3576.3829 | 1.004 | — |
+| `perf_b1_s8192_h64_state` | tirx | 3646.1689 | cudnn_frontend | 3620.0551 | 0.993 | — |
+| `perf_b2_s8192_h64_nostate` | tirx | 6802.8386 | cudnn_frontend | 6826.4924 | 1.003 | — |
+| `perf_b2_s8192_h64_state` | tirx | 6944.0862 | cudnn_frontend | 6928.8139 | 0.998 | — |
+| `perf_b4_s16384_h64_nostate` | tirx | 26932.1542 | cudnn_frontend | 27432.9232 | 1.019 | — |
+| `perf_b4_s16384_h64_state` | tirx | 27199.4096 | cudnn_frontend | 27440.5896 | 1.009 | — |
+| `perf_b4_s2048_h64_nostate` | tirx | 3441.0070 | cudnn_frontend | 3470.7769 | 1.009 | — |
+| `perf_b4_s2048_h64_state` | tirx | 3735.2194 | cudnn_frontend | 3708.8900 | 0.993 | — |
+| `perf_b4_s32768_h64_nostate` | tirx | 52502.2674 | cudnn_frontend | 52159.2021 | 0.993 | — |
+| `perf_b4_s32768_h64_state` | tirx | 52732.7084 | cudnn_frontend | 52841.1621 | 1.002 | — |
+| `perf_b4_s4096_h64_nostate` | tirx | 6777.0646 | cudnn_frontend | 6826.0422 | 1.007 | — |
+| `perf_b4_s4096_h64_state` | tirx | 7101.6662 | cudnn_frontend | 7067.3028 | 0.995 | — |
+| `perf_b4_s8192_h64_nostate` | tirx | 13475.3379 | cudnn_frontend | 13466.7405 | 0.999 | — |
+| `perf_b4_s8192_h64_state` | tirx | 13876.2465 | cudnn_frontend | 13859.9543 | 0.999 | — |
+| `perf_b8_s8192_h64_nostate` | tirx | 27053.5586 | cudnn_frontend | 27221.8372 | 1.006 | — |
+| `perf_b8_s8192_h64_state` | tirx | 27272.9918 | cudnn_frontend | 27531.5697 | 1.009 | — |
+
 ### cudnn_sm100_gdn2_prefill_f16
 
 | config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
@@ -599,6 +622,22 @@ Grouped workloads show one row per config and one timing column per implementati
 | `perf_b4_s8192_h64_state` | tirx | 45835.6203 | cudnn_frontend | 46391.9832 | 1.012 | — |
 | `perf_b8_s8192_h64_nostate` | tirx | 77944.0310 | cudnn_frontend | 79614.7813 | 1.021 | — |
 | `perf_b8_s8192_h64_state` | tirx | 77929.7797 | cudnn_frontend | 80522.5522 | 1.033 | — |
+
+### cudnn_sm100_kda_bprop_f16
+
+| config | ours impl | ours (µs) | ref impl | ref (µs) | ref/ours | other impls |
+|---|---|---:|---|---:|---:|---|
+| `perf_basic_b1_s2048_h16` | tirx | 1053.1860 | cudnn_frontend | 1046.4061 | 0.994 | — |
+| `perf_beta_b1_s8192_h16` | tirx | 3644.6299 | cudnn_frontend | 3629.0427 | 0.996 | — |
+| `perf_dynamic_b4_s2048_h64` | tirx | 1076.1847 | cudnn_frontend | 1285.1014 | 1.194 | — |
+| `perf_grouped_b1_s8192_h64_q64_k16_v32` | tirx | 14431.3196 | cudnn_frontend | 14572.8631 | 1.010 | — |
+| `perf_l2_b1_s8192_h16` | tirx | 3663.0313 | cudnn_frontend | 3636.2041 | 0.993 | — |
+| `perf_l2_b4_s8192_h64` | tirx | 45177.3357 | cudnn_frontend | 45790.6471 | 1.014 | — |
+| `perf_order_generate_b4_s2048_h64` | tirx | 14576.3662 | cudnn_frontend | 14495.2084 | 0.994 | — |
+| `perf_order_scratch_b4_s2048_h64` | tirx | 14596.3803 | cudnn_frontend | 14505.9977 | 0.994 | — |
+| `perf_safe_b1_s8192_h16` | tirx | 3637.7413 | cudnn_frontend | 3639.1145 | 1.000 | — |
+| `perf_state_b1_s8192_h16` | tirx | 3674.4352 | cudnn_frontend | 3675.0268 | 1.000 | — |
+| `perf_tail_b2_ragged_h16` | tirx | 2757.9099 | cudnn_frontend | 2780.4135 | 1.008 | — |
 
 ### fast_topk_clusters
 

--- a/tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn2_recompute_f16.py
@@ -11,13 +11,16 @@ Upstream source:
 driven by ``chunk_gdn2_recompute_sm100``).
 """
 
+import os
+
 import tirx_kernels.kern as K
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, hardware_num_sms
 from tvm.ir.type import PointerType, PrimType
 
 KERNEL_META = {
     "name": "cudnn_sm100_gdn2_recompute_f16",
     "category": "cudnn",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "nvidia-cudnn-frontend",
@@ -2277,6 +2280,21 @@ def _make_main(
     return main
 
 
+def _default_num_sms(config) -> int:
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        count = hardware_num_sms()
+        if config.get("dynamic_scheduler", False):
+            short_nostate = (
+                tuple(config.get("seq_lens", (64,))) == (2048,) * 4
+                and int(config.get("heads", 1)) == 64
+                and not config.get("use_initial_state", False)
+                and not config.get("store_final_state", False)
+            )
+            return min(count, 8 if short_nostate else 12)
+        return count
+    return 148
+
+
 def _normalized_config(config):
     config = {key: value for key, value in config.items() if key != "label"}
     config.setdefault("seq_lens", (64,))
@@ -2287,7 +2305,7 @@ def _normalized_config(config):
     config.setdefault("io_dtype", "bfloat16")
     config.setdefault("state_dtype", "float32")
     config.setdefault("cu_dtype", "int32")
-    config.setdefault("num_sms", 148)
+    config.setdefault("num_sms", _default_num_sms(config))
     if "checkpoint_every_n_tokens" not in config:
         config["checkpoint_every_n_tokens"] = config.pop("checkpoint", 0)
     config.setdefault("gate_lower_bound", -5.0)

--- a/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/gdn_recompute_f16.py
@@ -15,12 +15,15 @@ per-chunk recurrent-state checkpoint series a backward pass consumes; the query
 and output paths of the prefill kernel are absent.
 """
 
+import os
+
 import tirx_kernels.kern as K
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, hardware_num_sms
 
 KERNEL_META = {
     "name": "cudnn_sm100_gdn_recompute_f16",
     "category": "cudnn",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "nvidia-cudnn-frontend",
@@ -366,13 +369,15 @@ def _barrier_ptr(arena, byte_offset, stage=0):
 
 
 def _wait_barrier(arena, byte_offset, stage, phase):
+    barrier = _barrier_ptr(arena, byte_offset, stage)
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        barrier = K.local_scalar(
+            "uint32", init=K.cuda.cvta_generic_to_shared(barrier), name="barrier_addr"
+        )
     ready = K.local_scalar("uint32", init=K.uint32(0))
     with K.While(ready == K.uint32(0)):
         K.ptx.mbarrier.try_wait.parity.acquire.cta.shared__cta.b64(
-            ready,
-            _barrier_ptr(arena, byte_offset, stage),
-            K.cast(phase, "uint32"),
-            K.uint32(_TRY_WAIT_TICKS),
+            ready, barrier, K.cast(phase, "uint32"), K.uint32(_TRY_WAIT_TICKS)
         )
 
 
@@ -591,6 +596,12 @@ def _shfl_up_f32(value, delta):
         shuffled, K.reinterpret("uint32", value), K.uint32(delta), K.uint32(0), K.uint32(0xFFFFFFFF)
     )
     return K.reinterpret("float32", shuffled)
+
+
+def _warp_uniform_i32(value):
+    uniform = K.local_scalar("int32")
+    K.ptx["shfl_sync.idx.b32"](uniform, value, K.uint32(0), K.uint32(31), K.uint32(0xFFFFFFFF))
+    return uniform
 
 
 def _raw_descriptor(arena, byte_offset, leading_bytes, stride_bytes, layout):
@@ -931,10 +942,13 @@ def _tcgen_mma_ts(dst, tmem_a, b_desc, idesc, *, leader, accumulate, b_step_unit
         )
 
 
-def _make_prologue(*, run_order, order_generate, n_heads_out, checkpoints, cu_dtype):
+def _make_prologue(
+    *, run_order, order_generate, uniform_generated_order, n_heads_out, checkpoints, cu_dtype
+):
     cu_t = K.i64 if cu_dtype == "int64" else K.i32
+    prologue_warps = 8 if uniform_generated_order else 32
 
-    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    @K.kernel(warps=prologue_warps, arch="sm_100a", grid=1)
     def prologue(
         base_k: K.gptr[K.i64],
         base_v: K.gptr[K.i64],
@@ -992,12 +1006,14 @@ def _make_prologue(*, run_order, order_generate, n_heads_out, checkpoints, cu_dt
                         K.ptx.ld.global_.s32(value, work_item_staging.ptr_to([source * 8 + field]))
                         K.ptx.st.global_.s32(work_items.ptr_to([destination * 8 + field]), value)
 
-            with K.If(item_count > 4096), K.Then():
+            direct_condition = K.bool(True) if uniform_generated_order else item_count > 4096
+            with K.If(direct_condition), K.Then():
                 item = K.local_scalar("int32", init=thread)
                 with K.While(item < item_count):
                     write_work_item(item, item)
-                    K.assign(item, item + 1024)
-            with K.If(item_count <= 4096), K.Then():
+                    K.assign(item, item + prologue_warps * 32)
+            sort_condition = K.bool(False) if uniform_generated_order else item_count <= 4096
+            with K.If(sort_condition), K.Then():
                 with K.If(thread == 0), K.Then():
                     K.ptx.st.shared.v2.u32(
                         order_arena.ptr_to([32_768]), K.uint32(2_147_483_647), K.uint32(0x80000000)
@@ -1203,9 +1219,14 @@ def _make_main(
         # --- kernel body starts here ---
         arena = K.alloc_buffer((_ARENA_BYTES,), K.u8, scope="shared.dyn", align=1024)
         K.smem_pool(base=arena)
-        thread = K.thread_id()
-        warp = K.warp_id()
-        lane = K.lane_id()
+        if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+            thread = K.local_scalar("int32", init=K.thread_id(), name="thread")
+            warp = _warp_uniform_i32(thread >> 5)
+            lane = K.local_scalar("int32", init=thread & 31, name="lane")
+        else:
+            thread = K.thread_id()
+            warp = K.warp_id()
+            lane = K.lane_id()
 
         # Declaration-ordered physical mbarrier protocol; each row is
         # (byte offset, stages, arrive count, initializing warp).
@@ -2426,6 +2447,8 @@ def _normalized_config(config):
     config.setdefault("io_dtype", "bfloat16")
     config.setdefault("state_dtype", "float32")
     config.setdefault("cu_dtype", "int32")
+    if "num_sms" not in config and os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        config["num_sms"] = hardware_num_sms()
     config.setdefault("num_sms", 148)
     # The backward plan's regen call: per-chunk checkpoints, no final state.
     config.setdefault("checkpoint_every_n_tokens", 64)
@@ -2499,9 +2522,15 @@ def get_kernel(**config):
     config = _normalized_config(config)
     rows = _work_rows(config["seq_lens"], config["heads"], split=config["split"])
     num_ctas = min(int(config["num_sms"]), max(len(rows), 1))
+    uniform_generated_order = (
+        os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a"
+        and bool(config["order_generate"])
+        and len(set(config["seq_lens"])) <= 1
+    )
     prologue = _make_prologue(
         run_order=bool(config["run_order"]),
         order_generate=bool(config["order_generate"]),
+        uniform_generated_order=uniform_generated_order,
         n_heads_out=int(config["heads"]),
         checkpoints=int(config["checkpoint_every_n_tokens"]) > 0,
         cu_dtype=config["cu_dtype"],
@@ -2903,15 +2932,29 @@ def _validate_outputs(data, *, sources):
         )
 
 
+def _compile_tirx(config):
+    from tirx_kernels.runner import compile_kernel
+
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        large_initial_state = bool(config["use_initial_state"]) and len(config["seq_lens"]) >= 16
+        os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = "9" if large_initial_state else "6"
+    try:
+        return [compile_kernel(func) for func in get_kernel(**config)]
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
 def run_test(**config):
     """Compare TIRx with the upstream kernel on identical inputs."""
     import torch
 
-    from tirx_kernels.runner import compile_kernel
-
     config = _normalized_config(config)
     data = _prepare_data(config)
-    executables = [compile_kernel(func) for func in get_kernel(**config)]
+    executables = _compile_tirx(config)
     tirx_launch = _tirx_launch(executables, data)
     source_launch = _source_launch(data)
     tirx_launch()
@@ -2923,13 +2966,10 @@ def run_test(**config):
 
 def prepare_bench(**config):
     """Compile both TIRx launches without importing torch or touching CUDA."""
-    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+    from tirx_kernels.runner import prepared_gpu_benchmark
 
     config = _normalized_config(config)
-    state = {
-        "config": config,
-        "executables": [compile_kernel(func) for func in get_kernel(**config)],
-    }
+    state = {"config": config, "executables": _compile_tirx(config)}
     return prepared_gpu_benchmark(run_gpu, state)
 
 

--- a/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
+++ b/tirx_kernels/cudnn/linear_attention/kda_bprop_f16.py
@@ -10,12 +10,15 @@ Upstream source:
 (``prologue_kernel``, ``kernel``, and the two-launch ``run_bwd`` entry).
 """
 
+import os
+
 import tirx_kernels.kern as K
+from tirx_kernels.runner import PREPARE_CUDA_ARCH_ENV, hardware_num_sms
 
 KERNEL_META = {
     "name": "cudnn_sm100_kda_bprop_f16",
     "category": "cudnn",
-    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a"],
+    "runtime_cuda_archs": ["sm_100a", "sm_103a", "sm_107a", "sm_110a"],
     "reference_requirements": (
         {
             "package": "nvidia-cudnn-frontend",
@@ -532,7 +535,11 @@ def _tmem_cell(base, row, row_delta, column):
 
 
 def _make_prologue(*, run_order, order_generate, dynamic_scheduler, n_heads_out):
-    @K.kernel(warps=32, arch="sm_100a", grid=1)
+    prologue_warps = (
+        10 if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a" and not run_order else 32
+    )
+
+    @K.kernel(warps=prologue_warps, arch="sm_100a", grid=1)
     def prologue(
         base_q: K.gptr[K.i64],
         base_k: K.gptr[K.i64],
@@ -823,6 +830,11 @@ def _make_main(
     v_ratio,
 ):
     beta_dtype = K.bf16 if beta_sigmoid else K.f32
+    thor_state_path = os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a" and (
+        use_initial_state or use_dstate_in or use_dstate0
+    )
+    cg1_regs = 184 if thor_state_path else 168
+    support_regs = 40 if thor_state_path else 56
 
     @K.kernel(warps=16, arch="sm_100a", min_blocks_per_sm=1, grid=num_sms)
     def main(
@@ -873,12 +885,12 @@ def _make_main(
         K.ptx.ld.global_.s32(total_tiles, work_count.ptr_to([0]))
         roles = K.specialize()
         cg0 = roles.role("cg0", warps=range(0, 4), regs=144)
-        cg1 = roles.role("cg1", warps=range(4, 8), regs=168)
+        cg1 = roles.role("cg1", warps=range(4, 8), regs=cg1_regs)
         cg2 = roles.role("cg2", warps=range(8, 12), regs=144)
-        super_mma = roles.role("super_mma", warps=[12], regs=56)
-        tcgen = roles.role("tcgen", warps=[13], regs=56)
-        tma = roles.role("tma", warps=[14], regs=56)
-        epilogue = roles.role("epilogue", warps=[15], regs=56)
+        super_mma = roles.role("super_mma", warps=[12], regs=support_regs)
+        tcgen = roles.role("tcgen", warps=[13], regs=support_regs)
+        tma = roles.role("tma", warps=[14], regs=support_regs)
+        epilogue = roles.role("epilogue", warps=[15], regs=support_regs)
         with tma:
             tile = K.local_scalar("int32", init=K.cta_id())
             raw = K.PipelineState(2, phase=1)
@@ -3438,6 +3450,15 @@ def _normalized_config(config):
     config.setdefault("q_heads", config["heads"])
     config.setdefault("k_heads", config["heads"])
     config.setdefault("v_heads", config["heads"])
+    if "num_sms" not in config and os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        if config.get("beta_sigmoid", False):
+            config["num_sms"] = hardware_num_sms()
+        elif config.get("dynamic_scheduler", False) or config.get("run_order", False):
+            config["num_sms"] = min(hardware_num_sms(), 16)
+        else:
+            seq_lens = tuple(config.get("seq_lens", (64,)))
+            work_items = max(len(seq_lens) * int(config.get("heads", 1)), 1)
+            config["num_sms"] = min(work_items, 16) if len(seq_lens) > 1 else work_items
     config.setdefault("num_sms", 148)
     config.setdefault("scale", 1.0 / (_DK**0.5))
     for key in (
@@ -3879,15 +3900,34 @@ def _validate_outputs(data, *, sources):
         raise AssertionError(f"KDA backward validation failed for {config}: {failures}")
 
 
+def _compile_tirx(config):
+    from tirx_kernels.runner import compile_kernel
+
+    previous = os.environ.get("TVM_CUDA_PTXAS_REG_LEVEL")
+    state_path = bool(
+        config["use_initial_state"] or config["use_dstate_in"] or config["use_dstate0"]
+    )
+    if os.environ.get(PREPARE_CUDA_ARCH_ENV) == "sm_110a":
+        if state_path:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = "0"
+        elif config["beta_sigmoid"]:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = "3"
+    try:
+        return [compile_kernel(func) for func in get_kernel(**config)]
+    finally:
+        if previous is None:
+            os.environ.pop("TVM_CUDA_PTXAS_REG_LEVEL", None)
+        else:
+            os.environ["TVM_CUDA_PTXAS_REG_LEVEL"] = previous
+
+
 def run_test(**config):
     """Compare TIRx with the upstream kernel on identical inputs."""
     import torch
 
-    from tirx_kernels.runner import compile_kernel
-
     kernel_config = _normalized_config(config)
     data = _prepare_data(kernel_config)
-    executables = [compile_kernel(func) for func in get_kernel(**kernel_config)]
+    executables = _compile_tirx(kernel_config)
     tirx_launch = _tirx_launch(executables, data)
     source_launch = _source_launch(data)
     tirx_launch()
@@ -3899,13 +3939,10 @@ def run_test(**config):
 
 def prepare_bench(**config):
     """Compile the two TIRx launches without importing torch or touching CUDA."""
-    from tirx_kernels.runner import compile_kernel, prepared_gpu_benchmark
+    from tirx_kernels.runner import prepared_gpu_benchmark
 
     kernel_config = _normalized_config(config)
-    state = {
-        "config": kernel_config,
-        "executables": [compile_kernel(func) for func in get_kernel(**kernel_config)],
-    }
+    state = {"config": kernel_config, "executables": _compile_tirx(kernel_config)}
     return prepared_gpu_benchmark(run_gpu, state)
 
 


### PR DESCRIPTION
## Summary

Enable Jetson AGX Thor (`sm_110a`) support for:

- `cudnn_sm100_gdn_recompute_f16`
- `cudnn_sm100_gdn2_recompute_f16`
- `cudnn_sm100_kda_bprop_f16`

The Thor-specific schedules use the detected 20-SM hardware topology and tune CTA counts, prologue widths, register allocation, barrier polling, and compilation settings for each workload path. Existing `sm_100a`, `sm_103a`, and `sm_107a` behavior remains unchanged.

The README architecture annotations and bench-suite baseline tables are updated for all 47 configurations.

## Implementation

### GDN2 recompute

- Use Thor-specific CTA counts based on workload shape and scheduler mode.
- Use 8 CTAs for the short no-state workload, 12 CTAs for the remaining dynamic workloads, and the detected SM count for non-dynamic workloads.

### GDN recompute

- Use the detected Thor SM count instead of the existing 148-SM default.
- Hoist shared barrier address conversion out of polling loops.
- Materialize thread indices and broadcast the warp index to match the source kernel’s warp-uniform behavior.
- Use a smaller direct-copy prologue for uniform generated-order workloads.
- Select Thor-specific PTXAS register levels for state and non-state paths.
- Restore the caller’s PTXAS environment after compilation.

### KDA backward

- Select Thor-specific grid sizes for dynamic, ordered, beta-sigmoid, and static workloads.
- Reduce the prologue width for unordered workloads.
- Redistribute registers toward the state consumer warps when the state path is active.
- Select workload-specific PTXAS register levels and restore the previous environment after compilation.

## Performance

Measured on Jetson AGX Thor (`sm_110a`, 20 SM) against the corresponding cuDNN Frontend source implementation using the standard bench-suite timer:

- 25 warmup iterations
- 100 ms repeat window
- 1 second cooldown
- arithmetic mean across 15–30 rounds
- standard cache-clearing policy

`Source/TIRx` is the source latency divided by the TIRx latency. Every configuration satisfies the required `Source/TIRx > 0.99` threshold; values above 1 mean TIRx is faster.

The GDN `perf_b4_s4096_h64_state` row is from its 30-round confirmation run. The other GDN rows are from the complete 15-round matrix.

### GDN recompute — 18/18 pass

| Config | TIRx (µs) | cuDNN Frontend (µs) | Source/TIRx |
|---|---:|---:|---:|
| `perf_b16_s8192_h64_nostate` | 51563.402 | 51890.508 | 1.006 |
| `perf_b16_s8192_h64_state` | 52091.037 | 53434.506 | 1.026 |
| `perf_b1_s8192_h64_nostate` | 3560.505 | 3576.383 | 1.004 |
| `perf_b1_s8192_h64_state` | 3646.169 | 3620.055 | 0.993 |
| `perf_b2_s8192_h64_nostate` | 6802.839 | 6826.492 | 1.003 |
| `perf_b2_s8192_h64_state` | 6944.086 | 6928.814 | 0.998 |
| `perf_b4_s16384_h64_nostate` | 26932.154 | 27432.923 | 1.019 |
| `perf_b4_s16384_h64_state` | 27199.410 | 27440.590 | 1.009 |
| `perf_b4_s2048_h64_nostate` | 3441.007 | 3470.777 | 1.009 |
| `perf_b4_s2048_h64_state` | 3735.219 | 3708.890 | 0.993 |
| `perf_b4_s32768_h64_nostate` | 52502.267 | 52159.202 | 0.993 |
| `perf_b4_s32768_h64_state` | 52732.708 | 52841.162 | 1.002 |
| `perf_b4_s4096_h64_nostate` | 6777.065 | 6826.042 | 1.007 |
| `perf_b4_s4096_h64_state` | 7101.666 | 7067.303 | 0.995 |
| `perf_b4_s8192_h64_nostate` | 13475.338 | 13466.740 | 0.999 |
| `perf_b4_s8192_h64_state` | 13876.247 | 13859.954 | 0.999 |
| `perf_b8_s8192_h64_nostate` | 27053.559 | 27221.837 | 1.006 |
| `perf_b8_s8192_h64_state` | 27272.992 | 27531.570 | 1.009 |

### GDN2 recompute — 18/18 pass

| Config | TIRx (µs) | cuDNN Frontend (µs) | Source/TIRx |
|---|---:|---:|---:|
| `perf_b16_s8192_h64_nostate` | 155070.862 | 159703.912 | 1.030 |
| `perf_b16_s8192_h64_state` | 156298.543 | 161099.501 | 1.031 |
| `perf_b1_s8192_h64_nostate` | 11509.110 | 11647.329 | 1.012 |
| `perf_b1_s8192_h64_state` | 11614.818 | 11779.716 | 1.014 |
| `perf_b2_s8192_h64_nostate` | 23095.857 | 23228.426 | 1.006 |
| `perf_b2_s8192_h64_state` | 23240.659 | 23429.081 | 1.008 |
| `perf_b4_s16384_h64_nostate` | 77818.017 | 79805.275 | 1.026 |
| `perf_b4_s16384_h64_state` | 77934.019 | 79998.001 | 1.026 |
| `perf_b4_s2048_h64_nostate` | 11353.180 | 11619.620 | 1.023 |
| `perf_b4_s2048_h64_state` | 11764.024 | 11979.304 | 1.018 |
| `perf_b4_s32768_h64_nostate` | 155591.242 | 159374.367 | 1.024 |
| `perf_b4_s32768_h64_state` | 156032.563 | 159735.527 | 1.024 |
| `perf_b4_s4096_h64_nostate` | 22992.703 | 23278.925 | 1.012 |
| `perf_b4_s4096_h64_state` | 23258.400 | 23580.769 | 1.014 |
| `perf_b4_s8192_h64_nostate` | 45392.162 | 46261.404 | 1.019 |
| `perf_b4_s8192_h64_state` | 45835.620 | 46391.983 | 1.012 |
| `perf_b8_s8192_h64_nostate` | 77944.031 | 79614.781 | 1.021 |
| `perf_b8_s8192_h64_state` | 77929.780 | 80522.552 | 1.033 |

### KDA backward — 11/11 pass

| Config | TIRx (µs) | cuDNN Frontend (µs) | Source/TIRx |
|---|---:|---:|---:|
| `perf_basic_b1_s2048_h16` | 1053.186 | 1046.406 | 0.994 |
| `perf_beta_b1_s8192_h16` | 3644.630 | 3629.043 | 0.996 |
| `perf_dynamic_b4_s2048_h64` | 1076.185 | 1285.101 | 1.194 |
| `perf_grouped_b1_s8192_h64_q64_k16_v32` | 14431.320 | 14572.863 | 1.010 |
| `perf_l2_b1_s8192_h16` | 3663.031 | 3636.204 | 0.993 |
| `perf_l2_b4_s8192_h64` | 45177.336 | 45790.647 | 1.014 |
| `perf_order_generate_b4_s2048_h64` | 14576.366 | 14495.208 | 0.994 |
| `perf_order_scratch_b4_s2048_h64` | 14596.380 | 14505.998 | 0.994 |
| `perf_safe_b1_s8192_h16` | 3637.741 | 3639.115 | 1.000 |
| `perf_state_b1_s8192_h16` | 3674.435 | 3675.027 | 1.000 |
| `perf_tail_b2_ragged_h16` | 2757.910 | 2780.414 | 1.008 |

## Validation

- GDN2 recompute: 18/18 performance configurations pass.
- GDN recompute: 18/18 performance configurations pass, including the 30-round confirmation of the initially noisy configuration.
- KDA backward: 11/11 performance configurations pass.
- Affected correctness configurations pass against the cuDNN Frontend source.
- `python -m ruff check`
- `python -m ruff format --check`
- `python tests/lint/check_readme_kernels.py`
- `python -m pytest -q tests/test_registry.py tests/test_low_level_ir.py` — 39 passed
- `git diff --check`