### PR TITLE
Fix TVM main compatibility and MoE/cascade correctness

### DIFF
--- a/tirx_kernels/agent_evolved/moe_fp8_blockscale_dsv3.py
+++ b/tirx_kernels/agent_evolved/moe_fp8_blockscale_dsv3.py
@@ -431,10 +431,16 @@ def build_kernel(num_ctas):
         task_empty = K.MBarrier(smem, TASK_RING)
 
         roles = K.specialize(chain_dispatch=True)
-        prod_role = roles.role("prod", warps=[0], regs=REGS_WG0)
-        mma_role = roles.role("mma", warps=[1], regs=REGS_WG0)
-        aux_role = roles.role("aux", warps=[2, 3], regs=REGS_WG0)
-        math_role = roles.role("math", warps=range(MATH_WARP0, NWARPS), regs=REGS_MATH)
+        control_regs = roles.register_scope("control", warps=range(4), regs=REGS_WG0)
+        math_regs = roles.register_scope(
+            "math", warps=range(MATH_WARP0, NWARPS), regs=REGS_MATH
+        )
+        prod_role = roles.role("prod", warps=[0], register_scope=control_regs)
+        mma_role = roles.role("mma", warps=[1], register_scope=control_regs)
+        aux_role = roles.role("aux", warps=[2, 3], register_scope=control_regs)
+        math_role = roles.role(
+            "math", warps=range(MATH_WARP0, NWARPS), register_scope=math_regs
+        )
 
         K.ptx.barrier.cluster.arrive.relaxed.aligned()
         K.ptx.barrier.cluster.wait.acquire.aligned()
@@ -916,6 +922,8 @@ def build_kernel(num_ctas):
             load_regs(K.int32(0))
             with K.serial(0, nkb) as kb:
                 K.cuda.mbarrier_wait(sfempty_bar.ptr_to([sstate.stage]), sstate.phase ^ 1)
+                # Completed async TCGEN reads precede generic writes that reuse this stage.
+                K.ptx.fence.proxy.async_.shared__cta()
                 bpack0 = u32(
                     K.bitwise_or(
                         ue8m0_pack4(K.reinterpret("float32", raw[0])),
@@ -928,11 +936,18 @@ def build_kernel(num_ctas):
                         K.shift_left(ue8m0_pack4(K.reinterpret("float32", raw[3])), K.uint32(8)),
                     )
                 )
+                # Each v4 fills one TMEM lane's four 32-row scale columns.
+                # G1 half tiles put 64 up then 64 gate rows in each CTA's B.
+                split_g1 = K.And(kind == 0, half != 0)
+                first_upper = K.Select(split_g1, bpack1, bpack0)
+                second_lower = K.Select(split_g1, bpack0, bpack1)
                 K.ptx.st.shared.v4.u32(
-                    sfb_tile.ptr_to([sstate.stage, lane * 4]), bpack0, bpack0, bpack0, bpack0
+                    sfb_tile.ptr_to([sstate.stage, lane * 4]),
+                    bpack0, bpack0, first_upper, first_upper,
                 )
                 K.ptx.st.shared.v4.u32(
-                    sfb_tile.ptr_to([sstate.stage, 128 + lane * 4]), bpack1, bpack1, bpack1, bpack1
+                    sfb_tile.ptr_to([sstate.stage, 128 + lane * 4]),
+                    second_lower, second_lower, bpack1, bpack1,
                 )
                 K.cuda.warp_sync()
                 K.ptx.fence.proxy.async_.shared__cta()
@@ -942,6 +957,14 @@ def build_kernel(num_ctas):
                 with K.If(kb + 1 < nkb), K.Then():
                     load_regs(kb + 1)
             iket_end(tk_tile)
+
+        # Transition each complete warpgroup once. Functional roles are re-entered
+        # during finalization and must not repeat a partial-warpgroup transition.
+        with K.If(warp < MATH_WARP0):
+            with K.Then():
+                control_regs.emit()
+            with K.Else():
+                math_regs.emit()
 
         with prod_role:
             K.ptx.fence.proxy.async_.global_()
@@ -1118,17 +1141,25 @@ def build_kernel(num_ctas):
                                         SF_DESC_BASE, sfb_smem + sf_stage * K.uint32(BN * 4)
                                     ),
                                 )
-                                K.ptx[UTCCP](tmem_base + K.uint32(SFB_TMEM_COL), desc_sf, pred=el)
-                                K.assign(
-                                    desc_sf,
-                                    with_smem_addr(
-                                        SF_DESC_BASE,
-                                        sfb_smem + sf_stage * K.uint32(BN * 4) + K.uint32(128 * 4),
-                                    ),
-                                )
-                                K.ptx[UTCCP](
-                                    tmem_base + K.uint32(SFB_TMEM_COL + 4), desc_sf, pred=el
-                                )
+                                with K.If(half != 0):
+                                    with K.Then():
+                                        # M128 uses a 2x2 SFB layout: the two N128 halves
+                                        # occupy TMEM lane partitions 0/1 and 2/3.
+                                        K.ptx["tcgen05.cp.cta_group::2.64x128b.warpx2::01_23"](
+                                            tmem_base + K.uint32(SFB_TMEM_COL), desc_sf, pred=el
+                                        )
+                                    with K.Else():
+                                        K.ptx[UTCCP](tmem_base + K.uint32(SFB_TMEM_COL), desc_sf, pred=el)
+                                        K.assign(
+                                            desc_sf,
+                                            with_smem_addr(
+                                                SF_DESC_BASE,
+                                                sfb_smem + sf_stage * K.uint32(BN * 4) + K.uint32(128 * 4),
+                                            ),
+                                        )
+                                        K.ptx[UTCCP](
+                                            tmem_base + K.uint32(SFB_TMEM_COL + 4), desc_sf, pred=el
+                                        )
                                 K.ptx.tcgen05.fence__before_thread_sync()
                                 K.cuda.warp_sync()
                                 K.ptx[COMMIT](

--- a/tirx_kernels/agent_evolved/moe_fp8_blockscale_dsv3.py
+++ b/tirx_kernels/agent_evolved/moe_fp8_blockscale_dsv3.py
@@ -432,14 +432,13 @@ def build_kernel(num_ctas):
 
         roles = K.specialize(chain_dispatch=True)
         control_regs = roles.register_scope("control", warps=range(4), regs=REGS_WG0)
-        math_regs = roles.register_scope(
-            "math", warps=range(MATH_WARP0, NWARPS), regs=REGS_MATH
-        )
         prod_role = roles.role("prod", warps=[0], register_scope=control_regs)
         mma_role = roles.role("mma", warps=[1], register_scope=control_regs)
         aux_role = roles.role("aux", warps=[2, 3], register_scope=control_regs)
+        # Math owns complete warpgroups. Keep the register target at each role
+        # entry so ptxas retains the math allocation for both G and F.
         math_role = roles.role(
-            "math", warps=range(MATH_WARP0, NWARPS), register_scope=math_regs
+            "math", warps=range(MATH_WARP0, NWARPS), regs=REGS_MATH
         )
 
         K.ptx.barrier.cluster.arrive.relaxed.aligned()
@@ -958,13 +957,11 @@ def build_kernel(num_ctas):
                     load_regs(kb + 1)
             iket_end(tk_tile)
 
-        # Transition each complete warpgroup once. Functional roles are re-entered
-        # during finalization and must not repeat a partial-warpgroup transition.
+        # The control roles split one warpgroup: release its registers together.
+        # Re-entering aux during finalization must not repeat this transition.
         with K.If(warp < MATH_WARP0):
             with K.Then():
                 control_regs.emit()
-            with K.Else():
-                math_regs.emit()
 
         with prod_role:
             K.ptx.fence.proxy.async_.global_()

--- a/tirx_kernels/flashinfer/cascade/merge_state.py
+++ b/tirx_kernels/flashinfer/cascade/merge_state.py
@@ -202,8 +202,9 @@ def get_kernel(dtype: str, seq_len: int, num_heads: int, head_dim: int, **kwargs
                     o_bits[4 * k + 3],
                 )
 
-            # ---- merged log2-sum-exp behind the source's null-pointer guard (L68-70) ----
-            with K.If(K.Not(K.isnullptr(s_merged.data))), K.Then():
+            # One thread per head owns the scalar output, even though every
+            # thread computed the same blend weights. Keep the optional-output guard.
+            with K.If(K.And(tx == 0, K.Not(K.isnullptr(s_merged.data)))), K.Then():
                 lg = K.local_scalar("float32")
                 lse = K.local_scalar("float32")
                 K.ptx.lg2.approx.ftz.f32(lg, denom)  # math::ptx_log2

--- a/tirx_kernels/kern/specialize.py
+++ b/tirx_kernels/kern/specialize.py
@@ -11,6 +11,7 @@ requires but nothing else verifies.
 from __future__ import annotations
 
 import tvm
+from tvm_ffi import structural_map
 from tvm.script import tirx as T
 
 from . import entry as _entry
@@ -374,14 +375,12 @@ class Specialize:
             return out if changed else None
 
         def postorder(stmt):
-            if not isinstance(stmt, tvm.tirx.SeqStmt):
-                return None
             new = rewrite(list(stmt.seq))
             if new is None:
-                return None
+                return stmt
             return new[0] if len(new) == 1 else tvm.tirx.SeqStmt(new, stmt.span)
 
-        body = tvm.tirx.stmt_functor.ir_transform(func.body, None, postorder)
+        body = structural_map(func.body, (tvm.tirx.SeqStmt, postorder))
         return func.with_body(body)
 
     def finalize(self):


### PR DESCRIPTION
Current TVM main removes `ir_transform`, breaking Kern specialization. Validation against the updated compiler also exposed correctness issues in `merge_state` and the agent-evolved FP8 MoE kernel.

This change updates the specialization pass and fixes the kernel-side register and scale-staging contracts.

### Changes

**Update Kern specialization for the current TVM IR API**

Replace `ir_transform` with `structural_map` in the role-dispatch rewrite. Return unchanged nodes explicitly and preserve the existing rules for combining adjacent, mutually exclusive role guards.

**Give `merge_state` a single writer for the scalar output**

All threads processing a head previously stored the same merged log-sum-exp value to `s_merged`. Restrict that scalar store to `tx == 0`, while preserving the optional-output null-pointer guard and the distributed vector-output stores.

**Separate control-role dispatch from warpgroup register transitions**

The MoE control warpgroup is split into three functional roles:

- Warp 0: producer.
- Warp 1: MMA issuer.
- Warps 2–3: auxiliary work.

These roles now share one `register_scope`. All four control warps execute the same transition to 40 registers per thread before functional dispatch. Re-entering the auxiliary role during finalization does not emit another partial-warpgroup transition.

The math role already covers complete warpgroups, so it retains `regs=232` at its role entries. The G and F phases are separated by the existing grid/CTA barrier. Keeping the target at each math-role entry preserves the compiler's register allocation for both phases; hoisting it outside the role branches caused substantial spilling.

**Order scale-stage reuse across memory proxies**

Add `fence.proxy.async.shared::cta` after waiting for the scale stage to become reusable, before generic shared-memory stores overwrite it. This establishes the required ordering between completed asynchronous TCGEN reads and subsequent writes to the reused stage.

**Correct M128 SFB staging and broadcast**

Use `tcgen05.cp.cta_group::2.64x128b.warpx2::01_23` for the M128 SFB layout. Preserve the existing pair of `32x128b.warpx4` copies for M256.

For G1 half tiles, stage the distinct up and gate scales according to the 64-up/64-gate row arrangement in each CTA's B operand. Preserve the existing row ordering for G1 full tiles and G2. Validation uses nonuniform scales so swapped or incorrectly replicated scale regions cannot pass accidentally.

### Correctness validation

Validated against TVM `e4e489b788d08bf96fada95d221aa7c8a5fb566e` on B200 with CUDA 13.2.

- Kern API and low-level IR: 42 tests passed.
- `merge_state` GPU validation passed for FP16/BF16 and head dimensions 64/512.
- The MoE production random-input GPU test passed with 4 tokens and seed 1.
- Nonuniform-scale MoE GPU cases matched the independent reference exactly for M128 (1 token) and M256 (129 tokens routed to one local expert).
- The production-geometry, two-CTA MoE canonical case passed NumSim numerical comparison and complete, clean synccheck and racecheck execution with the companion tools fixes.

Companion tools changes:
https://github.com/mlc-ai/TIRx-kernel-agent/tree/codex/main-refresh-20260910

### GPU performance validation

Compared against `b33d953`: upstream kernel main `156a5c0` plus only the TVM structural-map compatibility fix.

Each before/after pair used the same physical B200, workload and seed. Measurements used the canonical Proton timer with 25 ms warmup, a 100 ms repeat budget and 15 rounds, aggregated by arithmetic mean. Pairs affected by detected external GPU activity were discarded and retried.

All five final MoE configurations passed the unchanged `after/before < 1.01` gate:

| Tokens | Before (µs) | After (µs) | Time change |
|---:|---:|---:|---:|
| 1 | 50.963 | 50.289 | −1.323% |
| 80 | 259.781 | 258.677 | −0.425% |
| 901 | 270.918 | 271.107 | +0.070% |
| 14107 | 679.39 | 680.31 | +0.134% |
| 32768 | 1425.632 | 1425.540 | −0.006% |

The final MoE compiler report matches the original baseline: 168 entry registers, an 8-byte stack, 8 bytes of spill stores and 128 bytes of spill loads.

All eight `merge_state` benchmark configurations were measured. Seven passed initially. BF16 S2048/H32/D128 initially measured +1.778%; a fresh isolated paired rerun measured −2.117% and passed the same gate. Both observations are retained; the initial regression was not reproduced.

The companion tools' two CPU performance tests and three GDN performance controllers remain unrun because the shared host was materially busy. No performance thresholds were changed.